### PR TITLE
core: own an internal metrics registry and expose evpl_metrics_scrape()

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -98,6 +98,35 @@ Stop a running event loop. Causes `evpl_run()` to return.
 
 ---
 
+### Metrics
+
+libevpl maintains its own [Prometheus](https://prometheus.io/) metrics (for
+example, allocator slab and buffer counters and gauges named `evpl_allocator_*`)
+on an internal registry. These are registered automatically during
+initialization — no caller setup is required.
+
+#### `evpl_metrics_scrape`
+
+```c
+int evpl_metrics_scrape(char *buffer, int buffer_size);
+```
+
+Serialize libevpl's metrics into `buffer` in the Prometheus text exposition
+format (version 0.0.4). Triggers libevpl initialization if it has not happened
+yet, so it is safe to call before `evpl_init()`.
+
+Embedders typically expose these alongside their own metrics by calling this
+function and appending the result to their own exposition output (the
+`evpl_*` metric names are disjoint from typical application names, so the
+concatenation remains a valid single page).
+
+**Parameters:**
+- `buffer` - Destination buffer for the serialized metrics
+- `buffer_size` - Capacity of `buffer` in bytes
+
+**Returns:** Number of bytes written, or `-1` if the buffer was too small
+
+**Thread Safety:** Can be called from any thread
 
 ---
 

--- a/include/evpl/evpl_core.h
+++ b/include/evpl/evpl_core.h
@@ -48,6 +48,15 @@ struct evpl_thread_config;
 void evpl_init(
     struct evpl_global_config *global_config);
 
+/* Serialize libevpl's own metrics into buffer in Prometheus text
+ * exposition format (version 0.0.4).  Returns the number of bytes
+ * written, or -1 if the buffer was too small.  Safe to call from any
+ * thread; triggers evpl initialization if it has not happened yet.
+ */
+int evpl_metrics_scrape(
+    char *buffer,
+    int   buffer_size);
+
 struct evpl * evpl_create(
     struct evpl_thread_config *config);
 

--- a/include/evpl/evpl_memory.h
+++ b/include/evpl/evpl_memory.h
@@ -59,7 +59,7 @@ struct evpl_iovec_ref {
         struct evpl_iovec_ref *ref);
 #ifdef EVPL_IOVEC_TRACE
     pthread_t         owner_thread;  /* Thread that allocated this ref (LOCAL only) */
-#endif
+#endif // ifdef EVPL_IOVEC_TRACE
 };
 
 struct evpl_iovec {
@@ -198,7 +198,7 @@ evpl_iovec_ref_release(
                                   "(owner=%lu, caller=%lu)",
                                   (unsigned long) ref->owner_thread,
                                   (unsigned long) pthread_self());
-#endif
+#endif // ifdef EVPL_IOVEC_TRACE
         prev = ref->refcnt--;
     }
 
@@ -265,7 +265,7 @@ evpl_iovec_ref_incr(struct evpl_iovec_ref *ref)
                                   "(owner=%lu, caller=%lu)",
                                   (unsigned long) ref->owner_thread,
                                   (unsigned long) pthread_self());
-#endif
+#endif // ifdef EVPL_IOVEC_TRACE
         ref->refcnt++;
     }
 } /* evpl_iovec_ref_incr */
@@ -418,29 +418,8 @@ void *
 evpl_slab_alloc(
     void **slab_private);
 
-/* Diagnostic metric instances the allocator updates inline.  Caller
- * owns the instances (typically a prometheus_metrics instance in the
- * embedding application).  Any field may be NULL — the allocator
- * skips NULL instances on update.
+/* The allocator's diagnostic counters and gauges are registered on
+ * libevpl's internal metrics registry at startup and exposed through
+ * evpl_metrics_scrape() (see evpl_core.h).  No caller registration is
+ * required.
  */
-struct prometheus_counter_instance;
-struct prometheus_gauge_instance;
-
-struct evpl_allocator_metrics {
-    struct prometheus_counter_instance *slabs_inline;
-    struct prometheus_counter_instance *slabs_prealloc;
-    struct prometheus_counter_instance *consumer_waits;
-    struct prometheus_counter_instance *consumer_wait_ns;
-    struct prometheus_gauge_instance   *free_buffers;
-    struct prometheus_gauge_instance   *outstanding_slabs;
-    struct prometheus_gauge_instance   *target_buffers;
-    struct prometheus_gauge_instance   *total_slabs;
-};
-
-/* Register prometheus metric instances with the global allocator.
- * Must be called after evpl_init.  The static gauges (target_buffers)
- * are populated immediately; counters and dynamic gauges fill in as
- * the allocator runs.
- */
-void evpl_set_allocator_metrics(
-    const struct evpl_allocator_metrics *metrics);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -74,7 +74,7 @@ add_subdirectory(thread)
 
 add_library(evpl SHARED ${CORE_SRC})
 
-target_link_libraries(evpl ${BACKEND_LIBDEPS} ssl crypto numa)
+target_link_libraries(evpl ${BACKEND_LIBDEPS} ssl crypto numa prometheus-c)
 
 install(TARGETS evpl DESTINATION lib)
 

--- a/src/core/allocator.c
+++ b/src/core/allocator.c
@@ -37,6 +37,10 @@ static void *
 evpl_allocator_prealloc_thread(
     void *arg);
 
+static void
+evpl_allocator_register_metrics(
+    struct evpl_allocator *allocator);
+
 struct evpl_allocator *
 evpl_allocator_create()
 {
@@ -63,6 +67,12 @@ evpl_allocator_create()
     allocator->target_buffers       = slabs * allocator->buffers_per_slab;
     allocator->num_prealloc_threads = threads;
 
+    /* Register before any slab is allocated and before the prealloc
+     * threads start, so the instance pointers are non-NULL by the time
+     * any path touches them (no race, full lifetime counted).
+     */
+    evpl_allocator_register_metrics(allocator);
+
     if (threads > 0) {
         allocator->prealloc_threads = evpl_zalloc(threads * sizeof(pthread_t));
 
@@ -80,6 +90,7 @@ evpl_allocator_create()
         pthread_mutex_lock(&allocator->lock);
         allocator->outstanding_slabs = slabs;
         allocator->wakeup_credits    = slabs;
+        prometheus_gauge_set(allocator->m_outstanding_slabs, slabs);
         for (i = 0; i < (int) slabs; i++) {
             pthread_cond_signal(&allocator->producer_cv);
         }
@@ -571,50 +582,82 @@ evpl_allocator_alloc_slab(
 
 } /* evpl_allocator_alloc_slab */
 
-SYMBOL_EXPORT void
-evpl_set_allocator_metrics(const struct evpl_allocator_metrics *m)
+static struct prometheus_counter_instance *
+evpl_allocator_counter(
+    struct prometheus_metrics *metrics,
+    const char                *name,
+    const char                *help)
 {
-    struct evpl_allocator *allocator;
-    struct evpl_slab      *slab;
-    uint64_t               total_slabs = 0;
+    struct prometheus_counter        *counter;
+    struct prometheus_counter_series *series;
 
-    __evpl_init();
+    counter = prometheus_metrics_create_counter(metrics, name, help);
+    series  = prometheus_counter_create_series(counter, NULL, NULL, 0);
 
-    allocator = evpl_shared->allocator;
+    return prometheus_counter_series_create_instance(series);
+} /* evpl_allocator_counter */
 
-    pthread_mutex_lock(&allocator->lock);
+static struct prometheus_gauge_instance *
+evpl_allocator_gauge(
+    struct prometheus_metrics *metrics,
+    const char                *name,
+    const char                *help)
+{
+    struct prometheus_gauge        *gauge;
+    struct prometheus_gauge_series *series;
 
-    allocator->m_slabs_inline      = m->slabs_inline;
-    allocator->m_slabs_prealloc    = m->slabs_prealloc;
-    allocator->m_consumer_waits    = m->consumer_waits;
-    allocator->m_consumer_wait_ns  = m->consumer_wait_ns;
-    allocator->m_free_buffers      = m->free_buffers;
-    allocator->m_outstanding_slabs = m->outstanding_slabs;
-    allocator->m_target_buffers    = m->target_buffers;
-    allocator->m_total_slabs       = m->total_slabs;
+    gauge  = prometheus_metrics_create_gauge(metrics, name, help);
+    series = prometheus_gauge_create_series(gauge, NULL, NULL, 0);
 
-    /* Backfill current state into the gauges so the first scrape
-     * shows reality, not zero.
-     */
-    if (m->free_buffers) {
-        prometheus_gauge_set(m->free_buffers, allocator->free_buffer_count);
-    }
-    if (m->outstanding_slabs) {
-        prometheus_gauge_set(m->outstanding_slabs, allocator->outstanding_slabs);
-    }
-    if (m->target_buffers) {
-        prometheus_gauge_set(m->target_buffers, allocator->target_buffers);
-    }
-    if (m->total_slabs) {
-        LL_FOREACH(allocator->slabs, slab)
-        {
-            total_slabs++;
-        }
-        prometheus_gauge_set(m->total_slabs, total_slabs);
-    }
+    return prometheus_gauge_series_create_instance(series);
+} /* evpl_allocator_gauge */
 
-    pthread_mutex_unlock(&allocator->lock);
-} /* evpl_set_allocator_metrics */
+/* Create the allocator's diagnostic metrics on libevpl's internal
+ * registry and store the instance handles in the allocator.  Called
+ * once from evpl_allocator_create() before any slab is allocated, so
+ * every counter starts at zero and counts the full lifetime; from then
+ * on the instances are mutated inline under allocator->lock.
+ */
+static void
+evpl_allocator_register_metrics(struct evpl_allocator *allocator)
+{
+    struct prometheus_metrics *metrics = evpl_shared->metrics;
+
+    allocator->m_slabs_inline = evpl_allocator_counter(metrics,
+                                                       "evpl_allocator_slabs_inline_total",
+                                                       "Slabs allocated inline on the consumer path");
+
+    allocator->m_slabs_prealloc = evpl_allocator_counter(metrics,
+                                                         "evpl_allocator_slabs_prealloc_total",
+                                                         "Slabs allocated by the preallocation threads");
+
+    allocator->m_consumer_waits = evpl_allocator_counter(metrics,
+                                                         "evpl_allocator_consumer_waits_total",
+                                                         "Times a consumer blocked waiting for a free buffer");
+
+    allocator->m_consumer_wait_ns = evpl_allocator_counter(metrics,
+                                                           "evpl_allocator_consumer_wait_ns_total",
+                                                           "Total nanoseconds consumers spent waiting for free buffers")
+    ;
+
+    allocator->m_free_buffers = evpl_allocator_gauge(metrics,
+                                                     "evpl_allocator_free_buffers",
+                                                     "Buffers currently available on the free list");
+
+    allocator->m_outstanding_slabs = evpl_allocator_gauge(metrics,
+                                                          "evpl_allocator_outstanding_slabs",
+                                                          "Slab fill requests issued but not yet satisfied");
+
+    allocator->m_target_buffers = evpl_allocator_gauge(metrics,
+                                                       "evpl_allocator_target_buffers",
+                                                       "Target free-buffer count the preallocator maintains");
+
+    allocator->m_total_slabs = evpl_allocator_gauge(metrics,
+                                                    "evpl_allocator_total_slabs",
+                                                    "Slabs allocated over the lifetime of the allocator");
+
+    prometheus_gauge_set(allocator->m_target_buffers, allocator->target_buffers);
+} /* evpl_allocator_register_metrics */
 
 
 void *

--- a/src/core/allocator.h
+++ b/src/core/allocator.h
@@ -36,9 +36,10 @@ struct evpl_allocator {
     pthread_cond_t                      producer_cv;
     pthread_cond_t                      consumer_cv;
 
-    /* Diagnostic metrics.  Owned by the caller (chimera), registered
-     * via evpl_set_allocator_metrics().  Mutated inline under
-     * allocator->lock — no atomics needed.  All NULL until registered.
+    /* Diagnostic metrics, registered on libevpl's internal metrics
+     * registry by evpl_allocator_register_metrics() at create time and
+     * exposed via evpl_metrics_scrape().  Mutated inline under
+     * allocator->lock — no atomics needed.
      */
     struct prometheus_counter_instance *m_slabs_inline;
     struct prometheus_counter_instance *m_slabs_prealloc;

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -106,6 +106,12 @@ evpl_shared_init(struct evpl_global_config *config)
 
     evpl_shared->numa_config = evpl_numa_discover();
 
+    /* Registry for libevpl's own metrics.  Created before the allocator
+     * so the allocator can self-register its counters/gauges on it.
+     * Exposed to embedders via evpl_metrics_scrape().
+     */
+    evpl_shared->metrics = prometheus_metrics_create(NULL, NULL, 0);
+
     evpl_shared->allocator = evpl_allocator_create();
 
     evpl_protocol_init(evpl_shared, EVPL_DATAGRAM_SOCKET_UDP,
@@ -196,6 +202,12 @@ evpl_cleanup()
 
     evpl_allocator_destroy(evpl_shared->allocator);
 
+    /* Destroyed after the allocator so any teardown-time gauge updates
+     * still target live instances.  Cascades free of all counters,
+     * gauges, series and instances registered on it.
+     */
+    prometheus_metrics_destroy(evpl_shared->metrics);
+
     for (i = 0; i < EVPL_NUM_FRAMEWORK; ++i) {
         if (evpl_shared->framework_private[i]) {
             evpl_shared->framework[i]->cleanup(evpl_shared->framework_private[i]
@@ -239,6 +251,16 @@ __evpl_init(void)
 {
     pthread_once(&evpl_shared_once, evpl_init_once);
 } /* __evpl_init */
+
+SYMBOL_EXPORT int
+evpl_metrics_scrape(
+    char *buffer,
+    int   buffer_size)
+{
+    __evpl_init();
+
+    return prometheus_metrics_scrape(evpl_shared->metrics, buffer, buffer_size);
+} /* evpl_metrics_scrape */
 
 static inline struct evpl_global_config *
 evpl_get_config(void)

--- a/src/core/evpl_shared.h
+++ b/src/core/evpl_shared.h
@@ -19,6 +19,7 @@ struct evpl_shared {
     struct evpl_global_config  *config;
     struct evpl_numa_config    *numa_config;
     struct evpl_endpoint       *endpoints;
+    struct prometheus_metrics  *metrics;
     struct evpl_allocator      *allocator;
     struct evpl_framework      *framework[EVPL_NUM_FRAMEWORK];
     void                       *framework_private[EVPL_NUM_FRAMEWORK];


### PR DESCRIPTION
## Summary

libevpl collects diagnostic metrics (allocator slab/buffer counters and gauges) but provided no way for an embedder to read them. It never owned a Prometheus registry — instead it relied on the caller injecting metric instances via `evpl_set_allocator_metrics()`, an API that had no users.

This change makes libevpl's metrics self-contained and readable:

- **Internal registry.** `struct evpl_shared` now owns a `prometheus_metrics` registry, created before the allocator and destroyed after it.
- **Allocator self-registration.** The allocator registers its metrics (named `evpl_allocator_*`) on that registry in `evpl_allocator_create()`, *before* the prealloc threads start — so the instance pointers are always non-NULL (no race) and the full lifetime is counted from zero.
- **New public API:**
  ```c
  int evpl_metrics_scrape(char *buffer, int buffer_size);
  ```
  Serializes libevpl's metrics in Prometheus text exposition format (v0.0.4). Triggers init if needed, so it is safe to call before `evpl_init()`. Returns bytes written, or `-1` if the buffer is too small. Embedders append the result to their own metrics output (the `evpl_*` names are disjoint, so the concatenation is a valid single page).
- **Removed** the now-redundant `evpl_set_allocator_metrics()` and `struct evpl_allocator_metrics` (no callers).
- The core library now links `prometheus-c`, which it calls directly rather than only through header-inline helpers.
- Documented `evpl_metrics_scrape()` in the Core API reference (`docs/api/core.md`).

The RPC2 per-procedure latency histograms continue to use the existing caller-injected `metrics` field on `evpl_rpc2_program` and are unaffected.