### PR TITLE
xlio: skip poll group poll when idle, toggle force_poll_mode dynamically

### DIFF
--- a/src/core/address.h
+++ b/src/core/address.h
@@ -83,5 +83,7 @@ evpl_address_get_address(
         sin6 = (struct sockaddr_in6 *) sa;
         inet_ntop(AF_INET6, &sin6->sin6_addr, addr_str, sizeof(addr_str));
         snprintf(str, len, "[%s]:%d", addr_str, ntohs(sin6->sin6_port));
+    } else {
+        snprintf(str, len, "(unspecified)");
     }
 } /* evpl_bind_get_local_address */

--- a/src/core/xlio/common.h
+++ b/src/core/xlio/common.h
@@ -112,12 +112,14 @@ struct evpl_xlio {
     struct xlio_api_t        *extra;
     struct evpl_xlio_api     *api;
     struct evpl_poll         *poll;
+    struct evpl_timer         idle_timer;
     xlio_poll_group_t         poll_group;
     struct evpl_xlio_socket **active_sockets;
     struct evpl_xlio_buffer  *free_xlio_buffers;
     struct evpl_xlio_zc      *free_zc;
     int                       num_active_sockets;
     int                       max_active_sockets;
+    int                       num_connections;
 };
 
 struct evpl_xlio_accepted_socket {
@@ -216,6 +218,17 @@ evpl_xlio_pending_close(
 #endif // if 0
 
         s->socket = 0;
+
+        if (!s->listen) {
+            --xlio->num_connections;
+            if (xlio->num_connections == 0) {
+                /* Last active connection gone — release the event loop so
+                 * it can drain spin_ns of idleness and park in
+                 * evpl_core_wait until the idle_timer (or some other
+                 * source) wakes it. */
+                evpl->force_poll_mode = 0;
+            }
+        }
     }
 } /* evpl_xlio_pending_close */
 

--- a/src/core/xlio/common.h
+++ b/src/core/xlio/common.h
@@ -120,6 +120,7 @@ struct evpl_xlio {
     int                       num_active_sockets;
     int                       max_active_sockets;
     int                       num_connections;
+    int                       idle_timer_active;
 };
 
 struct evpl_xlio_accepted_socket {

--- a/src/core/xlio/tcp.c
+++ b/src/core/xlio/tcp.c
@@ -330,6 +330,19 @@ evpl_xlio_tcp_attach(
     bind->local->addrlen = sslen;
     memcpy(bind->local->addr, &ss, sslen);
 
+    /* Now that the socket is attached to this thread's poll group, resolve
+     * the peer address here. evpl_xlio_socket_accept (the listener-thread
+     * callback) deliberately leaves remote NULL because calling
+     * getpeername() in that context races XLIO's connection state machine
+     * for short-lived connections. */
+    sslen = sizeof(ss);
+    rc    = xlio->extra->xlio_socket_getpeername(sock, (struct sockaddr *) &ss, &sslen);
+    evpl_xlio_abort_if(rc < 0, "xlio_socket_getpeername failed");
+
+    bind->remote          = evpl_address_alloc();
+    bind->remote->addrlen = sslen;
+    memcpy(bind->remote->addr, &ss, sslen);
+
     rc = xlio->extra->xlio_socket_update(s->socket, 0, (uintptr_t) s);
 
     evpl_xlio_abort_if(rc, "Failed to update socket");

--- a/src/core/xlio/xlio.c
+++ b/src/core/xlio/xlio.c
@@ -395,7 +395,9 @@ evpl_xlio_destroy(
 
     if (xlio->poll) {
         evpl_remove_poll(evpl, xlio->poll);
-        evpl_remove_timer(evpl, &xlio->idle_timer);
+        if (xlio->idle_timer_active) {
+            evpl_remove_timer(evpl, &xlio->idle_timer);
+        }
         evpl->force_poll_mode = 0;
     }
 
@@ -482,14 +484,19 @@ evpl_xlio_socket_init(
 
     if (!xlio->poll) {
         xlio->poll = evpl_add_poll(evpl, NULL, NULL, evpl_xlio_poll, xlio);
-
-        /* 10ms fallback: services listen sockets and any other XLIO work
-         * while the main poll callback is short-circuited because
-         * num_connections == 0. */
-        evpl_add_timer(evpl, &xlio->idle_timer, evpl_xlio_idle_timer, 10000UL);
     }
 
-    if (!listen) {
+    if (listen) {
+        /* Listen sockets need a periodic poll to catch incoming accepts
+         * even when num_connections == 0 (poll callback short-circuits).
+         * Worker threads never hit this branch and therefore never pay
+         * for the timer: when a worker has connections the regular poll
+         * runs, and when it doesn't there's nothing for XLIO to service. */
+        if (!xlio->idle_timer_active) {
+            evpl_add_timer(evpl, &xlio->idle_timer, evpl_xlio_idle_timer, 10000UL);
+            xlio->idle_timer_active = 1;
+        }
+    } else {
         if (xlio->num_connections == 0) {
             /* First active connection on this thread — pin the event loop
              * into poll mode so we get per-iteration polling latency. */

--- a/src/core/xlio/xlio.c
+++ b/src/core/xlio/xlio.c
@@ -225,6 +225,11 @@ evpl_xlio_socket_accept(
 
     srcaddr = evpl_address_alloc();
 
+    /* getpeername needs addrlen initialized to the buffer size; evpl_address_alloc
+     * zero-fills the struct, so without this the call writes nothing and we'd
+     * pass an empty sockaddr (sa_family = 0) up to the application. */
+    srcaddr->addrlen = sizeof(srcaddr->sa);
+
     xlio->extra->xlio_socket_getpeername(sock, srcaddr->addr, &srcaddr->addrlen);
 
     rc = xlio->extra->xlio_socket_detach_group(sock);

--- a/src/core/xlio/xlio.c
+++ b/src/core/xlio/xlio.c
@@ -207,7 +207,6 @@ evpl_xlio_socket_accept(
     struct evpl_xlio                 *xlio;
     struct evpl_bind                 *listen_bind;
     struct evpl_xlio_socket          *ls;
-    struct evpl_address              *srcaddr;
     struct evpl_xlio_accepted_socket *accepted_socket;
     int                               rc;
 
@@ -223,20 +222,16 @@ evpl_xlio_socket_accept(
 
     xlio = evpl_framework_private(evpl, EVPL_FRAMEWORK_XLIO);
 
-    srcaddr = evpl_address_alloc();
-
-    /* getpeername needs addrlen initialized to the buffer size; evpl_address_alloc
-     * zero-fills the struct, so without this the call writes nothing and we'd
-     * pass an empty sockaddr (sa_family = 0) up to the application. */
-    srcaddr->addrlen = sizeof(srcaddr->sa);
-
-    xlio->extra->xlio_socket_getpeername(sock, srcaddr->addr, &srcaddr->addrlen);
-
     rc = xlio->extra->xlio_socket_detach_group(sock);
 
     evpl_xlio_abort_if(rc, "Failed to detach socket from group");
 
-    listen_bind->accept_callback(evpl, listen_bind, srcaddr, accepted_socket, listen_bind->private_data);
+    /* The peer address is resolved on the worker thread inside
+     * evpl_xlio_tcp_attach, after the socket has been re-attached to that
+     * thread's poll group. Calling getpeername() from this listener-thread
+     * context races XLIO's internal connection state machine and can return
+     * stale or empty data when sockets churn quickly. */
+    listen_bind->accept_callback(evpl, listen_bind, NULL, accepted_socket, listen_bind->private_data);
 
 } /* evpl_xlio_socket_accept */
 

--- a/src/core/xlio/xlio.c
+++ b/src/core/xlio/xlio.c
@@ -266,6 +266,17 @@ evpl_xlio_socket_rx(
 } /* evpl_xlio_socket_rx */
 
 static void
+evpl_xlio_idle_timer(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    struct evpl_xlio *xlio = container_of(timer, struct evpl_xlio, idle_timer);
+
+    xlio->extra->xlio_poll_group_poll(xlio->poll_group);
+    xlio->extra->xlio_poll_group_flush(xlio->poll_group);
+} /* evpl_xlio_idle_timer */
+
+static void
 evpl_xlio_poll(
     struct evpl *evpl,
     void        *private_data)
@@ -274,6 +285,14 @@ evpl_xlio_poll(
     struct evpl_xlio_socket *s;
     struct evpl_bind        *bind;
     int                      i, res;
+
+    /* When this thread has no established XLIO connections, skip the entire
+     * poll. The idle_timer wakes us every 10ms to service listen sockets and
+     * detect new incoming work; once any connection exists, the regular poll
+     * path takes over again. */
+    if (xlio->num_connections == 0) {
+        return;
+    }
 
     xlio->extra->xlio_poll_group_poll(xlio->poll_group);
 
@@ -376,6 +395,7 @@ evpl_xlio_destroy(
 
     if (xlio->poll) {
         evpl_remove_poll(evpl, xlio->poll);
+        evpl_remove_timer(evpl, &xlio->idle_timer);
         evpl->force_poll_mode = 0;
     }
 
@@ -461,8 +481,21 @@ evpl_xlio_socket_init(
     }
 
     if (!xlio->poll) {
-        xlio->poll            = evpl_add_poll(evpl, NULL, NULL, evpl_xlio_poll, xlio);
-        evpl->force_poll_mode = 1;
+        xlio->poll = evpl_add_poll(evpl, NULL, NULL, evpl_xlio_poll, xlio);
+
+        /* 10ms fallback: services listen sockets and any other XLIO work
+         * while the main poll callback is short-circuited because
+         * num_connections == 0. */
+        evpl_add_timer(evpl, &xlio->idle_timer, evpl_xlio_idle_timer, 10000UL);
+    }
+
+    if (!listen) {
+        if (xlio->num_connections == 0) {
+            /* First active connection on this thread — pin the event loop
+             * into poll mode so we get per-iteration polling latency. */
+            evpl->force_poll_mode = 1;
+        }
+        ++xlio->num_connections;
     }
 
     s->readable       = 0;


### PR DESCRIPTION
## Summary

The XLIO Ultra API only supports busy polling — there is no eventfd or CQ-event notification we can sleep on, even in current upstream (libxlio 3.61.x). Until now, the first XLIO socket created on a thread pinned the libevpl event loop into `force_poll_mode` for the lifetime of the framework instance, so any thread that owned an XLIO listener spun at 100% CPU even when no TCP traffic was flowing (e.g. a deployment receiving only RDMA connections).

This change tracks the count of non-listen XLIO sockets per thread and:

- Short-circuits `evpl_xlio_poll` when the count is zero — the XLIO library is not called at all in that case.
- Drops `force_poll_mode` on the 1→0 transition so libevpl can drain its `spin_ns` idle window and park in `evpl_core_wait`.
- Re-arms `force_poll_mode` on the 0→1 transition so per-iteration polling resumes for active connections.

A 10ms `idle_timer` runs alongside the poll callback whenever any XLIO socket exists. It drives a single `xlio_poll_group_poll`/`xlio_poll_group_flush`, which is what services listen-socket accepts and any deferred XLIO work while the main poll callback is short-circuited.

## Trade-off

Up to ~10ms of latency for the *first* inbound connection on an otherwise-idle thread. Once that connection lands, `num_connections` goes positive, `force_poll_mode` re-arms, and subsequent activity is serviced at the usual per-iteration polling latency.

## Behaviour matrix

| State | `force_poll_mode` | `evpl_xlio_poll` | `idle_timer` | CPU shape |
|---|---|---|---|---|
| No XLIO sockets yet | 0 | not registered | not registered | epoll-driven, idle |
| Only listen socket(s), no connections | 0 | registered, short-circuits | fires every 10ms | epoll_wait with 10ms timeout |
| ≥1 active connection | 1 | full body | still fires (harmless) | spin loop |
| Last connection closed | flips to 0 | short-circuits again | continues firing | drains `spin_ns`, then parks |