### PR TITLE
rpc2/tests/multifrag: fix pump-thread shutdown deadlock

### DIFF
--- a/src/rpc2/tests/multifrag.c
+++ b/src/rpc2/tests/multifrag.c
@@ -36,8 +36,8 @@ static int                   port  = 8000;
 
 struct server_ctx {
     struct HELLO_V1 prog;
+    struct evpl    *evpl;
     volatile int    ready;
-    volatile int    stop;
     volatile int    received_count;
 };
 
@@ -100,11 +100,17 @@ server_pump(void *arg)
     thread = evpl_rpc2_thread_init(evpl, programs, 1, NULL, NULL);
     evpl_rpc2_server_attach(thread, server, ctx);
 
+    /* Publish evpl so the main thread can signal evpl_stop. The
+     * store must be visible before ctx->ready, so use a barrier. */
+    ctx->evpl = evpl;
+    __sync_synchronize();
     ctx->ready = 1;
 
-    while (!ctx->stop) {
-        evpl_continue(evpl);
-    }
+    /* evpl_run blocks on epoll until evpl_stop writes the eventfd
+     * doorbell. A plain `while (!stop) evpl_continue(...)` deadlocks
+     * because epoll_wait has no wakeup when stop is set from another
+     * thread. */
+    evpl_run(evpl);
 
     evpl_rpc2_server_stop(server);
     evpl_rpc2_server_detach(thread, server);
@@ -357,7 +363,7 @@ main(
                        "server processed %d calls, expected 3",
                        ctx.received_count);
 
-    ctx.stop = 1;
+    evpl_stop(ctx.evpl);
     pthread_join(pump, NULL);
 
     printf("Test PASSED\n");


### PR DESCRIPTION
## Summary

The multifrag test's pump thread polled a `volatile int stop` flag while calling `evpl_continue()`. `evpl_continue` blocks in `epoll_wait` when there is no I/O activity, so once the main thread had finished all sub-tests, setting `ctx.stop = 1` did not wake the pump thread — the test deadlocked until ctest's 10s SIGKILL.

Switch to the proper API: pump calls `evpl_run(evpl)`, main calls `evpl_stop(ctx.evpl)`. `evpl_stop` writes the per-loop eventfd, which breaks `epoll_wait` out across threads.

## Reproduction

- Before: ~0.3% flake (4 hangs in 1500 standalone runs).
- After: 0 hangs in 3000 runs of the fixed binary.

Root cause confirmed via a temporary SIGALRM watchdog (8s, before ctest's 10s) that dumped backtraces of both threads on every captured failure — all four were identical: main parked in `pthread_join`, pump parked in `epoll_wait` inside `evpl_continue`. The rpc2 reassembly code is not involved; this is purely a test-side shutdown bug.