### PR TITLE
Expose evpl_add_poll and evpl_remove_poll in the public API

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -20,6 +20,7 @@ Complete API documentation for libevpl organized by functional area.
 - **[Timer API](/api/timers)** - Scheduled callbacks and timeouts
 - **[Deferral API](/api/deferrals)** - Deferred task execution
 - **[Doorbell API](/api/doorbells)** - Inter-thread notifications
+- **[Poll API](/api/polls)** - Busy-poll callbacks for spin-mode work
 - **[Threading API](/api/threading)** - Thread creation and thread pools
 - **[Block I/O API](/api/block)** - High-performance storage operations (io_uring, VFIO-NVMe)
 - **[RDMA API](/api/rdma)** - RDMA-specific functionality

--- a/docs/api/polls.md
+++ b/docs/api/polls.md
@@ -1,0 +1,124 @@
+---
+title: Polls
+layout: default
+parent: Core
+nav_order: 8
+permalink: /api/polls
+---
+
+# Polls
+
+Provides per-thread poll callbacks that run while the event loop is in poll
+(busy-spin) mode, plus optional enter/exit hooks to set up or tear down
+state when the thread transitions between polling and event-driven waiting.
+
+For background on libevpl's hybrid event/poll model, see the
+[Architecture](/architecture) page.
+
+## Overview
+
+When an event loop is in poll mode it spins on the CPU instead of sleeping
+in `epoll_wait()`/`kqueue()`, calling each registered poll callback every
+iteration. The thread enters poll mode automatically when there is recent
+activity (events, doorbells, etc.) and exits after `spin_ns` of idleness,
+falling back to system-call-based waiting.
+
+**Use cases:**
+- Draining a lock-protected work queue without paying a syscall on every
+  request when traffic is bursty.
+- Polling completion queues for backends that do not generate epoll events
+  (RDMA CQ, io_uring CQE, VFIO-NVMe, libaio, XLIO).
+- Pinning a worker thread on-CPU for a configured duration after the last
+  request, in anticipation of more work.
+
+**Relation to doorbells:** a doorbell ring counts as activity, so it
+re-enters poll mode automatically. Combining a doorbell (for the wake) with
+a poll callback (for the spin-mode drain) gives a thread that wakes on
+demand and then briefly polls before sleeping again.
+
+## Functions
+
+### `evpl_add_poll`
+
+```c
+struct evpl_poll *
+evpl_add_poll(
+    struct evpl               *evpl,
+    evpl_poll_enter_callback_t enter_callback,
+    evpl_poll_exit_callback_t  exit_callback,
+    evpl_poll_callback_t       callback,
+    void                      *private_data);
+```
+
+Register a poll callback on the event loop.
+
+**Parameters:**
+- `evpl` - Event loop to attach to.
+- `enter_callback` - Optional. Invoked once when the event loop transitions
+  from event-driven waiting into poll mode. Pass `NULL` if not needed.
+- `exit_callback` - Optional. Invoked once when the event loop transitions
+  out of poll mode and back to event-driven waiting. Pass `NULL` if not
+  needed.
+- `callback` - Required. Invoked on every poll iteration while the thread
+  is in poll mode.
+- `private_data` - Opaque pointer passed back to each callback.
+
+**Returns:** Handle for the registration, used with `evpl_remove_poll`.
+
+**Thread Safety:** Must be called from the thread that owns `evpl`.
+
+**Behavior notes:**
+- Poll callbacks must be fast and non-blocking — they run on every spin
+  iteration.
+- Registering a poll callback does not by itself force the thread into
+  poll mode; that decision is governed by activity and the global
+  `poll_mode` / `spin_ns` / `poll_iterations` thread config.
+
+---
+
+### `evpl_remove_poll`
+
+```c
+void
+evpl_remove_poll(
+    struct evpl      *evpl,
+    struct evpl_poll *poll);
+```
+
+Detach a previously registered poll callback.
+
+**Parameters:**
+- `evpl` - Event loop the poll was attached to.
+- `poll` - Handle returned by `evpl_add_poll`.
+
+**Thread Safety:** Must be called from the thread that owns `evpl`.
+
+---
+
+## Callback Signatures
+
+```c
+typedef void (*evpl_poll_enter_callback_t)(
+    struct evpl *evpl,
+    void        *private_data);
+
+typedef void (*evpl_poll_exit_callback_t)(
+    struct evpl *evpl,
+    void        *private_data);
+
+typedef void (*evpl_poll_callback_t)(
+    struct evpl *evpl,
+    void        *private_data);
+```
+
+All callbacks receive the owning event loop and the `private_data` pointer
+supplied at registration. None of them return a value; they run on the
+thread that owns `evpl`.
+
+---
+
+## See Also
+
+- [Configuration API](/api/config) - `poll_mode`, `spin_ns`, `poll_iterations`
+- [Doorbell API](/api/doorbells) - Inter-thread wakeups (often paired with polls)
+- [Architecture](/architecture) - Hybrid event/poll model

--- a/include/evpl/evpl.h
+++ b/include/evpl/evpl.h
@@ -13,6 +13,7 @@
 #include <evpl/evpl_endpoint.h>
 #include <evpl/evpl_deferral.h>
 #include <evpl/evpl_doorbell.h>
+#include <evpl/evpl_poll.h>
 #include <evpl/evpl_timer.h>
 #include <evpl/evpl_bind.h>
 #include <evpl/evpl_block.h>

--- a/include/evpl/evpl_poll.h
+++ b/include/evpl/evpl_poll.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#ifndef EVPL_INCLUDED
+#error "Do not include evpl_poll.h directly, include evpl/evpl.h instead"
+#endif /* ifndef EVPL_INCLUDED */
+
+struct evpl_poll;
+
+typedef void (*evpl_poll_enter_callback_t)(
+    struct evpl *evpl,
+    void        *private_data);
+
+typedef void (*evpl_poll_exit_callback_t)(
+    struct evpl *evpl,
+    void        *private_data);
+
+typedef void (*evpl_poll_callback_t)(
+    struct evpl *evpl,
+    void        *private_data);
+
+struct evpl_poll *
+evpl_add_poll(
+    struct evpl               *evpl,
+    evpl_poll_enter_callback_t enter_callback,
+    evpl_poll_exit_callback_t  exit_callback,
+    evpl_poll_callback_t       callback,
+    void                      *private_data);
+
+void
+evpl_remove_poll(
+    struct evpl      *evpl,
+    struct evpl_poll *poll);

--- a/src/core/poll.c
+++ b/src/core/poll.c
@@ -4,8 +4,9 @@
 
 #include "core/evpl.h"
 #include "core/poll.h"
+#include "macros.h"
 
-struct evpl_poll *
+SYMBOL_EXPORT struct evpl_poll *
 evpl_add_poll(
     struct evpl               *evpl,
     evpl_poll_enter_callback_t enter_callback,
@@ -25,7 +26,7 @@ evpl_add_poll(
     return poll;
 } /* evpl_add_poll */
 
-void
+SYMBOL_EXPORT void
 evpl_remove_poll(
     struct evpl      *evpl,
     struct evpl_poll *poll)

--- a/src/core/poll.h
+++ b/src/core/poll.h
@@ -4,18 +4,8 @@
 
 #pragma once
 
-
-typedef void (*evpl_poll_enter_callback_t)(
-    struct evpl *evpl,
-    void        *private_data);
-
-typedef void (*evpl_poll_exit_callback_t)(
-    struct evpl *evpl,
-    void        *private_data);
-
-typedef void (*evpl_poll_callback_t)(
-    struct evpl *evpl,
-    void        *private_data);
+#define EVPL_INTERNAL 1
+#include "evpl/evpl.h"
 
 struct evpl_poll {
     evpl_poll_enter_callback_t enter_callback;
@@ -23,16 +13,3 @@ struct evpl_poll {
     evpl_poll_callback_t       callback;
     void                      *private_data;
 };
-
-struct evpl_poll *
-evpl_add_poll(
-    struct evpl               *evpl,
-    evpl_poll_enter_callback_t enter_callback,
-    evpl_poll_exit_callback_t  exit_callback,
-    evpl_poll_callback_t       callback,
-    void                      *private_data);
-
-void
-evpl_remove_poll(
-    struct evpl      *evpl,
-    struct evpl_poll *poll);


### PR DESCRIPTION
## Summary

- Move the `evpl_poll` type, callback typedefs, and `evpl_add_poll`/`evpl_remove_poll` prototypes into a new public header `include/evpl/evpl_poll.h`, pulled in via `evpl/evpl.h`. The internal `src/core/poll.h` is reduced to the struct definition only, matching the layering used by doorbells.
- Mark `evpl_add_poll` and `evpl_remove_poll` with `SYMBOL_EXPORT` so they're linkable from outside the library.
- Add an API reference page `docs/api/polls.md` and link it from the API index.

## Motivation

The poll registration API is currently libevpl-internal. Exposing it lets consumers register per-thread poll callbacks (e.g., to drain a lock-protected work queue while the thread is in libevpl's spin-mode after a doorbell wake) without depending on internal headers or building against the source tree.

This unblocks a chimera-nas/chimera change that adds an "async delegation" thread pool which uses evpl_add_poll to keep worker threads on-CPU briefly after each request.

## Verification

- make syntax-check — clean.
- make debug — full build + all 59 ctest cases pass.
- No call-site changes inside libevpl; all internal users still pick up the same typedefs/prototypes through core/poll.h's include of evpl/evpl.h.