### PR TITLE
block: per-device latency, request size and queue depth metrics

### DIFF
--- a/src/core/block.c
+++ b/src/core/block.c
@@ -3,10 +3,94 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <pthread.h>
+#include <time.h>
 
 #include "core/evpl_shared.h"
 #include "core/macros.h"
 #include "core/evpl.h"
+#include "core/timing.h"
+
+/* Completion-tracking record threaded through a block request so the
+ * core can measure latency and request size and maintain queue depth
+ * without the protocol's help.  Allocated from a per-queue freelist and
+ * touched only on the queue's own thread, so no locking is required.
+ */
+struct evpl_block_op {
+    struct timespec          start;
+    uint64_t                 size;
+    struct evpl_block_queue *queue;
+    evpl_block_callback_t    callback;
+    void                    *private_data;
+    struct evpl_block_op    *next;
+};
+
+static inline uint64_t
+evpl_block_iov_size(
+    const struct evpl_iovec *iov,
+    int                      niov)
+{
+    uint64_t total = 0;
+    int      i;
+
+    for (i = 0; i < niov; i++) {
+        total += evpl_iovec_length(&iov[i]);
+    }
+
+    return total;
+} /* evpl_block_iov_size */
+
+static inline struct evpl_block_op *
+evpl_block_op_get(struct evpl_block_queue *queue)
+{
+    struct evpl_block_op *op = queue->op_freelist;
+
+    if (op) {
+        queue->op_freelist = op->next;
+    } else {
+        op = evpl_zalloc(sizeof(*op));
+    }
+
+    return op;
+} /* evpl_block_op_get */
+
+static void
+evpl_block_complete(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct evpl_block_op    *op    = private_data;
+    struct evpl_block_queue *queue = op->queue;
+    evpl_block_callback_t    callback;
+    void                    *callback_private;
+    struct timespec          now;
+    int64_t                  elapsed;
+
+    evpl_get_hf_monotonic_time(evpl, &now);
+    elapsed = evpl_ts_interval(&now, &op->start);
+
+    /* prometheus_histogram_sample() bucketizes via clz, which is
+     * undefined at zero, so floor the latency at one nanosecond.
+     */
+    prometheus_histogram_sample(queue->m_latency, elapsed > 0 ? elapsed : 1);
+
+    if (op->size) {
+        prometheus_histogram_sample(queue->m_request_size, op->size);
+    }
+
+    prometheus_gauge_add(queue->m_queue_depth, -1);
+
+    /* Capture the user callback before recycling op: the callback may
+     * issue another request (and thus reuse this op) or close the queue.
+     */
+    callback         = op->callback;
+    callback_private = op->private_data;
+
+    op->next           = queue->op_freelist;
+    queue->op_freelist = op;
+
+    callback(evpl, status, callback_private);
+} /* evpl_block_complete */
 
 SYMBOL_EXPORT struct evpl_block_device *
 evpl_block_open_device(
@@ -35,12 +119,38 @@ evpl_block_open_device(
 
     blockdev->protocol = protocol;
 
+    /* Per-device metric series, labelled with the device URI and the
+     * protocol type so callers can aggregate across all devices or
+     * break out by device/type.
+     */
+    blockdev->m_latency = prometheus_histogram_create_series(
+        evpl_shared->block_latency,
+        (const char *[]) { "device", "type" },
+        (const char *[]) { uri, protocol->name }, 2);
+
+    blockdev->m_request_size = prometheus_histogram_create_series(
+        evpl_shared->block_request_size,
+        (const char *[]) { "device", "type" },
+        (const char *[]) { uri, protocol->name }, 2);
+
+    blockdev->m_queue_depth = prometheus_gauge_create_series(
+        evpl_shared->block_queue_depth,
+        (const char *[]) { "device", "type" },
+        (const char *[]) { uri, protocol->name }, 2);
+
     return blockdev;
 } /* evpl_block_open_device */
 
 SYMBOL_EXPORT void
 evpl_block_close_device(struct evpl_block_device *bdev)
 {
+    prometheus_histogram_destroy_series(evpl_shared->block_latency,
+                                        bdev->m_latency);
+    prometheus_histogram_destroy_series(evpl_shared->block_request_size,
+                                        bdev->m_request_size);
+    prometheus_gauge_destroy_series(evpl_shared->block_queue_depth,
+                                    bdev->m_queue_depth);
+
     bdev->close_device(bdev);
 } /* evpl_block_close_device */
 
@@ -67,7 +177,19 @@ evpl_block_open_queue(
 
     queue = blockdev->open_queue(evpl, blockdev);
 
-    queue->protocol = blockdev->protocol;
+    queue->protocol    = blockdev->protocol;
+    queue->device      = blockdev;
+    queue->op_freelist = NULL;
+
+    /* Each queue gets its own instance of the device's series so the
+     * I/O path mutates them lock-free; the scrape sums instances.
+     */
+    queue->m_latency = prometheus_histogram_series_create_instance(
+        blockdev->m_latency);
+    queue->m_request_size = prometheus_histogram_series_create_instance(
+        blockdev->m_request_size);
+    queue->m_queue_depth = prometheus_gauge_series_create_instance(
+        blockdev->m_queue_depth);
 
     return queue;
 } /* evpl_block_open_queue */
@@ -77,6 +199,21 @@ evpl_block_close_queue(
     struct evpl             *evpl,
     struct evpl_block_queue *queue)
 {
+    struct evpl_block_device *bdev = queue->device;
+    struct evpl_block_op     *op;
+
+    prometheus_histogram_series_destroy_instance(bdev->m_latency,
+                                                 queue->m_latency);
+    prometheus_histogram_series_destroy_instance(bdev->m_request_size,
+                                                 queue->m_request_size);
+    prometheus_gauge_series_destroy_instance(bdev->m_queue_depth,
+                                             queue->m_queue_depth);
+
+    while ((op = queue->op_freelist)) {
+        queue->op_freelist = op->next;
+        evpl_free(op);
+    }
+
     queue->close_queue(evpl, queue);
 } /* evpl_block_close_queue */
 
@@ -91,7 +228,17 @@ evpl_block_read(
     void ( *callback )(struct evpl *evpl, int status, void *private_data),
     void *private_data)
 {
-    queue->read(evpl, queue, iov, niov, offset, callback, private_data);
+    struct evpl_block_op *op = evpl_block_op_get(queue);
+
+    op->queue        = queue;
+    op->callback     = callback;
+    op->private_data = private_data;
+    op->size         = evpl_block_iov_size(iov, niov);
+
+    evpl_get_hf_monotonic_time(evpl, &op->start);
+    prometheus_gauge_add(queue->m_queue_depth, 1);
+
+    queue->read(evpl, queue, iov, niov, offset, evpl_block_complete, op);
 } /* evpl_block_read */
 
 SYMBOL_EXPORT void
@@ -105,7 +252,17 @@ evpl_block_write(
     void ( *callback )(struct evpl *evpl, int status, void *private_data),
     void *private_data)
 {
-    queue->write(evpl, queue, iov, niov, offset, sync, callback, private_data);
+    struct evpl_block_op *op = evpl_block_op_get(queue);
+
+    op->queue        = queue;
+    op->callback     = callback;
+    op->private_data = private_data;
+    op->size         = evpl_block_iov_size(iov, niov);
+
+    evpl_get_hf_monotonic_time(evpl, &op->start);
+    prometheus_gauge_add(queue->m_queue_depth, 1);
+
+    queue->write(evpl, queue, iov, niov, offset, sync, evpl_block_complete, op);
 } /* evpl_block_write */
 
 SYMBOL_EXPORT void
@@ -115,5 +272,15 @@ evpl_block_flush(
     void ( *callback )(struct evpl *evpl, int status, void *private_data),
     void *private_data)
 {
-    queue->flush(evpl, queue, callback, private_data);
+    struct evpl_block_op *op = evpl_block_op_get(queue);
+
+    op->queue        = queue;
+    op->callback     = callback;
+    op->private_data = private_data;
+    op->size         = 0;
+
+    evpl_get_hf_monotonic_time(evpl, &op->start);
+    prometheus_gauge_add(queue->m_queue_depth, 1);
+
+    queue->flush(evpl, queue, evpl_block_complete, op);
 } /* evpl_block_flush */

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -112,6 +112,23 @@ evpl_shared_init(struct evpl_global_config *config)
      */
     evpl_shared->metrics = prometheus_metrics_create(NULL, NULL, 0);
 
+    /* Block I/O metric definitions.  Per-device series (labelled by
+     * device and type) are created lazily when a device is opened; the
+     * histograms use base-2 buckets, so 32 buckets cover up to ~2.1s of
+     * latency and ~2GiB of request size.
+     */
+    evpl_shared->block_latency = prometheus_metrics_create_histogram_exponential(
+        evpl_shared->metrics, "evpl_block_latency_nanoseconds",
+        "Block I/O request latency in nanoseconds", 32);
+
+    evpl_shared->block_request_size = prometheus_metrics_create_histogram_exponential(
+        evpl_shared->metrics, "evpl_block_request_bytes",
+        "Block I/O request size in bytes", 32);
+
+    evpl_shared->block_queue_depth = prometheus_metrics_create_gauge(
+        evpl_shared->metrics, "evpl_block_queue_depth",
+        "Outstanding block I/O requests");
+
     evpl_shared->allocator = evpl_allocator_create();
 
     evpl_protocol_init(evpl_shared, EVPL_DATAGRAM_SOCKET_UDP,

--- a/src/core/evpl_shared.h
+++ b/src/core/evpl_shared.h
@@ -15,16 +15,19 @@
 struct evpl_allocator;
 
 struct evpl_shared {
-    pthread_mutex_t             lock;
-    struct evpl_global_config  *config;
-    struct evpl_numa_config    *numa_config;
-    struct evpl_endpoint       *endpoints;
-    struct prometheus_metrics  *metrics;
-    struct evpl_allocator      *allocator;
-    struct evpl_framework      *framework[EVPL_NUM_FRAMEWORK];
-    void                       *framework_private[EVPL_NUM_FRAMEWORK];
-    struct evpl_protocol       *protocol[EVPL_NUM_PROTO];
-    struct evpl_block_protocol *block_protocol[EVPL_NUM_BLOCK_PROTOCOL];
+    pthread_mutex_t              lock;
+    struct evpl_global_config   *config;
+    struct evpl_numa_config     *numa_config;
+    struct evpl_endpoint        *endpoints;
+    struct prometheus_metrics   *metrics;
+    struct prometheus_histogram *block_latency;
+    struct prometheus_histogram *block_request_size;
+    struct prometheus_gauge     *block_queue_depth;
+    struct evpl_allocator       *allocator;
+    struct evpl_framework       *framework[EVPL_NUM_FRAMEWORK];
+    void                        *framework_private[EVPL_NUM_FRAMEWORK];
+    struct evpl_protocol        *protocol[EVPL_NUM_PROTO];
+    struct evpl_block_protocol  *block_protocol[EVPL_NUM_BLOCK_PROTOCOL];
 };
 
 extern struct evpl_shared *evpl_shared;

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -9,6 +9,12 @@
 struct evpl_event;
 struct evpl_bind;
 struct evpl_shared;
+struct evpl_block_op;
+
+struct prometheus_histogram_series;
+struct prometheus_histogram_instance;
+struct prometheus_gauge_series;
+struct prometheus_gauge_instance;
 
 /*
  * Some sets of protocols share a common framework that requires
@@ -156,40 +162,63 @@ struct evpl_protocol {
 
 struct evpl_block_device {
     /* Private data owned by the protocol */
-    void                       *private_data;
+    void                               *private_data;
 
     /* Protocol that owns this device */
-    struct evpl_block_protocol *protocol;
+    struct evpl_block_protocol         *protocol;
 
     /* Size of the device in bytes, set by the protocol */
-    uint64_t                    size;
+    uint64_t                            size;
 
     /* maximum size of a single I/O request in bytes */
-    uint64_t                    max_request_size;
+    uint64_t                            max_request_size;
+
+    /* Per-device metric series, labelled by device URI and protocol
+     * type.  Each queue creates its own instance from these so the
+     * hot path is mutated lock-free; the scrape aggregates instances.
+     */
+    struct prometheus_histogram_series *m_latency;
+    struct prometheus_histogram_series *m_request_size;
+    struct prometheus_gauge_series     *m_queue_depth;
 
     /* Open a device queue */
-    struct evpl_block_queue   * (*open_queue)(
+    struct evpl_block_queue           * (*open_queue)(
         struct evpl              *evpl,
         struct evpl_block_device *blockdev);
 
-    void                        (*close_device)(
+    void                                (*close_device)(
         struct evpl_block_device *blockdev);
 };
 
 struct evpl_block_queue {
     /* Private data owned by the protocol */
-    void                       *private_data;
+    void                                 *private_data;
 
     /* Protocol that owns this queue */
-    struct evpl_block_protocol *protocol;
+    struct evpl_block_protocol           *protocol;
+
+    /* Device that owns this queue, retained so the per-queue metric
+     * instances can be released against its series at close.
+     */
+    struct evpl_block_device             *device;
+
+    /* Per-queue metric instances, mutated only on this queue's thread
+     * (lock-free).  Created from the device's series at open.
+     */
+    struct prometheus_histogram_instance *m_latency;
+    struct prometheus_histogram_instance *m_request_size;
+    struct prometheus_gauge_instance     *m_queue_depth;
+
+    /* Freelist of completion-tracking ops; queue-thread-local. */
+    struct evpl_block_op                 *op_freelist;
 
     /* Close a device queue */
-    void                        (*close_queue)(
+    void                                  (*close_queue)(
         struct evpl             *evpl,
         struct evpl_block_queue *queue);
 
     /* Read from a block queue */
-    void                        (*read)(
+    void                                  (*read)(
         struct evpl             *evpl,
         struct evpl_block_queue *queue,
         struct evpl_iovec       *iov,
@@ -199,7 +228,7 @@ struct evpl_block_queue {
         void                    *private_data);
 
     /* Write to a block queue */
-    void                        (*write)(
+    void                                  (*write)(
         struct evpl             *evpl,
         struct evpl_block_queue *queue,
         const struct evpl_iovec *iov,
@@ -210,7 +239,7 @@ struct evpl_block_queue {
         void                    *private_data);
 
     /* Flush a block device */
-    void                        (*flush)(
+    void                                  (*flush)(
         struct evpl             *evpl,
         struct evpl_block_queue *queue,
         evpl_block_callback_t    callback,


### PR DESCRIPTION
## Summary

Instrument the core block I/O path with Prometheus metrics so callers can observe block device behaviour — aggregated across all devices or broken out per device. Builds on the internal metrics registry from #61.

Three metrics, each labelled `{device=<uri>, type=<protocol>}`:

- **`evpl_block_latency_nanoseconds`** — histogram of request latency
- **`evpl_block_request_bytes`** — histogram of request size
- **`evpl_block_queue_depth`** — gauge of outstanding requests

## Design

- Metric **definitions** are created once on the shared registry; histograms use base-2 buckets (32 buckets cover ~2.1s latency / ~2GiB size).
- A per-**device** series is created in `evpl_block_open_device` (labels = URI + `protocol->name`).
- Each **queue** creates its own instance of the device's series in `evpl_block_open_queue`. Because a queue is single-threaded, the I/O path mutates its instances **without locking**; the scrape sums instances across a device's queues. A query-time `sum without(device)` gives the global view.
- `block.c` wraps `read`/`write`/`flush`: it records a start timestamp and request size, bumps the queue-depth gauge on dispatch, then samples latency + size and decrements the gauge on completion. Tracking records come from a **per-queue freelist** to keep the hot path allocation-free.
- Flushes carry no size, so they are counted in latency but excluded from the size histogram.
- Lifecycle: `close_queue` releases the queue's instances and drains the freelist before the protocol frees the queue; `close_device` destroys the device's series.

## Validation

- `libevpl/io_uring/basic` and `libevpl/libaio/basic` pass.
- Exercised live via a diskfs/io_uring daemon: the series appear with both labels, latency/size sample counts differ by exactly the number of flushes, and the queue-depth gauge returns to 0 when idle.