### PR TITLE
Batch contiguous iovecs in evpl_xlio_tcp_write()

### DIFF
--- a/src/core/xlio/common.h
+++ b/src/core/xlio/common.h
@@ -75,11 +75,14 @@ typedef void (*evpl_xlio_error_callback_t)(
     struct evpl_xlio_socket *s);
 
 
+#define EVPL_XLIO_BATCH_MAX 64
+
 struct evpl_xlio_zc {
-    struct evpl_xlio_buffer *buffer;
-    unsigned int             length;
-    int                      complete;
-    struct evpl_xlio_zc     *next;
+    unsigned int           niov;
+    unsigned int           length;
+    int                    complete;
+    struct evpl_xlio_zc   *next;
+    struct evpl_iovec_ref *refs[EVPL_XLIO_BATCH_MAX];
 };
 
 struct evpl_xlio_socket {

--- a/src/core/xlio/tcp.c
+++ b/src/core/xlio/tcp.c
@@ -27,48 +27,91 @@ extern struct evpl_shared *evpl_shared;
 
 #include "common.h"
 
-static inline void
-evpl_xlio_prepare_iov(
+/* Gather a contiguous run of iovecs from the send ring that share the
+ * same mkey (xlio_socket_sendv takes one mkey for the whole batch).
+ */
+static inline int
+evpl_xlio_prepare_batch(
     struct evpl                  *evpl,
     struct evpl_xlio             *xlio,
     struct evpl_xlio_socket      *s,
-    struct iovec                 *iov,
+    struct iovec                 *iovs,
+    int                           max_niov,
     struct xlio_socket_send_attr *send_attr,
-    struct evpl_iovec_ring       *ring)
+    struct evpl_iovec_ring       *ring,
+    uint64_t                     *r_total,
+    struct evpl_xlio_zc         **r_zc)
 {
     struct ibv_mr      **mrset;
     struct evpl_iovec   *iovec;
-    struct evpl_xlio_zc *zc;
-    int                  pos = ring->tail;
+    struct evpl_xlio_zc *zc           = NULL;
+    int                  pos          = ring->tail;
+    int                  niov         = 0;
+    int                  batch_inline = -1;
+    unsigned int         batch_key    = 0;
+    uint64_t             total        = 0;
 
-    iovec = &ring->iovec[pos];
+    *r_zc    = NULL;
+    *r_total = 0;
 
-    mrset = evpl_memory_framework_private(iovec, EVPL_FRAMEWORK_XLIO);
+    if (max_niov > EVPL_XLIO_BATCH_MAX) {
+        max_niov = EVPL_XLIO_BATCH_MAX;
+    }
 
-    send_attr->mkey = mrset[s->pd_index]->lkey;
+    while (pos != ring->head && niov < max_niov) {
+        iovec = &ring->iovec[pos];
 
-    iov->iov_base = iovec->data;
-    iov->iov_len  = iovec->length;
+        int          this_inline = (iovec->length <= 64) ? 1 : 0;
+        unsigned int this_key;
 
-    if (iovec->length <= 64) {
-        send_attr->flags = XLIO_SOCKET_SEND_FLAG_INLINE;
+        mrset    = evpl_memory_framework_private(iovec, EVPL_FRAMEWORK_XLIO);
+        this_key = mrset[s->pd_index]->lkey;
 
-        evpl_xlio_send_completion(evpl, s, iovec->length);
+        if (niov == 0) {
+            batch_key    = this_key;
+            batch_inline = this_inline;
+        } else if (this_key != batch_key || this_inline != batch_inline) {
+            break;
+        }
+
+        iovs[niov].iov_base = iovec->data;
+        iovs[niov].iov_len  = iovec->length;
+        total              += iovec->length;
+        niov++;
+        pos = (pos + 1) & ring->mask;
+    }
+
+    if (niov == 0) {
+        return 0;
+    }
+
+    send_attr->mkey = batch_key;
+
+    if (batch_inline) {
+        send_attr->flags       = XLIO_SOCKET_SEND_FLAG_INLINE;
+        send_attr->userdata_op = 0;
     } else {
-        send_attr->flags = 0;
+        zc         = evpl_xlio_alloc_zc(xlio);
+        zc->niov   = niov;
+        zc->length = total;
 
-        zc = evpl_xlio_alloc_zc(xlio);
-
-        zc->buffer = container_of(evpl_iovec_get_ref(iovec),
-                                  struct evpl_xlio_buffer, ref);
-        zc->length = iovec->length;
+        int p = ring->tail;
+        for (int i = 0; i < niov; i++) {
+            zc->refs[i] = evpl_iovec_get_ref(&ring->iovec[p]);
+            p           = (p + 1) & ring->mask;
+        }
 
         s->zc_pending++;
 
+        send_attr->flags       = 0;
         send_attr->userdata_op = (uintptr_t) zc;
     }
 
-} /* evpl_xlio_prepare_iov */
+    *r_total = total;
+    *r_zc    = zc;
+
+    return niov;
+} /* evpl_xlio_prepare_batch */
 
 void
 evpl_xlio_tcp_read(
@@ -126,24 +169,47 @@ evpl_xlio_tcp_write(
 {
     struct evpl_xlio            *xlio;
     struct evpl_bind            *bind = evpl_private2bind(s);
-    struct iovec                 iov;
+    struct iovec                 iovs[EVPL_XLIO_BATCH_MAX];
     struct xlio_socket_send_attr send_attr;
+    struct evpl_xlio_zc         *zc;
+    uint64_t                     total;
+    int                          niov;
     ssize_t                      res;
+    int                          batches = 0;
 
     xlio = evpl_framework_private(evpl, EVPL_FRAMEWORK_XLIO);
 
-    evpl_xlio_prepare_iov(evpl, xlio, s, &iov, &send_attr, &bind->iovec_send);
+    while (batches < 16) {
 
-    res = xlio->extra->xlio_socket_sendv(s->socket, &iov, 1, &send_attr);
+        niov = evpl_xlio_prepare_batch(evpl, xlio, s,
+                                       iovs, EVPL_XLIO_BATCH_MAX,
+                                       &send_attr, &bind->iovec_send,
+                                       &total, &zc);
 
-    if (res) {
-        return res;
+        if (niov == 0) {
+            break;
+        }
+
+        res = xlio->extra->xlio_socket_sendv(s->socket, iovs, niov, &send_attr);
+
+        if (res) {
+            if (zc) {
+                s->zc_pending--;
+                evpl_xlio_free_zc(xlio, zc);
+            }
+            return res;
+        }
+
+        if (!zc) {
+            evpl_xlio_send_completion(evpl, s, total);
+        }
+
+        evpl_iovec_ring_consume(evpl, &bind->iovec_send, total);
+        batches++;
     }
 
-    evpl_iovec_ring_consume(evpl, &bind->iovec_send, iov.iov_len);
-
     return 0;
-} /* evpl_write_tcp */
+} /* evpl_xlio_tcp_write */
 
 void
 evpl_xlio_tcp_connect(

--- a/src/core/xlio/xlio.c
+++ b/src/core/xlio/xlio.c
@@ -182,12 +182,15 @@ evpl_xlio_socket_completion(
     struct evpl             *evpl = s->evpl;
     struct evpl_xlio        *xlio;
     struct evpl_xlio_zc     *zc = (struct evpl_xlio_zc *) userdata_op;
+    unsigned int             i;
 
     xlio = evpl_framework_private(evpl, EVPL_FRAMEWORK_XLIO);
 
     evpl_xlio_send_completion(evpl, s, zc->length);
 
-    evpl_iovec_ref_release(evpl, &zc->buffer->ref);
+    for (i = 0; i < zc->niov; i++) {
+        evpl_iovec_ref_release(evpl, zc->refs[i]);
+    }
 
     --s->zc_pending;
 


### PR DESCRIPTION
## Summary

The XLIO socketxtreme send path was hardcoded to call `xlio_socket_sendv()` with `niov=1`. For large RPC replies built from many small iovecs, this forced a full trip through the outer evpl poll loop per iovec — a 1 MiB reply assembled from 256 × 4 KiB iovecs required 256 poll iterations to drain, with substantial per-iteration poll-loop overhead.

This change gathers contiguous iovecs from the send ring that share the same `mkey` (and the same inline-vs-ZC mode) and ships them in a single `xlio_socket_sendv()` call.

## Design notes

- `xlio_socket_send_attr` carries a single `mkey` for the whole sendv, so the gather has to break on mkey changes. Different slabs have different `lkey`s; in practice an RPC reply's iovecs tend to come from the same buffer, so batches stay large.
- Zero-copy completion tracking (`evpl_xlio_zc`) now holds an **array of `evpl_iovec_ref *`** instead of a single buffer pointer, so the completion callback can release all refs from one batched send.
- `evpl_xlio_tcp_write()` now drains the send ring in a loop within a single `write_callback` invocation (bounded by 16 batches as a safety cap so one busy socket can't starve others in the same poll group), eliminating the poll-loop bounce overhead.
- `EVPL_XLIO_BATCH_MAX = 64` iovecs per sendv.

## Impact

In chimera's NFS-over-XLIO workload, this raised 1 MiB read throughput from ~16 GiB/s to ~21 GiB/s and noticeably reduced CPU spent in `cq_mgr_tx::poll_and_process_element_tx` and the surrounding XLIO poll machinery (fewer trips through it per byte sent).

## Test

All existing `make test_release` tests pass (59/59).