### PR TITLE
vfio: guard poll unpin against the NULL evpl setup path

### DIFF
--- a/src/core/vfio/vfio.c
+++ b/src/core/vfio/vfio.c
@@ -561,7 +561,11 @@ evpl_vfio_poll_queue(
             cb->fn(evpl, cqe->sc ? EIO : 0, cb->arg);
         }
 
-        if (queue->poll_mode) {
+        /* The admin queue is drained synchronously during device setup
+         * with a NULL evpl (and is never poll_mode), so only unpin when
+         * we have a real event loop that was pinned at submit time.
+         */
+        if (queue->poll_mode && evpl) {
             evpl_poll_unpin(evpl);
         }
 


### PR DESCRIPTION
## Summary

`evpl_vfio_poll_queue()` is called with a `NULL` evpl while the admin queue is drained synchronously during device setup (e.g. identify / queue creation). Its completion loop calls `evpl_poll_unpin(evpl)` whenever the queue is in poll mode, which dereferences `evpl`.

The admin queue is never `poll_mode`, so this is not reached in practice, but it is an unchecked NULL dereference — clang's static analyzer (`core.NullDereference`) flags the path. Guard the unpin so it only runs when there is a real event loop (which, by construction, is the only case where a submit pinned it).

Found via chimera's scan-build, which analyzes the libevpl tree.

## Validation

`scan-build` on `vfio.c` reports **No bugs found** with this change (it previously reported the null dereference at `evpl.h:246`).