### PR TITLE
rpc2: drop an unmatched REPLY instead of closing the connection

### DIFF
--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -1176,9 +1176,15 @@ evpl_rpc2_recv_msg(
             HASH_FIND(hh, rpc2_conn->pending_calls, &rpc_msg.xid, sizeof(rpc_msg.xid), request);
 
             if (unlikely(!request)) {
-                evpl_rpc2_error("rpc2 received reply for unknown call %u", rpc_msg.xid);
+                /* A REPLY that matches no outstanding call is benign: it is a
+                 * late, duplicate, or already-timed-out reply (e.g. an NFSv4.1
+                 * backchannel call we have already reaped).  ONC RPC has no way
+                 * to acknowledge a reply, so the only correct action is to drop
+                 * it.  Do not tear down the connection: each RDMA receive is a
+                 * discrete message and each TCP record is independently framed,
+                 * so a stray reply cannot desync the stream. */
+                evpl_rpc2_debug("rpc2 dropping reply for unknown call %u", rpc_msg.xid);
                 evpl_rpc2_msg_free(thread, msg);
-                evpl_close(evpl, bind);
                 return;
             }
 


### PR DESCRIPTION
## Problem

When the server received an RPC message that decoded as a `REPLY` whose xid matched no outstanding call, it logged an error and tore down the whole connection:

```
rpc2 received reply for unknown call 1
-> evpl_close(bind)
```

That is incorrect. ONC RPC (RFC 5531) has no way to acknowledge a reply, and an unmatched reply is a benign, expected event — a late, duplicate, or already-reaped reply (e.g. an NFSv4.1 backchannel call we already timed out). The only correct response is to discard it.

Closing was also unjustified at the transport level: each RDMA receive is a discrete message and each TCP record is independently framed, so a stray reply cannot desync the stream — there is nothing to resync by reconnecting.

## Fix

Drop the reply (logged at debug) and keep the connection open.

## Testing

- `ctest -R libevpl/rpc2` — 7/7 pass.

## Note

This removes an over-aggressive connection reset. It was observed paired with an RDMA double-close abort (fixed in #52) when a Linux NFSv4 client mounted over RDMA: the spurious REPLY closed the connection, which then hit the connected-RDMA close bug. The two fixes are independent.