### PR TITLE
rpc2: add pre-dispatch reply-capture hook for application caches

### DIFF
--- a/include/evpl/evpl_rpc2_program.h
+++ b/include/evpl/evpl_rpc2_program.h
@@ -19,6 +19,7 @@ struct prometheus_histogram_instance;
 #endif // ifndef container_of
 
 struct evpl;
+struct evpl_iovec;
 struct evpl_rpc2_conn;
 struct evpl_rpc2_program;
 struct evpl_rpc2_cred;
@@ -45,6 +46,25 @@ struct evpl_rpc2_rdma_segment_list {
 };
 
 /*
+ * Optional pre-dispatch reply-capture callback.
+ *
+ * If set on an evpl_rpc2_encoding before a send_reply call, libevpl invokes
+ * this callback inside send_reply -- after the reply has been marshalled
+ * into iovecs but before they are queued onto the wire and the request is
+ * freed.  This gives applications a chance to copy out the encoded reply
+ * bytes for later replay (NFS4.1 session replay cache).
+ *
+ * The iov array is the complete RPC reply (header + body).  Pointers are
+ * valid only for the duration of the callback; the callback must copy any
+ * bytes it wishes to retain.
+ */
+typedef void (*evpl_rpc2_reply_capture_cb_t)(
+    const struct evpl_iovec *iov,
+    int                      niov,
+    int                      total_length,
+    void                    *private_data);
+
+/*
  * evpl_rpc2_encoding is the public interface between libevpl and applications.
  *
  * This structure contains pointers to everything needed for XDR encoding/decoding
@@ -56,6 +76,10 @@ struct evpl_rpc2_encoding {
     struct xdr_dbuf             *dbuf;        /* Dynamic buffer for allocations */
     struct evpl_rpc2_rdma_chunk *read_chunk;  /* RDMA read chunk (for writes) */
     struct evpl_rpc2_rdma_chunk *write_chunk; /* RDMA write chunk (for replies) */
+    /* Optional reply-capture hook -- see evpl_rpc2_reply_capture_cb_t.
+     * NULL means "do not capture". */
+    evpl_rpc2_reply_capture_cb_t reply_capture_cb;
+    void                        *reply_capture_private;
 };
 
 struct evpl_rpc2_program {

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -183,16 +183,20 @@ evpl_rpc2_request_alloc(struct evpl_rpc2_thread *thread)
         request = evpl_zalloc(sizeof(*request));
     }
 
-    request->thread                      = thread;
-    request->pending_reads               = 0;
-    request->read_chunk.niov             = 0;
-    request->read_chunk.length           = 0;
-    request->write_chunk.niov            = 0;
-    request->write_chunk.length          = 0;
-    request->write_chunk.max_length      = 0;
-    request->write_segments.num_segments = 0;
-    request->reply_segments.num_segments = 0;
-    request->msg                         = NULL;
+    request->thread                       = thread;
+    request->pending_reads                = 0;
+    request->read_chunk.niov              = 0;
+    request->read_chunk.length            = 0;
+    request->write_chunk.niov             = 0;
+    request->write_chunk.length           = 0;
+    request->write_chunk.max_length       = 0;
+    request->write_segments.num_segments  = 0;
+    request->reply_segments.num_segments  = 0;
+    request->msg                          = NULL;
+    /* Reset any reply-capture hook left over from the previous use of
+     * this recycled request -- the application must re-arm per-call. */
+    request->encoding.reply_capture_cb      = NULL;
+    request->encoding.reply_capture_private = NULL;
 
     return request;
 } /* evpl_rpc2_request_alloc */
@@ -540,6 +544,18 @@ evpl_rpc2_send_reply(
         final_reply_iov    = msg_iov;
         final_reply_niov   = msg_niov;
         final_reply_length = length;
+    }
+
+    /* If the application requested reply capture (e.g. for an NFS4.1
+     * SEQUENCE replay cache), invoke the callback now -- the iovec
+     * array is fully populated and still valid; dispatch_reply will
+     * free the request (and therefore the iovec metadata) below. */
+    if (request->encoding.reply_capture_cb) {
+        request->encoding.reply_capture_cb(
+            final_reply_iov,
+            final_reply_niov,
+            final_reply_length,
+            request->encoding.reply_capture_private);
     }
 
     evpl_rpc2_dispatch_reply(evpl, request, final_reply_iov, final_reply_niov, final_reply_length);

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -183,16 +183,16 @@ evpl_rpc2_request_alloc(struct evpl_rpc2_thread *thread)
         request = evpl_zalloc(sizeof(*request));
     }
 
-    request->thread                       = thread;
-    request->pending_reads                = 0;
-    request->read_chunk.niov              = 0;
-    request->read_chunk.length            = 0;
-    request->write_chunk.niov             = 0;
-    request->write_chunk.length           = 0;
-    request->write_chunk.max_length       = 0;
-    request->write_segments.num_segments  = 0;
-    request->reply_segments.num_segments  = 0;
-    request->msg                          = NULL;
+    request->thread                      = thread;
+    request->pending_reads               = 0;
+    request->read_chunk.niov             = 0;
+    request->read_chunk.length           = 0;
+    request->write_chunk.niov            = 0;
+    request->write_chunk.length          = 0;
+    request->write_chunk.max_length      = 0;
+    request->write_segments.num_segments = 0;
+    request->reply_segments.num_segments = 0;
+    request->msg                         = NULL;
     /* Reset any reply-capture hook left over from the previous use of
      * this recycled request -- the application must re-arm per-call. */
     request->encoding.reply_capture_cb      = NULL;


### PR DESCRIPTION
## Summary

Adds an opt-in callback that fires inside `evpl_rpc2_send_reply` just before the marshalled iovecs are dispatched onto the wire. Applications use it to copy out the encoded reply for later replay.

- New public typedef `evpl_rpc2_reply_capture_cb_t` in `evpl_rpc2_program.h`.
- Two new fields on `struct evpl_rpc2_encoding`: `reply_capture_cb` and `reply_capture_private`.
- `evpl_rpc2_send_reply` invokes the callback with the final iovec list (`final_reply_iov` / `final_reply_niov` / `final_reply_length`) just before `evpl_rpc2_dispatch_reply` queues them via `evpl_sendv` (which takes refs and then frees the request, including the encoding's dbuf — leaving the iovecs unreachable post-dispatch).
- `evpl_rpc2_request_alloc` resets the capture fields so a recycled request never carries a stale hook from its previous use.

## Motivation

Chimera's NFS4.1 server needs a SEQUENCE replay cache (RFC 5661 §2.10.6): on TCP retransmit the server must reproduce the exact reply for the slot rather than re-execute the compound (otherwise non-idempotent ops like OPEN-CREATE / REMOVE / RENAME / LOCK / CLOSE / WRITE silently double-execute, since libevpl does no RPC-layer duplicate detection).

The encoded reply iovecs only exist in a narrow window between marshalling and dispatch; the application can't access them from outside `send_reply`. This hook provides that access without changing the default code path.

## Compatibility

No behavior change when the callback is NULL — and it is NULL by default for every request. Existing applications need no changes.