### PR TITLE
vfio: poll NVMe completions instead of MSI-X interrupts in poll mode

### DIFF
--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -418,7 +418,8 @@ evpl_continue(struct evpl *evpl)
             elapsed = 0;
         }
 
-        if (!evpl->force_poll_mode && elapsed > evpl->config.spin_ns) {
+        if (!evpl->force_poll_mode && !evpl->poll_pin_count &&
+            elapsed > evpl->config.spin_ns) {
             if (evpl->poll_mode) {
                 for (i = 0; i < evpl->num_poll; ++i) {
                     poll = &evpl->poll[i];

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -122,6 +122,7 @@ struct evpl {
     int                           num_enabled_events;
     int                           poll_mode;
     int                           force_poll_mode;
+    int                           poll_pin_count;
 
     struct evpl_doorbell         *doorbells;
 
@@ -224,4 +225,24 @@ evpl_activity(struct evpl *evpl)
 {
     evpl->activity++;
 } /* evpl_activity */
+
+/*
+ * Pin the calling thread into poll mode for as long as the pin count is
+ * non-zero.  Used by frameworks (e.g. VFIO/NVMe in poll mode) that have an
+ * outstanding request which can only be reaped by polling, since the loop
+ * would otherwise fall back to interrupt/event mode after spin_ns of
+ * inactivity and never reap the completion.  Refcounted so that multiple
+ * queues on one thread compose correctly.
+ */
+static inline void
+evpl_poll_pin(struct evpl *evpl)
+{
+    evpl->poll_pin_count++;
+} /* evpl_poll_pin */
+
+static inline void
+evpl_poll_unpin(struct evpl *evpl)
+{
+    evpl->poll_pin_count--;
+} /* evpl_poll_unpin */
 

--- a/src/core/vfio/vfio.c
+++ b/src/core/vfio/vfio.c
@@ -68,6 +68,7 @@ struct evpl_vfio_queue {
     int                            sq_tail;
     int                            cq_head;
     uint16_t                       cq_phase;
+    int                            poll_mode;
     int                            eventfd;
     struct evpl_event              event;
     struct evpl_deferral           ring_sq;
@@ -512,6 +513,10 @@ evpl_vfio_poll_queue(
             cb->fn(evpl, cqe->sc ? EIO : 0, cb->arg);
         }
 
+        if (queue->poll_mode) {
+            evpl_poll_unpin(evpl);
+        }
+
         --queue->cidcount;
 
         if (++queue->cq_head == queue->size) {
@@ -587,6 +592,14 @@ evpl_vfio_create_ioq(
 
     ioq = evpl_vfio_queue_alloc(device, id, size);
 
+    /*
+     * When libevpl poll mode is enabled we keep the submitting thread pinned
+     * into poll mode while requests are outstanding (see evpl_vfio_read/write/
+     * flush), so the device never needs to raise an MSI-X interrupt.  Only
+     * arm the completion-queue interrupt when poll mode is disabled.
+     */
+    ioq->poll_mode = evpl->config.poll_mode;
+
     cid = evpl_vfio_alloc_cid(device->adminq, NULL, 0);
 
     ccq_cmd = &device->adminq->sq[cid].create_cq;
@@ -599,7 +612,7 @@ evpl_vfio_create_ioq(
     ccq_cmd->pc          = 1;
     ccq_cmd->qid         = ioq->id;
     ccq_cmd->qsize       = ioq->size - 1;
-    ccq_cmd->ien         = ioq->id > 0 ? 1 : 0;
+    ccq_cmd->ien         = (ioq->id > 0 && !ioq->poll_mode) ? 1 : 0;
     ccq_cmd->iv          = ioq->id - 1;
 
     /* create the sq */
@@ -923,6 +936,10 @@ evpl_vfio_read(
 
     evpl_activity(evpl);
 
+    if (queue->poll_mode) {
+        evpl_poll_pin(evpl);
+    }
+
     cid = evpl_vfio_alloc_cid(queue, callback, private_data);
 
     cmd = &queue->sq[cid].rw;
@@ -971,6 +988,9 @@ evpl_vfio_write(
 
     evpl_activity(evpl);
 
+    if (queue->poll_mode) {
+        evpl_poll_pin(evpl);
+    }
 
     cid = evpl_vfio_alloc_cid(queue, callback, private_data);
 
@@ -1016,6 +1036,9 @@ evpl_vfio_flush(
 
     evpl_activity(evpl);
 
+    if (queue->poll_mode) {
+        evpl_poll_pin(evpl);
+    }
 
     cid = evpl_vfio_alloc_cid(queue, callback, private_data);
 
@@ -1122,10 +1145,19 @@ evpl_vfio_open_queue(
     bqueue->write        = evpl_vfio_write;
     bqueue->flush        = evpl_vfio_flush;
 
-    evpl_add_event(evpl, &queue->event, queue->eventfd,
-                   evpl_vfio_event_callback, NULL, NULL);
+    /*
+     * In poll mode the completion queue is reaped by the poll callback and the
+     * submitting thread is pinned into poll mode while requests are
+     * outstanding, so the MSI-X eventfd is never armed (ien=0) and we skip the
+     * interrupt event entirely.  Only register the eventfd when poll mode is
+     * disabled.
+     */
+    if (!queue->poll_mode) {
+        evpl_add_event(evpl, &queue->event, queue->eventfd,
+                       evpl_vfio_event_callback, NULL, NULL);
 
-    evpl_event_read_interest(evpl, &queue->event);
+        evpl_event_read_interest(evpl, &queue->event);
+    }
 
     evpl_deferral_init(&queue->ring_sq, evpl_vfio_defer_ring_sq, queue);
 


### PR DESCRIPTION
## Summary

When libevpl poll mode is enabled at the config level, VFIO/NVMe queues now run interrupt-free. An NVMe device only ever signals us in response to a command we submitted, and we already register a completion-queue poll callback — so rather than also arming an MSI-X interrupt, we pin the submitting thread into poll mode for as long as any request is outstanding. The completion is then always reaped by polling, and the MSI-X eventfd path is only used when poll mode is disabled.

This also closes a latent correctness gap: completions don't bump `evpl_activity()`, so a request taking longer than `spin_ns` (1ms default) with no new submits would previously let the loop fall back to event mode — relying on the interrupt to recover. With interrupts off that would hang; the pin prevents it.

## Changes

**Core event loop (`src/core/evpl.{h,c}`)**
- Added a refcounted poll pin: `poll_pin_count` on `struct evpl`, plus `evpl_poll_pin()` / `evpl_poll_unpin()` inlines.
- The spin-down guard in `evpl_continue` now also checks `!poll_pin_count`, so the loop won't leave poll mode while a request is pinned. Refcounted (and separate from xlio's `force_poll_mode`) so multiple queues on one thread compose correctly.

**VFIO (`src/core/vfio/vfio.c`)**
- `struct evpl_vfio_queue` gains a `poll_mode` flag, set once at queue open from `config.poll_mode`.
- IO completion queues created with `ien = (id > 0 && !poll_mode)` — interrupt disabled in poll mode.
- `read`/`write`/`flush` pin on submit; `poll_queue` unpins per reaped completion (poll mode only).
- The MSI-X eventfd event is registered only when poll mode is off.

## Correctness notes
- **Pin/unpin balance:** each read/write/flush allocates one CID → one CQ entry, so one pin pairs with one unpin. The admin queue keeps `poll_mode = 0` and never pins/unpins, so the count stays balanced.
- **No stuck-in-epoll window:** submits happen in-thread during callback processing; the pin plus the existing `evpl_activity()` bump force re-entry into poll mode before any blocking wait.
- `evpl_add_poll` registration stays unconditional — required in poll mode, dormant in interrupt mode since poll mode never engages when `config.poll_mode` is 0.

## Testing
All 61 libevpl ctests pass on a Release build. The on-hardware VFIO path is not exercisable without an NVMe device, so the interrupt-free path is covered by construction and the compile/test of the shared event-loop change.