### PR TITLE
core: handle EINTR on eventfd wakeups

### DIFF
--- a/src/core/doorbell.c
+++ b/src/core/doorbell.c
@@ -4,6 +4,8 @@
 
 #include <sys/eventfd.h>
 #include <unistd.h>
+#include <errno.h>
+#include <string.h>
 #include <utlist.h>
 
 #include "doorbell.h"
@@ -22,7 +24,9 @@ evpl_event_user_callback(
     uint64_t              word;
     ssize_t               len;
 
-    len = read(event->fd, &word, sizeof(word));
+    do {
+        len = read(event->fd, &word, sizeof(word));
+    } while (len < 0 && errno == EINTR);
 
     if (len != sizeof(word)) {
         evpl_event_mark_unreadable(evpl, event);
@@ -71,8 +75,15 @@ evpl_ring_doorbell(struct evpl_doorbell *doorbell)
 {
     uint64_t word = 1;
     ssize_t  len;
+    int      err;
 
-    len = write(doorbell->event.fd, &word, sizeof(word));
+    do {
+        len = write(doorbell->event.fd, &word, sizeof(word));
+    } while (len < 0 && errno == EINTR);
 
-    evpl_core_abort_if(len != sizeof(word), "failed to write to doorbell fd");
+    err = errno;
+
+    evpl_core_abort_if(len != sizeof(word),
+                       "failed to write to doorbell fd %d: len=%zd errno=%d (%s)",
+                       doorbell->event.fd, len, err, strerror(err));
 } /* evpl_ring_doorbell */

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -263,7 +263,9 @@ evpl_ipc_callback(
     uint64_t                     value;
     ssize_t                      rc;
 
-    rc = read(event->fd, &value, sizeof(value));
+    do {
+        rc = read(event->fd, &value, sizeof(value));
+    } while (rc < 0 && errno == EINTR);
 
     if (rc != sizeof(value)) {
         evpl_event_mark_unreadable(evpl, event);
@@ -601,6 +603,7 @@ evpl_stop(struct evpl *evpl)
 {
     uint64_t value = 1;
     ssize_t  len;
+    int      err;
 
     evpl_core_assert(evpl->running);
 
@@ -608,10 +611,15 @@ evpl_stop(struct evpl *evpl)
 
     __sync_synchronize();
 
-    len = write(evpl->eventfd, &value, sizeof(value));
+    do {
+        len = write(evpl->eventfd, &value, sizeof(value));
+    } while (len < 0 && errno == EINTR);
+
+    err = errno;
 
     evpl_core_abort_if(len != sizeof(value),
-                       "evpl_stop: write to eventfd failed");
+                       "evpl_stop: write to eventfd %d failed: len=%zd errno=%d (%s)",
+                       evpl->eventfd, len, err, strerror(err));
 } /* evpl_stop */
 
 
@@ -806,4 +814,3 @@ evpl_slab_alloc(void **slab_private)
 
     return evpl_allocator_alloc_slab(evpl_shared->allocator, slab_private);
 }      /* evpl_slab_alloc */
-

--- a/src/core/io_uring/io_uring.c
+++ b/src/core/io_uring/io_uring.c
@@ -8,6 +8,7 @@
 #include <sys/uio.h>
 #include <stdatomic.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "io_uring_internal.h"
 
@@ -178,7 +179,9 @@ evpl_io_uring_complete_event(
     uint64_t                      value;
     int                           rc, n;
 
-    rc = read(ctx->eventfd, &value, sizeof(value));
+    do {
+        rc = read(ctx->eventfd, &value, sizeof(value));
+    } while (rc < 0 && errno == EINTR);
 
     if (rc != sizeof(value)) {
         evpl_event_mark_unreadable(evpl, &ctx->event);

--- a/src/core/libaio/libaio.c
+++ b/src/core/libaio/libaio.c
@@ -145,7 +145,9 @@ evpl_libaio_complete_event(
     uint64_t                    value;
     int                         rc, n;
 
-    rc = read(ctx->eventfd, &value, sizeof(value));
+    do {
+        rc = read(ctx->eventfd, &value, sizeof(value));
+    } while (rc < 0 && errno == EINTR);
 
     if (rc != sizeof(value)) {
         evpl_event_mark_unreadable(evpl, &ctx->event);

--- a/src/core/listen.c
+++ b/src/core/listen.c
@@ -4,6 +4,8 @@
 
 #include <pthread.h>
 #include <unistd.h>
+#include <errno.h>
+#include <string.h>
 #include <utlist.h>
 
 #include "core/bind.h"
@@ -26,6 +28,7 @@ evpl_listener_accept(
     struct evpl_connect_request  *request;
     uint64_t                      one = 1;
     int                           rc;
+    int                           err;
 
     pthread_mutex_lock(&EvplListenerLock);
 
@@ -58,10 +61,15 @@ evpl_listener_accept(
     DL_APPEND(binding->evpl->connect_requests, request);
     pthread_mutex_unlock(&binding->evpl->lock);
 
-    rc = write(binding->evpl->eventfd, &one, sizeof(one));
+    do {
+        rc = write(binding->evpl->eventfd, &one, sizeof(one));
+    } while (rc < 0 && errno == EINTR);
+
+    err = errno;
 
     evpl_core_abort_if(rc != sizeof(one),
-                       "evpl_listener_accept: write failed");
+                       "evpl_listener_accept: write to eventfd %d failed: rc=%d errno=%d (%s)",
+                       binding->evpl->eventfd, rc, err, strerror(err));
 
     pthread_mutex_unlock(&EvplListenerLock);
 } /* evpl_listener_accept */

--- a/src/core/thread/thread.c
+++ b/src/core/thread/thread.c
@@ -5,6 +5,7 @@
 #include <pthread.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "core/evpl.h"
 #include "evpl/evpl.h"
@@ -56,7 +57,9 @@ evpl_thread_event(
     uint64_t word;
     ssize_t  rc;
 
-    rc = read(event->fd, &word, sizeof(word));
+    do {
+        rc = read(event->fd, &word, sizeof(word));
+    } while (rc < 0 && errno == EINTR);
 
     if (rc != sizeof(word)) {
         evpl_event_mark_unreadable(evpl, event);

--- a/src/core/vfio/vfio.c
+++ b/src/core/vfio/vfio.c
@@ -1071,7 +1071,9 @@ evpl_vfio_event_callback(
     uint64_t                value;
     ssize_t                 len;
 
-    len = read(event->fd, &value, sizeof(value));
+    do {
+        len = read(event->fd, &value, sizeof(value));
+    } while (len < 0 && errno == EINTR);
 
     if (len != sizeof(value)) {
         evpl_event_mark_unreadable(evpl, event);


### PR DESCRIPTION
Eventfd reads/writes in the core wakeup paths should not treat EINTR as a hard failure. Retry interrupted eventfd reads/writes and include fd, return value, and errno details in fatal write diagnostics so shutdown failures are actionable.\n\nThis is intended to make failures like Chimera CI's evpl_stop abort after a successful test body report the real errno, while also handling the benign EINTR case.\n\nValidation:\n- cmake --build build --target evpl\n- make -C ext/libevpl syntax-check\n- ctest --test-dir build -R 'libevpl/core/' --output-on-failure --timeout 300\n- ctest --test-dir build -R 'libevpl/socket/rand_full_duplex_stream_tcp|libevpl/core/timer_oneshot' --output-on-failure --timeout 300