### PR TITLE
docs: add Community page and Discord link in header

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,6 +22,7 @@ analytics:
 
 aux_links:
   GitHub: https://github.com/chimera-nas/libevpl
+  Discord: https://discord.gg/hnRkvQFecq
 
 plugins:
   - jekyll-sitemap

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,26 @@
+---
+title: Community
+layout: default
+nav_order: 8
+permalink: /community
+---
+
+# Community
+
+libevpl is an open source project and we welcome participation from anyone interested in high-performance I/O, kernel bypass networking, and modern storage stacks.
+
+## GitHub
+
+Source code, issue tracking, and pull requests live on GitHub:
+
+- [github.com/chimera-nas/libevpl](https://github.com/chimera-nas/libevpl)
+
+Bug reports, feature requests, and contributions are all welcome. Please file issues for anything you find or wish to discuss.
+
+## Discord
+
+For real-time discussion, questions, and design conversations, join the project Discord server:
+
+- [Join the Chimera / libevpl Discord](https://discord.gg/hnRkvQFecq)
+
+The Discord is a good place to ask questions, share what you're building, or chat with other developers using libevpl.


### PR DESCRIPTION
## Summary
- Adds a new Community page (`docs/community.md`) with links to the GitHub repo and the project Discord server.
- Adds the Discord invite to `docs/_config.yml` `aux_links` so it appears next to GitHub in the docs top header.