### PR TITLE
rpc2: do not abort the process on an undispatchable client reply

### DIFF
--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -879,8 +879,12 @@ evpl_rpc2_client_handle_reply(
 
     request->read_chunk.niov = 0;
 
+    /* A reply we cannot dispatch (e.g. an RPC-level MSG_DENIED, or a body that
+     * does not match the procedure's result type) must not take down the whole
+     * process -- drop it and free the request.  The pending caller callback is
+     * not invoked in this case. */
     if (unlikely(error)) {
-        evpl_rpc2_abort("Failed to dispatch rpc2 reply: %d", error);
+        evpl_rpc2_error("Dropping rpc2 reply that failed to dispatch: %d", error);
     }
 
     evpl_rpc2_request_free(thread, request);


### PR DESCRIPTION
## rpc2: don't abort the process on an undispatchable client reply

`evpl_rpc2_client_handle_reply()` called `evpl_rpc2_abort()` — taking the whole
process down — whenever `recv_reply_dispatch` returned an error. But that error
fires for entirely normal cases: an RPC-level `MSG_DENIED` (e.g. an `AUTH_ERROR`
rejection), or any reply whose body doesn't match the expected procedure result.
A misbehaving or rejecting peer should not be able to crash the server.

Log and drop the reply (freeing the request) instead; the pending caller
callback simply isn't invoked.

Surfaced bringing up the NFSv4.1 backchannel in chimera: a `CB_COMPOUND` the
client rejected with `AUTH_ERROR` took the whole NFS server down.
