### PR TITLE
io_uring: fix spurious EIO from block flush on recycled requests

### DIFF
--- a/src/core/io_uring/io_uring_block.c
+++ b/src/core/io_uring/io_uring_block.c
@@ -170,6 +170,11 @@ evpl_io_uring_flush(
     req->callback           = evpl_io_uring_callback;
     req->block.callback     = callback;
     req->block.private_data = private_data;
+    /* fsync completes with res == 0; the shared completion callback flags a
+     * short transfer (res != block.length) as EIO, so a recycled request's
+     * stale block.length would spuriously fail.  Match the read/write paths
+     * (and libaio) by zeroing it for the zero-length fsync. */
+    req->block.length = 0;
 
     sqe = io_uring_get_sqe(&ctx->ring);
 


### PR DESCRIPTION
## Problem

`evpl_io_uring_flush()` allocates a request but never sets `req->block.length`. Requests are recycled from a free list, and `evpl_io_uring_request_alloc()` only resets `bounce`/`need_debounce` — so `block.length` retains a stale value from a prior read/write.

The shared completion callback (`evpl_io_uring_callback`) flags a short transfer as an error:

```c
if (req->res < 0)              rc = -req->res;
else if (req->res != req->block.length) rc = EIO;
else                          rc = 0;
```

An fsync completes with `res == 0`, so against a recycled request whose stale `block.length` is non-zero, the flush spuriously returns **EIO**.

The libaio backend's flush already sets `length = 0`, which is why only the io_uring block backend is affected.

## Fix

Zero `req->block.length` in the flush path, matching the read/write paths and libaio.

## How it surfaced

Found while routing diskfs (chimera) mount-time superblock/log writes through `evpl_block_*` on the io_uring backend — the first code to call `evpl_block_flush` on an io_uring block queue. Block flush via io_uring failed 100% with EIO; the libaio backend was unaffected. With the fix, the full diskfs KVM suite passes on both backends.