### PR TITLE
http: add evpl_http_request_header_iterate()

### DIFF
--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -249,6 +249,36 @@ Get a request header value.
 
 ---
 
+#### `evpl_http_request_header_iterate`
+
+```c
+typedef void (*evpl_http_request_header_cb_t)(
+    const char *name,
+    const char *value,
+    void       *private_data);
+
+void evpl_http_request_header_iterate(
+    struct evpl_http_request     *request,
+    evpl_http_request_header_cb_t callback,
+    void                         *private_data);
+```
+
+Invoke `callback` once for every header on the request, in the order the
+headers were received. Use this when the set of header names isn't known
+up front — for example, when canonicalizing headers for signature
+verification.
+
+The `name` and `value` pointers passed to the callback are owned by the
+request and remain valid for the duration of the call only; copy them if
+they need to outlive the callback.
+
+**Parameters:**
+- `request` - HTTP request
+- `callback` - Function to invoke for each header
+- `private_data` - Opaque pointer forwarded to `callback`
+
+---
+
 ### Request Body
 
 #### `evpl_http_request_get_data_avail`

--- a/include/evpl/evpl_http.h
+++ b/include/evpl/evpl_http.h
@@ -94,6 +94,17 @@ evpl_http_request_header(
     struct evpl_http_request *request,
     const char               *name);
 
+typedef void (*evpl_http_request_header_cb_t)(
+    const char *name,
+    const char *value,
+    void       *private_data);
+
+void
+evpl_http_request_header_iterate(
+    struct evpl_http_request     *request,
+    evpl_http_request_header_cb_t callback,
+    void                         *private_data);
+
 uint64_t
 evpl_http_request_get_data_avail(
     struct evpl_http_request *request);

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -1064,6 +1064,20 @@ evpl_http_request_header(
     return NULL;
 } /* evpl_http_request_header */
 
+SYMBOL_EXPORT void
+evpl_http_request_header_iterate(
+    struct evpl_http_request     *request,
+    evpl_http_request_header_cb_t callback,
+    void                         *private_data)
+{
+    struct evpl_http_request_header *header;
+
+    DL_FOREACH(request->request_headers, header)
+    {
+        callback(header->name, header->value, private_data);
+    }
+} /* evpl_http_request_header_iterate */
+
 SYMBOL_EXPORT uint64_t
 evpl_http_request_get_data_avail(struct evpl_http_request *request)
 {

--- a/src/http/tests/http_basic.c
+++ b/src/http/tests/http_basic.c
@@ -27,6 +27,18 @@ server_wake(
 } /* server_wake */
 
 static void
+count_header(
+    const char *name,
+    const char *value,
+    void       *private_data)
+{
+    int *count = private_data;
+
+    fprintf(stderr, "iterate header: %s: %s\n", name, value);
+    (*count)++;
+} /* count_header */
+
+static void
 server_notify(
     struct evpl                *evpl,
     struct evpl_http_agent     *agent,
@@ -38,6 +50,7 @@ server_notify(
     void                       *private_data)
 {
     struct evpl_iovec iov;
+    int               header_count;
 
     switch (notify_type) {
         case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
@@ -45,6 +58,15 @@ server_notify(
             break;
         case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
             fprintf(stderr, "notify request complete\n");
+
+            header_count = 0;
+            evpl_http_request_header_iterate(request, count_header,
+                                             &header_count);
+            if (header_count == 0) {
+                fprintf(stderr, "header iteration found no headers\n");
+                exit(1);
+            }
+
             evpl_http_request_add_header(request, "MyHeader", "MyValue");
 
             evpl_iovec_alloc(evpl, 11, 0, 1, 0, &iov);


### PR DESCRIPTION
## Summary

Adds `evpl_http_request_header_iterate()` so consumers can walk every request header. The existing `evpl_http_request_header()` only does single-name lookup, which isn't sufficient for use cases that need to discover headers they don't know the names of up front.

Concrete motivation: S3 AWS Signature V2 verification in chimera. The `CanonicalizedAmzHeaders` section of the V2 string-to-sign must include every `x-amz-*` request header, lowercased and sorted lexicographically. Recent boto3 (1.36+) adds `x-amz-checksum-crc32` / `x-amz-sdk-checksum-algorithm` by default on PUT/POST, so without enumeration the server has no way to discover what the client signed.

API:
```c
typedef void (*evpl_http_request_header_cb_t)(
    const char *name, const char *value, void *private_data);

void evpl_http_request_header_iterate(
    struct evpl_http_request *request,
    evpl_http_request_header_cb_t callback,
    void *private_data);
```

Implementation is a trivial `DL_FOREACH` over the existing `request_headers` list. `http_basic` test extended to assert the callback fires at least once.