### PR TITLE
http_basic: include <stdlib.h> for exit()

### DIFF
--- a/src/http/tests/http_basic.c
+++ b/src/http/tests/http_basic.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/eventfd.h>
 #include <unistd.h>


### PR DESCRIPTION
## Summary

Follow-up to #46. The new header-iteration coverage calls `exit(1)` when the callback isn't invoked, but doesn't include `<stdlib.h>`. Debug builds quietly accept the implicit declaration; downstream release builds with `-Werror` (e.g. chimera CI) reject it:

```
error: implicit declaration of function 'exit' [-Werror=implicit-function-declaration]
   67 |                 exit(1);
```

One-line fix: add the missing include.