### PR TITLE
Process pending_close_binds unconditionally in evpl_continue

### DIFF
--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -354,7 +354,7 @@ evpl_continue(struct evpl *evpl)
     struct evpl_deferral *deferral;
     struct evpl_poll     *poll;
     struct evpl_timer    *timer;
-    int                   i, n;
+    int                   i;
     int                   msecs = evpl->config.wait_ms;
     uint64_t              elapsed;
     int64_t               remain;
@@ -442,14 +442,12 @@ evpl_continue(struct evpl *evpl)
             msecs = 0;
         }
 
-        n = evpl_core_wait(&evpl->core, msecs);
+        (void) evpl_core_wait(&evpl->core, msecs);
 
-        if (evpl->pending_close_binds && n == 0) {
-            while (evpl->pending_close_binds) {
-                bind = evpl->pending_close_binds;
-                bind->protocol->close(evpl, bind);
-                evpl_bind_destroy(evpl, bind);
-            }
+        while (evpl->pending_close_binds) {
+            bind = evpl->pending_close_binds;
+            bind->protocol->close(evpl, bind);
+            evpl_bind_destroy(evpl, bind);
         }
 
         evpl->poll_iterations = 0;


### PR DESCRIPTION
## Summary
- Binds pending close were only cleaned up when `evpl_core_wait()` returned 0 (no events)
- Under sustained load this condition may never be met, causing pending close binds to accumulate indefinitely and preventing connections from being fully torn down
- Now processes `pending_close_binds` on every iteration of `evpl_continue()` regardless of event count