### PR TITLE
Honor initiator_depth in RDMA CM

### DIFF
--- a/include/evpl/evpl_rpc2_program.h
+++ b/include/evpl/evpl_rpc2_program.h
@@ -48,6 +48,8 @@ struct evpl_rpc2_msg {
     struct evpl_rpc2_msg                 *next;
     struct evpl_rpc2_rdma_chunk           read_chunk;
     struct evpl_rpc2_rdma_chunk           write_chunk;
+    struct evpl_iovec                     reply_segment_iov;
+    struct evpl_iovec                     segment_iov[64];
 };
 
 struct evpl_rpc2_program {

--- a/src/core/bind.c
+++ b/src/core/bind.c
@@ -135,6 +135,11 @@ evpl_bind_prepare(
             evpl_shared->config->iovec_ring_size,
             evpl_shared->config->page_size);
 
+        evpl_rdma_request_ring_alloc(
+            &bind->rdma_rw,
+            evpl_shared->config->rdma_request_ring_size,
+            evpl_shared->config->page_size);
+
         evpl_deferral_init(&bind->close_deferral,
                            evpl_bind_close_deferral, bind);
 
@@ -203,6 +208,7 @@ evpl_bind_destroy(
     evpl_iovec_ring_clear(evpl, &bind->iovec_recv);
     evpl_iovec_ring_clear(evpl, &bind->iovec_send);
     evpl_dgram_ring_clear(evpl, &bind->dgram_send);
+    evpl_rdma_request_ring_clear(evpl, &bind->rdma_rw);
 
     bind->flags |= EVPL_BIND_CLOSED;
 

--- a/src/core/bind.h
+++ b/src/core/bind.h
@@ -7,6 +7,7 @@
 #include "core/allocator.h"
 #include "core/iovec_ring.h"
 #include "core/dgram_ring.h"
+#include "core/rdma_request.h"
 #include "core/evpl.h"
 
 #define EVPL_MAX_PRIVATE         4096
@@ -17,25 +18,27 @@
 #define EVPL_BIND_SENT_NOTIFY    0x08
 
 struct evpl_bind {
-    struct evpl_protocol   *protocol;
-    uint64_t                flags;
-    struct evpl_deferral    flush_deferral;
-    struct evpl_deferral    close_deferral;
-    evpl_notify_callback_t  notify_callback;
-    evpl_segment_callback_t segment_callback;   /* only for dgram-on-stream */
-    evpl_accept_callback_t  accept_callback;   /* only for listeners */
-    void                   *private_data;
+    struct evpl_protocol         *protocol;
+    uint64_t                      flags;
+    struct evpl_deferral          flush_deferral;
+    struct evpl_deferral          close_deferral;
+    evpl_notify_callback_t        notify_callback;
+    evpl_segment_callback_t       segment_callback; /* only for dgram-on-stream */
+    evpl_accept_callback_t        accept_callback; /* only for listeners */
+    void                         *private_data;
 
-    struct evpl_bind       *prev;
-    struct evpl_bind       *next;
+    struct evpl_bind             *prev;
+    struct evpl_bind             *next;
 
-    struct evpl_iovec_ring  iovec_send;
-    struct evpl_iovec_ring  iovec_recv;
+    struct evpl_iovec_ring        iovec_send;
+    struct evpl_iovec_ring        iovec_recv;
 
-    struct evpl_dgram_ring  dgram_send;
+    struct evpl_rdma_request_ring rdma_rw;
 
-    struct evpl_address    *local;
-    struct evpl_address    *remote;
+    struct evpl_dgram_ring        dgram_send;
+
+    struct evpl_address          *local;
+    struct evpl_address          *remote;
     /* protocol specific private data follows */
 };
 

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -23,18 +23,19 @@ evpl_global_config_init(void)
     config->thread_default.spin_ns         = 1000000UL;
     config->thread_default.wait_ms         = -1;
 
-    config->max_pending        = 16;
-    config->max_poll_fd        = 16;
-    config->max_num_iovec      = 128;
-    config->huge_pages         = 0;
-    config->buffer_size        = 2 * 1024 * 1024;
-    config->slab_size          = 1 * 1024 * 1024 * 1024;
-    config->refcnt             = 1;
-    config->iovec_ring_size    = 1024;
-    config->dgram_ring_size    = 256;
-    config->max_datagram_size  = 65536;
-    config->max_datagram_batch = 16;
-    config->resolve_timeout_ms = 5000;
+    config->max_pending            = 16;
+    config->max_poll_fd            = 16;
+    config->max_num_iovec          = 128;
+    config->huge_pages             = 0;
+    config->buffer_size            = 2 * 1024 * 1024;
+    config->slab_size              = 1 * 1024 * 1024 * 1024;
+    config->refcnt                 = 1;
+    config->iovec_ring_size        = 1024;
+    config->dgram_ring_size        = 256;
+    config->rdma_request_ring_size = 64;
+    config->max_datagram_size      = 65536;
+    config->max_datagram_batch     = 16;
+    config->resolve_timeout_ms     = 5000;
 
     config->page_size = sysconf(_SC_PAGESIZE);
 

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -508,6 +508,7 @@ evpl_destroy(struct evpl *evpl)
 
         evpl_iovec_ring_free(&bind->iovec_send);
         evpl_iovec_ring_free(&bind->iovec_recv);
+        evpl_rdma_request_ring_free(&bind->rdma_rw);
         evpl_dgram_ring_free(&bind->dgram_send);
         evpl_free(bind);
     }

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -44,6 +44,7 @@ struct evpl_global_config {
     unsigned int              max_datagram_batch;
     unsigned int              refcnt;
     unsigned int              iovec_ring_size;
+    unsigned int              rdma_request_ring_size;
     unsigned int              dgram_ring_size;
     unsigned int              resolve_timeout_ms;
 

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -79,6 +79,9 @@ struct evpl_protocol {
     /* 1 iff stream oriented protocol */
     unsigned int           stream;
 
+    /* 1 iff supports RDMA read/write */
+    unsigned int           rdma;
+
     /* human readable name for protocol, no spaces */
     const char            *name;
 
@@ -138,30 +141,6 @@ struct evpl_protocol {
     void                   (*bind)(
         struct evpl      *evpl,
         struct evpl_bind *bind);
-
-    /*
-     * Callbacks for RDMA read/write operations
-     */
-
-    void                   (*rdma_read)(
-        struct evpl *evpl,
-        struct evpl_bind *bind,
-        uint32_t remote_key,
-        uint64_t remote_address,
-        struct evpl_iovec *iov,
-        int niov,
-        void ( *callback )(int status, void *private_data),
-        void *private_data);
-
-    void                   (*rdma_write)(
-        struct evpl *evpl,
-        struct evpl_bind *bind,
-        uint32_t remote_key,
-        uint64_t remote_address,
-        struct evpl_iovec *iov,
-        int niov,
-        void ( *callback )(int status, void *private_data),
-        void *private_data);
 };
 
 /* API for a block protocol */

--- a/src/core/rdma_request.h
+++ b/src/core/rdma_request.h
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "core/evpl.h"
+#include "core/iovec.h"
+
+enum evpl_rdma_request_type {
+    EVPL_RDMA_READ,
+    EVPL_RDMA_WRITE,
+};
+
+struct evpl_rdma_request {
+    enum evpl_rdma_request_type type;
+    uint32_t                    remote_key;
+    uint64_t                    remote_address;
+    struct evpl_iovec          *iov;
+    int                         niov;
+    void                        (*callback)(
+        int   status,
+        void *private_data);
+    void                       *private_data;
+};
+
+struct evpl_rdma_request_ring {
+    struct evpl_rdma_request *request;
+    int                       size;
+    int                       mask;
+    int                       head;
+    int                       tail;
+    int                       alignment;
+};
+
+
+
+static inline void
+evpl_rdma_request_ring_alloc(
+    struct evpl_rdma_request_ring *ring,
+    int                            size,
+    int                            alignment)
+{
+    ring->request = evpl_valloc(size * sizeof(struct evpl_rdma_request), alignment);
+
+    ring->size      = size;
+    ring->mask      = size - 1;
+    ring->head      = 0;
+    ring->tail      = 0;
+    ring->alignment = alignment;
+} // evpl_rdma_request_ring_alloc
+
+static inline void
+evpl_rdma_request_ring_free(struct evpl_rdma_request_ring *ring)
+{
+    evpl_free(ring->request);
+} // evpl_rdma_request_ring_free
+
+static inline void
+evpl_rdma_request_ring_resize(struct evpl_rdma_request_ring *ring)
+{
+    int                       new_size    = ring->size << 1;
+    struct evpl_rdma_request *new_request = evpl_valloc(
+        new_size * sizeof(struct evpl_rdma_request), ring->alignment);
+
+    evpl_core_assert(ring->request);
+
+    if (ring->head > ring->tail) {
+        memcpy(new_request, &ring->request[ring->tail], (ring->head - ring->tail) *
+               sizeof(struct evpl_rdma_request));
+    } else {
+        memcpy(new_request, &ring->request[ring->tail], (ring->size - ring->tail) *
+               sizeof(struct evpl_rdma_request));
+        memcpy(&new_request[ring->size - ring->tail], ring->request, ring->head *
+               sizeof(struct evpl_rdma_request));
+    }
+
+    ring->head = ring->size - 1;
+    ring->tail = 0;
+
+    evpl_free(ring->request);
+
+    ring->request = new_request;
+    ring->size    = new_size;
+    ring->mask    = new_size - 1;
+} // evpl_rdma_request_ring_resize
+
+
+static inline void
+evpl_rdma_request_ring_clear(
+    struct evpl                   *evpl,
+    struct evpl_rdma_request_ring *ring)
+{
+    struct evpl_rdma_request *request;
+    int                       i;
+
+    while (ring->tail != ring->head) {
+
+        request = &ring->request[ring->tail];
+
+        for (i = 0; i < request->niov; i++) {
+            evpl_iovec_decref(&request->iov[i]);
+        }
+
+        ring->tail = (ring->tail + 1) & ring->mask;
+    }
+
+    ring->head = 0;
+    ring->tail = 0;
+} // evpl_rdma_request_ring_clear
+
+static inline struct evpl_rdma_request *
+evpl_rdma_request_ring_head(struct evpl_rdma_request_ring *ring)
+{
+    if (ring->head == ring->tail) {
+        return NULL;
+    } else {
+        return &ring->request[(ring->head + ring->size - 1) & ring->mask];
+    }
+} // evpl_rdma_request_ring_head
+
+static inline struct evpl_rdma_request *
+evpl_rdma_request_ring_tail(struct evpl_rdma_request_ring *ring)
+{
+    if (ring->head == ring->tail) {
+        return NULL;
+    } else {
+        return &ring->request[ring->tail];
+    }
+} // evpl_rdma_request_ring_tail
+
+
+static inline int
+evpl_rdma_request_ring_is_empty(const struct evpl_rdma_request_ring *ring)
+{
+    return ring->head == ring->tail;
+} // evpl_rdma_request_ring_is_empty
+
+static inline int
+evpl_rdma_request_ring_is_full(const struct evpl_rdma_request_ring *ring)
+{
+    return ((ring->head + 1) & ring->mask) == ring->tail;
+} // evpl_rdma_request_ring_is_full
+
+static inline uint64_t
+evpl_rdma_request_ring_elements(const struct evpl_rdma_request_ring *ring)
+{
+    return ((ring->head + ring->size) - ring->tail) & ring->mask;
+} // evpl_rdma_request_ring_elements
+
+static inline struct evpl_rdma_request *
+evpl_rdma_request_ring_add(
+    struct evpl_rdma_request_ring *ring,
+    enum evpl_rdma_request_type    type,
+    uint32_t                       remote_key,
+    uint64_t                       remote_address,
+    struct evpl_iovec             *iov,
+    int                            niov,
+    void (                        *callback )(
+        int   status,
+        void *private_data),
+    void                          *private_data)
+{
+    struct evpl_rdma_request *res;
+
+    if (unlikely(evpl_rdma_request_ring_is_full(ring))) {
+        evpl_rdma_request_ring_resize(ring);
+    }
+
+    res = &ring->request[ring->head];
+
+    res->type           = type;
+    res->remote_key     = remote_key;
+    res->remote_address = remote_address;
+    res->iov            = iov;
+    res->niov           = niov;
+    res->callback       = callback;
+    res->private_data   = private_data;
+
+    ring->head = (ring->head + 1) & ring->mask;
+
+    return res;
+} // evpl_rdma_request_ring_add
+
+
+static inline void
+evpl_rdma_request_ring_remove(struct evpl_rdma_request_ring *ring)
+{
+    ring->tail = (ring->tail + 1) & ring->mask;
+} // evpl_rdma_request_ring_remove


### PR DESCRIPTION
* Add ringbuffer for RDMA read/write requests rather than just directly delivering them to hardware.  This allows honoring the RDMA CM initiator_depth parameter and not overloading the peer with too many requests.