### PR TITLE
Allocator: preallocator threads, slab prefault, per-thread shared cache, metrics

### DIFF
--- a/include/evpl/evpl_config.h
+++ b/include/evpl/evpl_config.h
@@ -195,3 +195,11 @@ void evpl_global_config_set_max_pending(
 void evpl_global_config_set_max_poll_fd(
     struct evpl_global_config *config,
     unsigned int               max);
+
+void evpl_global_config_set_preallocate_slabs(
+    struct evpl_global_config *config,
+    unsigned int               slabs);
+
+void evpl_global_config_set_preallocate_threads(
+    struct evpl_global_config *config,
+    unsigned int               threads);

--- a/include/evpl/evpl_memory.h
+++ b/include/evpl/evpl_memory.h
@@ -417,3 +417,30 @@ uint64_t evpl_get_slab_size(
 void *
 evpl_slab_alloc(
     void **slab_private);
+
+/* Diagnostic metric instances the allocator updates inline.  Caller
+ * owns the instances (typically a prometheus_metrics instance in the
+ * embedding application).  Any field may be NULL — the allocator
+ * skips NULL instances on update.
+ */
+struct prometheus_counter_instance;
+struct prometheus_gauge_instance;
+
+struct evpl_allocator_metrics {
+    struct prometheus_counter_instance *slabs_inline;
+    struct prometheus_counter_instance *slabs_prealloc;
+    struct prometheus_counter_instance *consumer_waits;
+    struct prometheus_counter_instance *consumer_wait_ns;
+    struct prometheus_gauge_instance   *free_buffers;
+    struct prometheus_gauge_instance   *outstanding_slabs;
+    struct prometheus_gauge_instance   *target_buffers;
+    struct prometheus_gauge_instance   *total_slabs;
+};
+
+/* Register prometheus metric instances with the global allocator.
+ * Must be called after evpl_init.  The static gauges (target_buffers)
+ * are populated immediately; counters and dynamic gauges fill in as
+ * the allocator runs.
+ */
+void evpl_set_allocator_metrics(
+    const struct evpl_allocator_metrics *metrics);

--- a/src/core/allocator.c
+++ b/src/core/allocator.c
@@ -4,9 +4,11 @@
 
 #define _GNU_SOURCE
 #include <pthread.h>
+#include <string.h>
 #include <sys/mman.h>
 #include <linux/memfd.h>
 #include <unistd.h>
+#include <time.h>
 #include <utlist.h>
 
 #include "core/evpl.h"
@@ -31,14 +33,58 @@ struct evpl_slab {
     struct evpl_slab      *next;
 } __attribute__((aligned(64)));
 
+static void *
+evpl_allocator_prealloc_thread(
+    void *arg);
+
 struct evpl_allocator *
 evpl_allocator_create()
 {
     struct evpl_allocator *allocator = evpl_zalloc(sizeof(*allocator));
+    unsigned int           slabs, threads;
+    int                    i;
 
     pthread_mutex_init(&allocator->lock, NULL);
+    pthread_cond_init(&allocator->producer_cv, NULL);
+    pthread_cond_init(&allocator->consumer_cv, NULL);
 
     allocator->hugepages = evpl_shared->config->huge_pages;
+
+    allocator->buffers_per_slab = evpl_shared->config->slab_size /
+        evpl_shared->config->buffer_size;
+
+    slabs   = evpl_shared->config->preallocate_slabs;
+    threads = evpl_shared->config->preallocate_threads;
+
+    if (slabs > 0 && threads == 0) {
+        threads = 1;
+    }
+
+    allocator->target_buffers       = slabs * allocator->buffers_per_slab;
+    allocator->num_prealloc_threads = threads;
+
+    if (threads > 0) {
+        allocator->prealloc_threads = evpl_zalloc(threads * sizeof(pthread_t));
+
+        for (i = 0; i < (int) threads; i++) {
+            pthread_create(&allocator->prealloc_threads[i], NULL,
+                           evpl_allocator_prealloc_thread, allocator);
+        }
+
+        /* Seed initial fill so target is reached before first consumer.
+         * Issued under the lock; producers will pick the wakeups up once
+         * the framework registration callbacks are wired (after
+         * evpl_init returns), but the slab inventory builds up at startup
+         * either way.
+         */
+        pthread_mutex_lock(&allocator->lock);
+        allocator->outstanding_slabs = slabs;
+        allocator->wakeup_credits    = slabs;
+        for (i = 0; i < (int) slabs; i++) {
+            pthread_cond_signal(&allocator->producer_cv);
+        }
+        pthread_mutex_unlock(&allocator->lock);
+    }
 
     return allocator;
 
@@ -51,6 +97,19 @@ evpl_allocator_destroy(struct evpl_allocator *allocator)
     struct evpl_buffer    *buffer;
     struct evpl_framework *framework;
     int                    i;
+
+    if (allocator->num_prealloc_threads > 0) {
+        pthread_mutex_lock(&allocator->lock);
+        allocator->shutdown = 1;
+        pthread_cond_broadcast(&allocator->producer_cv);
+        pthread_mutex_unlock(&allocator->lock);
+
+        for (i = 0; i < allocator->num_prealloc_threads; i++) {
+            pthread_join(allocator->prealloc_threads[i], NULL);
+        }
+
+        evpl_free(allocator->prealloc_threads);
+    }
 
     while (allocator->free_buffers) {
         buffer = allocator->free_buffers;
@@ -125,20 +184,32 @@ evpl_allocator_destroy(struct evpl_allocator *allocator)
     evpl_free(allocator);
 } /* evpl_allocator_destroy */
 
+/* The heavy part: mmap + register, NO mutation of allocator state.
+ * Safe to call without holding allocator->lock.  Caller is responsible
+ * for linking the returned slab into allocator->slabs under the lock.
+ */
 static struct evpl_slab *
-evpl_allocator_create_slab(struct evpl_allocator *allocator)
+evpl_allocator_build_slab(struct evpl_allocator *allocator)
 {
     struct evpl_slab      *slab;
     struct evpl_framework *framework;
     int                    i;
+    int                    hugepages;
 
     slab            = evpl_zalloc(sizeof(*slab));
     slab->size      = evpl_shared->config->slab_size;
     slab->allocator = allocator;
 
+    /* hugepages is set at create time and only flipped 1->0 inside this
+     * function under fallback.  Reading without the lock is fine; the
+     * worst case is two threads racing the same fallback, both
+     * subsequently succeeding via valloc.
+     */
+    hugepages = allocator->hugepages;
+
  again:
 
-    if (allocator->hugepages) {
+    if (hugepages) {
 
         slab->data = mmap(NULL, evpl_shared->config->slab_size,
                           PROT_READ | PROT_WRITE,
@@ -148,10 +219,9 @@ evpl_allocator_create_slab(struct evpl_allocator *allocator)
         if (slab->data == MAP_FAILED) {
             evpl_core_info("Could not allocate huge pages, disabling...");
             allocator->hugepages = 0;
+            hugepages            = 0;
             goto again;
         }
-
-        *(uint64_t *) slab->data = 0;
 
         slab->hugepages = 1;
     } else {
@@ -160,6 +230,13 @@ evpl_allocator_create_slab(struct evpl_allocator *allocator)
                                  evpl_shared->config->page_size);
 
     }
+
+    /* Pre-fault every page so consumers don't pay first-touch fault
+     * latency in the IO hot path.  This runs in a preallocator thread
+     * (or the inline-fallback caller), never on the steady-state hot
+     * path.
+     */
+    memset(slab->data, 0, slab->size);
 
     for (i = 0; i < EVPL_NUM_FRAMEWORK; ++i) {
 
@@ -177,44 +254,231 @@ evpl_allocator_create_slab(struct evpl_allocator *allocator)
 
     }
 
+    return slab;
+} /* evpl_allocator_build_slab */
+
+/* Carve a built slab into buffers and link both into the allocator.
+ * Caller MUST hold allocator->lock.  Returns the number of buffers
+ * added to free_buffers.
+ */
+static int
+evpl_allocator_install_slab(
+    struct evpl_allocator *allocator,
+    struct evpl_slab      *slab)
+{
+    struct evpl_global_config *config = evpl_shared->config;
+    struct evpl_buffer        *buffer;
+    int                        num_buffers, i;
+
     LL_PREPEND(allocator->slabs, slab);
 
+    num_buffers   = slab->size / config->buffer_size;
+    slab->buffers = evpl_zalloc(num_buffers * sizeof(*slab->buffers));
+
+    for (i = 0; i < num_buffers; i++) {
+        buffer           = &slab->buffers[i];
+        buffer->data     = slab->data + i * config->buffer_size;
+        buffer->ref.slab = slab;
+        buffer->used     = 0;
+        buffer->size     = config->buffer_size;
+
+        slab->refcnt++;
+
+        LL_PREPEND(allocator->free_buffers, buffer);
+    }
+
+    allocator->free_buffer_count += num_buffers;
+
+    return num_buffers;
+} /* evpl_allocator_install_slab */
+
+/* Legacy entry point used by evpl_allocator_alloc_slab (whole-slab
+ * out-loan for XLIO's mem_alloc callback).  Builds and links a slab
+ * but does not carve it into buffers.  Caller MUST hold the lock.
+ */
+static struct evpl_slab *
+evpl_allocator_create_slab(struct evpl_allocator *allocator)
+{
+    struct evpl_slab *slab = evpl_allocator_build_slab(allocator);
+
+    LL_PREPEND(allocator->slabs, slab);
     return slab;
 } /* evpl_allocator_create_slab */
+
+/* Decide how many slab-creation requests to issue based on the
+ * current deficit.  Caller MUST hold allocator->lock.
+ */
+static void
+evpl_allocator_maybe_signal(struct evpl_allocator *allocator)
+{
+    int deficit_buffers;
+    int deficit_slabs;
+    int in_flight;
+    int max_new, wake;
+
+    if (allocator->num_prealloc_threads == 0) {
+        return;
+    }
+
+    in_flight       = allocator->outstanding_slabs * allocator->buffers_per_slab;
+    deficit_buffers = allocator->target_buffers -
+        allocator->free_buffer_count - in_flight;
+
+    if (deficit_buffers <= 0) {
+        return;
+    }
+
+    deficit_slabs = (deficit_buffers + allocator->buffers_per_slab - 1) /
+        allocator->buffers_per_slab;
+
+    /* Cap concurrent in-flight slabs at the thread count — extra
+     * signals would just queue producer wakeups with no thread to
+     * service them.
+     */
+    max_new = allocator->num_prealloc_threads - allocator->outstanding_slabs;
+
+    if (max_new <= 0) {
+        return;
+    }
+
+    wake = deficit_slabs < max_new ? deficit_slabs : max_new;
+
+    allocator->outstanding_slabs += wake;
+    allocator->wakeup_credits    += wake;
+
+    if (allocator->m_outstanding_slabs) {
+        prometheus_gauge_set(allocator->m_outstanding_slabs,
+                             allocator->outstanding_slabs);
+    }
+
+    while (wake-- > 0) {
+        pthread_cond_signal(&allocator->producer_cv);
+    }
+} /* evpl_allocator_maybe_signal */
+
+static void *
+evpl_allocator_prealloc_thread(void *arg)
+{
+    struct evpl_allocator *allocator = arg;
+    struct evpl_slab      *slab;
+
+    for ( ; ;) {
+
+        pthread_mutex_lock(&allocator->lock);
+
+        while (allocator->wakeup_credits == 0 && !allocator->shutdown) {
+            pthread_cond_wait(&allocator->producer_cv, &allocator->lock);
+        }
+
+        if (allocator->shutdown) {
+            pthread_mutex_unlock(&allocator->lock);
+            break;
+        }
+
+        allocator->wakeup_credits--;
+
+        pthread_mutex_unlock(&allocator->lock);
+
+        /* Heavy lifting (mmap + ibv_reg_mr) outside the lock so
+         * consumers can keep draining free_buffers in parallel.
+         */
+        slab = evpl_allocator_build_slab(allocator);
+
+        pthread_mutex_lock(&allocator->lock);
+
+        evpl_allocator_install_slab(allocator, slab);
+
+        allocator->outstanding_slabs--;
+
+        if (allocator->m_slabs_prealloc) {
+            prometheus_counter_increment(allocator->m_slabs_prealloc);
+        }
+        if (allocator->m_outstanding_slabs) {
+            prometheus_gauge_set(allocator->m_outstanding_slabs,
+                                 allocator->outstanding_slabs);
+        }
+        if (allocator->m_free_buffers) {
+            prometheus_gauge_set(allocator->m_free_buffers,
+                                 allocator->free_buffer_count);
+        }
+        if (allocator->m_total_slabs) {
+            prometheus_gauge_add(allocator->m_total_slabs, 1);
+        }
+
+        pthread_cond_broadcast(&allocator->consumer_cv);
+
+        pthread_mutex_unlock(&allocator->lock);
+    }
+
+    return NULL;
+} /* evpl_allocator_prealloc_thread */
 
 struct evpl_buffer *
 evpl_allocator_alloc(struct evpl_allocator *allocator)
 {
-    struct evpl_global_config *config = evpl_shared->config;
-    struct evpl_slab          *slab;
-    struct evpl_buffer        *buffer;
-    int                        num_buffers;
+    struct evpl_buffer *buffer;
+    struct evpl_slab   *slab;
+    struct timespec     wait_start, wait_end;
+    int                 did_wait = 0;
 
     pthread_mutex_lock(&allocator->lock);
 
-    if (!allocator->free_buffers) {
+    /* Top up the pool first; any deficit (including from this
+     * allocation about to happen) wakes a producer.
+     */
+    evpl_allocator_maybe_signal(allocator);
 
-        slab = evpl_allocator_create_slab(allocator);
+    while (!allocator->free_buffers) {
 
-        num_buffers = slab->size / config->buffer_size;
+        if (allocator->num_prealloc_threads > 0) {
+            /* Wait for a producer to deliver — heavy work is off the
+             * hot path entirely.
+             */
+            if (!did_wait) {
+                did_wait = 1;
+                clock_gettime(CLOCK_MONOTONIC, &wait_start);
+            }
+            pthread_cond_wait(&allocator->consumer_cv, &allocator->lock);
+            continue;
+        }
 
-        slab->buffers = evpl_zalloc(num_buffers * sizeof(*slab->buffers));
+        /* No pool configured — fall back to inline slab create. */
+        pthread_mutex_unlock(&allocator->lock);
+        slab = evpl_allocator_build_slab(allocator);
+        pthread_mutex_lock(&allocator->lock);
+        evpl_allocator_install_slab(allocator, slab);
+        if (allocator->m_slabs_inline) {
+            prometheus_counter_increment(allocator->m_slabs_inline);
+        }
+        if (allocator->m_total_slabs) {
+            prometheus_gauge_add(allocator->m_total_slabs, 1);
+        }
+    }
 
-        for (int i = 0; i < num_buffers; i++) {
-            buffer           = &slab->buffers[i];
-            buffer->data     = slab->data + i * config->buffer_size;
-            buffer->ref.slab = slab;
-            buffer->used     = 0;
-            buffer->size     = config->buffer_size;
-
-            slab->refcnt++;
-
-            LL_PREPEND(allocator->free_buffers, buffer);
+    if (did_wait) {
+        clock_gettime(CLOCK_MONOTONIC, &wait_end);
+        uint64_t ns = (wait_end.tv_sec - wait_start.tv_sec) * 1000000000ULL +
+            (wait_end.tv_nsec - wait_start.tv_nsec);
+        if (allocator->m_consumer_waits) {
+            prometheus_counter_increment(allocator->m_consumer_waits);
+        }
+        if (allocator->m_consumer_wait_ns) {
+            prometheus_counter_add(allocator->m_consumer_wait_ns, ns);
         }
     }
 
     buffer = allocator->free_buffers;
     LL_DELETE(allocator->free_buffers, buffer);
+    allocator->free_buffer_count--;
+    if (allocator->m_free_buffers) {
+        prometheus_gauge_set(allocator->m_free_buffers,
+                             allocator->free_buffer_count);
+    }
+
+    /* Re-check after the consume — if we just dropped below target,
+     * fire another wake so the next consumer doesn't have to wait.
+     */
+    evpl_allocator_maybe_signal(allocator);
 
     pthread_mutex_unlock(&allocator->lock);
 
@@ -261,6 +525,11 @@ evpl_allocator_free(
 {
     pthread_mutex_lock(&allocator->lock);
     LL_PREPEND(allocator->free_buffers, buffer);
+    allocator->free_buffer_count++;
+    if (allocator->m_free_buffers) {
+        prometheus_gauge_set(allocator->m_free_buffers,
+                             allocator->free_buffer_count);
+    }
     pthread_mutex_unlock(&allocator->lock);
 } /* evpl_allocator_free */
 
@@ -273,6 +542,16 @@ evpl_allocator_alloc_slab(
 
     pthread_mutex_lock(&allocator->lock);
     slab = evpl_allocator_create_slab(allocator);
+    /* Whole-slab loanouts (e.g. XLIO mem_alloc callback) count under
+     * "inline" since they synchronously stall the caller exactly like
+     * an inline alloc fallback would.
+     */
+    if (allocator->m_slabs_inline) {
+        prometheus_counter_increment(allocator->m_slabs_inline);
+    }
+    if (allocator->m_total_slabs) {
+        prometheus_gauge_add(allocator->m_total_slabs, 1);
+    }
     pthread_mutex_unlock(&allocator->lock);
 
     *slab_private = slab;
@@ -280,6 +559,51 @@ evpl_allocator_alloc_slab(
     return slab->data;
 
 } /* evpl_allocator_alloc_slab */
+
+SYMBOL_EXPORT void
+evpl_set_allocator_metrics(const struct evpl_allocator_metrics *m)
+{
+    struct evpl_allocator *allocator;
+    struct evpl_slab      *slab;
+    uint64_t               total_slabs = 0;
+
+    __evpl_init();
+
+    allocator = evpl_shared->allocator;
+
+    pthread_mutex_lock(&allocator->lock);
+
+    allocator->m_slabs_inline      = m->slabs_inline;
+    allocator->m_slabs_prealloc    = m->slabs_prealloc;
+    allocator->m_consumer_waits    = m->consumer_waits;
+    allocator->m_consumer_wait_ns  = m->consumer_wait_ns;
+    allocator->m_free_buffers      = m->free_buffers;
+    allocator->m_outstanding_slabs = m->outstanding_slabs;
+    allocator->m_target_buffers    = m->target_buffers;
+    allocator->m_total_slabs       = m->total_slabs;
+
+    /* Backfill current state into the gauges so the first scrape
+     * shows reality, not zero.
+     */
+    if (m->free_buffers) {
+        prometheus_gauge_set(m->free_buffers, allocator->free_buffer_count);
+    }
+    if (m->outstanding_slabs) {
+        prometheus_gauge_set(m->outstanding_slabs, allocator->outstanding_slabs);
+    }
+    if (m->target_buffers) {
+        prometheus_gauge_set(m->target_buffers, allocator->target_buffers);
+    }
+    if (m->total_slabs) {
+        LL_FOREACH(allocator->slabs, slab)
+        {
+            total_slabs++;
+        }
+        prometheus_gauge_set(m->total_slabs, total_slabs);
+    }
+
+    pthread_mutex_unlock(&allocator->lock);
+} /* evpl_set_allocator_metrics */
 
 
 void *
@@ -300,7 +624,21 @@ evpl_buffer_free(
 {
     struct evpl_buffer *buffer = container_of(ref, struct evpl_buffer, ref);
 
-    evpl_allocator_free(buffer->ref.slab->allocator, buffer);
+    if (evpl) {
+        /* Park on the releasing thread's shared free list rather than
+         * going through the global allocator lock.  Buffers are fungible
+         * so it doesn't matter which thread allocated them — what
+         * matters is they end up cached somewhere a future alloc on this
+         * thread can pick them up lock-free.  Returned to the global
+         * allocator at evpl_destroy time.
+         */
+        LL_PREPEND(evpl->free_shared_buffers, buffer);
+    } else {
+        /* No evpl context (e.g. during module shutdown) — bypass the
+         * cache and go straight to the global allocator.
+         */
+        evpl_allocator_free(buffer->ref.slab->allocator, buffer);
+    }
 } /* evpl_buffer_free */
 
 
@@ -328,7 +666,15 @@ evpl_buffer_alloc(
 {
     struct evpl_buffer *buffer;
 
-    if (!(flags & EVPL_IOVEC_FLAG_SHARED) && evpl->free_local_buffers) {
+    if (flags & EVPL_IOVEC_FLAG_SHARED) {
+        if (evpl && evpl->free_shared_buffers) {
+            /* Try thread-local shared cache first (no global lock) */
+            buffer = evpl->free_shared_buffers;
+            LL_DELETE(evpl->free_shared_buffers, buffer);
+        } else {
+            buffer = evpl_allocator_alloc(evpl_shared->allocator);
+        }
+    } else if (evpl && evpl->free_local_buffers) {
         /* For LOCAL allocations, try thread-local free list first (no lock) */
         buffer = evpl->free_local_buffers;
         LL_DELETE(evpl->free_local_buffers, buffer);

--- a/src/core/allocator.h
+++ b/src/core/allocator.h
@@ -10,15 +10,44 @@
 
 #include "core/allocator.h"
 #include "core/logging.h"
+#include "prometheus-c.h"
 
 #include "evpl/evpl.h"
 
 
 struct evpl_allocator {
-    struct evpl_slab   *slabs;
-    struct evpl_buffer *free_buffers;
-    int                 hugepages;
-    pthread_mutex_t     lock;
+    struct evpl_slab                   *slabs;
+    struct evpl_buffer                 *free_buffers;
+    int                                 hugepages;
+    pthread_mutex_t                     lock;
+
+    /* Preallocation pool — keeps free_buffer_count >= target_buffers
+     * by waking worker threads to mmap+register slabs out of the IO
+     * hot path.  All inactive when num_prealloc_threads == 0.
+     */
+    int                                 free_buffer_count;
+    int                                 target_buffers;
+    int                                 buffers_per_slab;
+    int                                 outstanding_slabs; /* signaled or in-flight */
+    int                                 wakeup_credits; /* signaled, not yet claimed */
+    int                                 num_prealloc_threads;
+    int                                 shutdown;
+    pthread_t                          *prealloc_threads;
+    pthread_cond_t                      producer_cv;
+    pthread_cond_t                      consumer_cv;
+
+    /* Diagnostic metrics.  Owned by the caller (chimera), registered
+     * via evpl_set_allocator_metrics().  Mutated inline under
+     * allocator->lock — no atomics needed.  All NULL until registered.
+     */
+    struct prometheus_counter_instance *m_slabs_inline;
+    struct prometheus_counter_instance *m_slabs_prealloc;
+    struct prometheus_counter_instance *m_consumer_waits;
+    struct prometheus_counter_instance *m_consumer_wait_ns;
+    struct prometheus_gauge_instance   *m_free_buffers;
+    struct prometheus_gauge_instance   *m_outstanding_slabs;
+    struct prometheus_gauge_instance   *m_target_buffers;
+    struct prometheus_gauge_instance   *m_total_slabs;
 };
 
 struct evpl_buffer {

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -68,6 +68,9 @@ evpl_global_config_init(void)
     config->libaio_enabled     = 1;
     config->libaio_max_pending = 256;
 
+    config->preallocate_slabs   = 0;
+    config->preallocate_threads = 0;
+
     config->tls_cert_file    = NULL;
     config->tls_key_file     = NULL;
     config->tls_cipher_list  = NULL;
@@ -486,4 +489,20 @@ evpl_global_config_set_max_poll_fd(
 {
     config->max_poll_fd = max;
 } /* evpl_global_config_set_max_poll_fd */
+
+SYMBOL_EXPORT void
+evpl_global_config_set_preallocate_slabs(
+    struct evpl_global_config *config,
+    unsigned int               slabs)
+{
+    config->preallocate_slabs = slabs;
+} /* evpl_global_config_set_preallocate_slabs */
+
+SYMBOL_EXPORT void
+evpl_global_config_set_preallocate_threads(
+    struct evpl_global_config *config,
+    unsigned int               threads)
+{
+    config->preallocate_threads = threads;
+} /* evpl_global_config_set_preallocate_threads */
 

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -669,6 +669,12 @@ evpl_destroy(struct evpl *evpl)
         evpl_allocator_free(evpl_shared->allocator, buffer);
     }
 
+    while (evpl->free_shared_buffers) {
+        buffer = evpl->free_shared_buffers;
+        LL_DELETE(evpl->free_shared_buffers, buffer);
+        evpl_allocator_free(evpl_shared->allocator, buffer);
+    }
+
     evpl_core_destroy(&evpl->core);
 
     close(evpl->eventfd);

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -71,6 +71,9 @@ struct evpl_global_config {
     unsigned int              libaio_enabled;
     unsigned int              libaio_max_pending;
 
+    unsigned int              preallocate_slabs;
+    unsigned int              preallocate_threads;
+
     char                     *tls_cert_file;
     char                     *tls_key_file;
     char                     *tls_ca_file;
@@ -135,6 +138,7 @@ struct evpl {
     struct evpl_buffer           *shared_buffer;
     struct evpl_buffer           *datagram_buffer;
     struct evpl_buffer           *free_local_buffers;
+    struct evpl_buffer           *free_shared_buffers;
     struct evpl_bind             *free_binds;
     struct evpl_bind             *binds;
     struct evpl_bind             *pending_close_binds;


### PR DESCRIPTION
## Summary

Three closely related allocator improvements that, together, push slab management entirely off the IO hot path; plus a diagnostic-metrics hook so embedding applications can observe what's happening.

## 1. Preallocator thread pool

Two new config knobs:

```c
evpl_global_config_set_preallocate_slabs(config, N);     // default 0
evpl_global_config_set_preallocate_threads(config, N);   // default 0
```

When configured, spawns a small pool of producer threads that proactively build slabs to keep `free_buffer_count >= target_buffers`. In the hot path `evpl_allocator_alloc()` signals one or more producers based on the current deficit (capped by `num_prealloc_threads` to avoid over-producing) and waits on `consumer_cv` when the pool is empty — instead of building slabs inline.

If `preallocate_slabs > 0` but `preallocate_threads` is unset, threads defaults to 1.

When neither is set, the allocator behaves exactly as before.

The slab-building heavy lifting (`mmap` + `ibv_reg_mr` for any registered frameworks + memset) happens on a producer thread, outside `allocator->lock`, so consumers can continue draining `free_buffers` in parallel.

## 2. Slab prefault

`evpl_allocator_build_slab()` now `memset()`s the entire mapped region after `mmap`. This faults hugepages out of the hot path. Without it, the first worker to touch each hugepage pays the kernel fault cost in-line during IO.

The cost moves to the (background) preallocator threads, or the one-time inline-fallback path when no producers are configured.

## 3. Per-thread cache for SHARED buffers

Mirrors the existing thread-local cache for LOCAL buffers. `evpl_buffer_alloc()` with `EVPL_IOVEC_FLAG_SHARED` now tries `evpl->free_shared_buffers` (no lock) before going to the global allocator. Releases redirect to the releasing thread's cache. Drained back to the global allocator on `evpl_destroy()`.

Removes per-iovec global-mutex contention for SHARED-flag allocations, which can dominate cycle costs when many threads carve small iovecs from many large buffers concurrently.

## 4. Diagnostic metrics

New API:

```c
struct evpl_allocator_metrics {
    struct prometheus_counter_instance *slabs_inline;
    struct prometheus_counter_instance *slabs_prealloc;
    struct prometheus_counter_instance *consumer_waits;
    struct prometheus_counter_instance *consumer_wait_ns;
    struct prometheus_gauge_instance   *free_buffers;
    struct prometheus_gauge_instance   *outstanding_slabs;
    struct prometheus_gauge_instance   *target_buffers;
    struct prometheus_gauge_instance   *total_slabs;
};

void evpl_set_allocator_metrics(const struct evpl_allocator_metrics *metrics);
```

The caller (e.g. an embedder's prometheus integration) creates the instances and passes them in. The allocator bumps them inline under its existing lock. All instance pointers are optional; NULL fields are skipped.

Counters use the inline `prometheus_counter_increment` / `_add` and gauges use `prometheus_gauge_set` — header-only inline in prometheus-c, so the allocator doesn't gain a link-time dependency on prometheus-c.

## Operational signal

With this in place an embedding application can answer:
- Is preallocation keeping up?  `rate(consumer_waits_total[1m])` should be 0 in steady state.
- How often does the hot path fall back to inline slab create? `rate(slabs_inline_total[1m])` should be 0 under load.
- How big is the pool right now? `free_buffers` gauge.

## Test

All existing `make test_release` tests pass (59/59).