### PR TITLE
rdmacm: wait for DISCONNECTED before destroying a locally-closed bind

### DIFF
--- a/src/core/bind.h
+++ b/src/core/bind.h
@@ -16,6 +16,14 @@
 #define EVPL_BIND_FINISH         0x04
 #define EVPL_BIND_SENT_NOTIFY    0x08
 
+/* Set by a protocol's pending_close callback when teardown cannot complete
+ * synchronously (e.g. RDMA must wait for the RDMA_CM_EVENT_DISCONNECTED event
+ * before the cm_id can be destroyed).  While set, the core leaves the bind on
+ * pending_close_binds without calling close()/destroy.  The protocol clears it
+ * once the asynchronous teardown has reached the point where the bind can be
+ * finalized. */
+#define EVPL_BIND_CLOSE_DEFERRED 0x10
+
 struct evpl_bind {
     struct evpl_protocol   *protocol;
     uint64_t                flags;

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -445,10 +445,20 @@ evpl_continue(struct evpl *evpl)
         n = evpl_core_wait(&evpl->core, msecs);
 
         if (evpl->pending_close_binds && n == 0) {
-            while (evpl->pending_close_binds) {
-                bind = evpl->pending_close_binds;
-                bind->protocol->close(evpl, bind);
-                evpl_bind_destroy(evpl, bind);
+            struct evpl_bind *next;
+
+            bind = evpl->pending_close_binds;
+            while (bind) {
+                next = bind->next;
+                /* A protocol with an asynchronous teardown (RDMA) keeps the
+                 * bind parked here until its disconnect event arrives; do not
+                 * finalize it yet or its private state would be freed while
+                 * the protocol still references it. */
+                if (!(bind->flags & EVPL_BIND_CLOSE_DEFERRED)) {
+                    bind->protocol->close(evpl, bind);
+                    evpl_bind_destroy(evpl, bind);
+                }
+                bind = next;
             }
         }
 

--- a/src/core/rdmacm/rdmacm.c
+++ b/src/core/rdmacm/rdmacm.c
@@ -444,7 +444,15 @@ evpl_rdmacm_event_callback(
 
             rdmacm_id->connected = 0;
 
-            evpl_close(evpl, bind);
+            if (bind->flags & EVPL_BIND_CLOSE_DEFERRED) {
+                /* We initiated this disconnect; the bind has been parked on
+                 * pending_close_binds awaiting exactly this event.  Clear the
+                 * deferral so the core finalizes (close + destroy) it on the
+                 * next iteration, now that this event has been acked. */
+                bind->flags &= ~EVPL_BIND_CLOSE_DEFERRED;
+            } else {
+                evpl_close(evpl, bind);
+            }
             break;
         case RDMA_CM_EVENT_REJECTED:
 
@@ -1641,10 +1649,17 @@ evpl_rdmacm_pending_close(
     struct evpl_rdmacm_id *rdmacm_id = evpl_bind_private(bind);
 
     if (rdmacm_id->connected) {
+        /* rdma_disconnect() is asynchronous: the cm_id stays valid and a
+         * RDMA_CM_EVENT_DISCONNECTED event is still owed to us.  Park the bind
+         * until that event arrives (see evpl_rdmacm_event_callback) so the
+         * cm_id is not torn down, and so the core does not free the bind's
+         * private state out from under the still-live cm_id. */
+        bind->flags |= EVPL_BIND_CLOSE_DEFERRED;
         rdma_disconnect(rdmacm_id->id);
-    } else {
-        evpl_rdmacm_destroy_qp(evpl, rdmacm_id);
     }
+
+    /* The cm_id is destroyed in evpl_rdmacm_close(), which the core invokes
+     * once the bind is no longer deferred. */
 
 } /* evpl_rdmacm_pending_close */
 
@@ -1676,6 +1691,8 @@ evpl_rdmacm_close(
 
         evpl_rdmacm_qp_lookup_del(rdmacm_id->dev, rdmacm_id->qp_num);
     }
+
+    evpl_rdmacm_destroy_qp(evpl, rdmacm_id);
 } /* evpl_rdmacm_close */
 
 void


### PR DESCRIPTION
## Problem

A locally-initiated close of a *connected* RDMA bind — e.g. a server calling `evpl_close()` on a connection — aborts with `bind <p> already closed`:

```
evpl_close (bind.c:182)
evpl_rdmacm_event_callback (rdmacm.c, RDMA_CM_EVENT_DISCONNECTED)
```

`evpl_rdmacm_pending_close()` issues `rdma_disconnect()`, which is **asynchronous**: the `cm_id` stays valid and a `RDMA_CM_EVENT_DISCONNECTED` event is still owed to us. But the core close path finalized the bind in the same idle iteration — marking it `EVPL_BIND_CLOSED` and recycling its memory — while the `cm_id` still referenced that memory through its `context`. When the owed `DISCONNECTED` event arrived, the handler resolved it back to the freed bind and called `evpl_close()` again, tripping the abort. The `cm_id`/QP were also leaked on this path, since teardown was never reached.

The peer-initiated path happened to be safe only because there the `DISCONNECTED` event is processed *before* `evpl_close()`.

## Fix

Add `EVPL_BIND_CLOSE_DEFERRED` so a protocol with an asynchronous teardown can park a bind on `pending_close_binds`; the core skips finalizing parked binds.

- `evpl_rdmacm_pending_close()` sets the flag and only issues `rdma_disconnect()` for a connected id.
- cm_id/QP teardown (`destroy_qp`) moves into `evpl_rdmacm_close()`, which the core invokes after the `DISCONNECTED` event has been acked.
- The `DISCONNECTED` handler clears the flag for binds we closed ourselves (letting the core finalize) and closes as before for peer-initiated disconnects.

This also fixes the cm_id/QP leak on the locally-initiated close path.

## Testing

- `ctest -R libevpl/rpc2` — 7/7 pass (incl. RDMA DDP, multifrag).
- Chimera's `nfs3rdma` POSIX suite — 544/544 pass (exercises RDMA connect + teardown).