### PR TITLE
cmake: skip netns-wrapped tests when ip netns add is not permitted

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,42 @@
 cmake_minimum_required(VERSION 3.22)
 
 option(IO_URING_ENABLED "Enable io_uring support" ON)
+option(REQUIRE_NETNS_TESTS "Fail configure if network namespace tests cannot be enabled" OFF)
 set(LIBAIO_ENABLED "" CACHE STRING "Enable libaio support (empty=autodetect, YES=required, NO=disabled)")
 
 project(libevpl LANGUAGES C)
 
 enable_testing()
+
+# Network namespace testing detection.
+# Tests run inside `ip netns` for isolation, which needs CAP_NET_ADMIN.
+# A previous probe (e.g. by a parent project) may have already populated
+# LIBEVPL_NETNS_TESTING in the cache; otherwise do a fresh probe.
+if(NOT DEFINED LIBEVPL_NETNS_TESTING)
+    execute_process(
+        COMMAND bash -c "set -e; n=libevpl_netns_probe_$$; ip netns add \"$n\"; ip netns delete \"$n\""
+        RESULT_VARIABLE LIBEVPL_NETNS_PROBE_RESULT
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+    if(LIBEVPL_NETNS_PROBE_RESULT EQUAL 0)
+        set(LIBEVPL_NETNS_TESTING TRUE)
+    else()
+        set(LIBEVPL_NETNS_TESTING FALSE)
+    endif()
+endif()
+
+if(LIBEVPL_NETNS_TESTING)
+    message(STATUS "Network namespace testing enabled")
+else()
+    if(REQUIRE_NETNS_TESTS)
+        message(FATAL_ERROR
+            "REQUIRE_NETNS_TESTS=ON but `ip netns add` failed "
+            "(need CAP_NET_ADMIN / root).")
+    endif()
+    message(STATUS "Network namespace testing disabled "
+        "(netns-requiring tests will be skipped)")
+endif()
 
 message(STATUS "Building ${CMAKE_BUILD_TYPE} for ${CMAKE_SYSTEM_NAME}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,24 +10,28 @@ macro(unit_test module test_name)
 
     target_link_libraries(${module}_${test_name} evpl pthread)
 
-    # Add the test
-    add_test(NAME libevpl/${module}/${test_name} COMMAND ${LIBEVPL_SOURCE_DIR}/scripts/netns_test_wrapper.sh ${CMAKE_CURRENT_BINARY_DIR}/${module}_${test_name})
+    if(LIBEVPL_NETNS_TESTING)
+        # Add the test
+        add_test(NAME libevpl/${module}/${test_name} COMMAND ${LIBEVPL_SOURCE_DIR}/scripts/netns_test_wrapper.sh ${CMAKE_CURRENT_BINARY_DIR}/${module}_${test_name})
 
-    # Set TEST_FILE environment variable to point to the test source
-    list(GET sources 0 first_source)
-    set_tests_properties(libevpl/${module}/${test_name} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${first_source}")
+        # Set TEST_FILE environment variable to point to the test source
+        list(GET sources 0 first_source)
+        set_tests_properties(libevpl/${module}/${test_name} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${first_source}")
+    endif()
 
 endmacro()
 
 macro(unit_test_bin module test_name binary_name)
 
-    add_test(NAME libevpl/${module}/${test_name} COMMAND ${LIBEVPL_SOURCE_DIR}/scripts/netns_test_wrapper.sh ${TEST_BIN}/${binary_name} ${ARGN})
+    if(LIBEVPL_NETNS_TESTING)
+        add_test(NAME libevpl/${module}/${test_name} COMMAND ${LIBEVPL_SOURCE_DIR}/scripts/netns_test_wrapper.sh ${TEST_BIN}/${binary_name} ${ARGN})
 
 
-    get_target_property(test_file ${binary_name} TEST_FILE)
-    set_tests_properties(libevpl/${module}/${test_name} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${test_file}")
+        get_target_property(test_file ${binary_name} TEST_FILE)
+        set_tests_properties(libevpl/${module}/${test_name} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}")
+    endif()
 endmacro()
 
 macro(unit_test_xdr module test_name xdr_file)

--- a/src/rpc2/tests/CMakeLists.txt
+++ b/src/rpc2/tests/CMakeLists.txt
@@ -39,13 +39,15 @@ endmacro()
 
 # Macro to add a test instance for a specific protocol
 macro(unit_test_rpc2_instance test_name protocol port)
-    add_test(NAME libevpl/rpc2/${test_name}_${protocol}
-             COMMAND ${LIBEVPL_SOURCE_DIR}/scripts/netns_test_wrapper.sh
-                     ${RPC2_TEST_EXE_${test_name}} -r ${protocol} -p ${port})
+    if(LIBEVPL_NETNS_TESTING)
+        add_test(NAME libevpl/rpc2/${test_name}_${protocol}
+                 COMMAND ${LIBEVPL_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                         ${RPC2_TEST_EXE_${test_name}} -r ${protocol} -p ${port})
 
-    set_tests_properties(libevpl/rpc2/${test_name}_${protocol} PROPERTIES
-        ENVIRONMENT "TEST_FILE=${RPC2_TEST_SRC_${test_name}}"
-        TIMEOUT 10)
+        set_tests_properties(libevpl/rpc2/${test_name}_${protocol} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${RPC2_TEST_SRC_${test_name}}"
+            TIMEOUT 10)
+    endif()
 endmacro()
 
 # Build RPC2 test executables


### PR DESCRIPTION
## Summary

- Probe `ip netns add` at configure time and skip tests that need it when the privilege isn't there, so unprivileged builds don't see a wall of failures.
- Add a `REQUIRE_NETNS_TESTS` option (default OFF) so CI can demand the coverage and fail loudly if the privilege ever regresses.
- Allow a parent project (chimera) to pre-populate `LIBEVPL_NETNS_TESTING` and avoid a double probe.

Companion to the chimera PR that does the same at the top level.