### PR TITLE
iovec: release taken refs when alloc/reserve exceed max_iovecs

### DIFF
--- a/src/core/iovec.c
+++ b/src/core/iovec.c
@@ -45,6 +45,12 @@ evpl_iovec_reserve(
         }
 
         if (unlikely(niovs + 1 > max_iovecs)) {
+            /* Out of iovec slots with data still to place.  Release the
+             * refs already taken into r_iovec so we don't leak buffers
+             * on this error return; the current buffer stays retained
+             * for the next allocation.
+             */
+            evpl_iovecs_release(evpl, r_iovec, niovs);
             return -1;
         }
 
@@ -139,6 +145,12 @@ evpl_iovec_alloc(
         }
 
         if (unlikely(niovs + 1 > max_iovecs)) {
+            /* Out of iovec slots with data still to place.  Release the
+             * refs already taken into r_iovec so we don't leak buffers
+             * on this error return; the current buffer stays retained
+             * for the next allocation.
+             */
+            evpl_iovecs_release(evpl, r_iovec, niovs);
             return -1;
         }
 


### PR DESCRIPTION
## Summary

`evpl_iovec_alloc()` and `evpl_iovec_reserve()` take a buffer reference into each `r_iovec` entry as they place data across buffers. When the requested `length` cannot be covered within `max_iovecs`, they bail with `return -1` — but they did so **without releasing the references already taken** into `r_iovec[0..niovs-1]`, leaking those buffers.

This fix releases the populated iovecs (`evpl_iovecs_release`) before the error return. The current buffer (`*bufferp` / `evpl->current_buffer`) is left retained for the next allocation, as before — only the already-placed iovec refs are dropped.

The path is only reached when a single allocation needs more than `max_iovecs` buffers, so it is rarely hit in practice, but when it is, the leaked buffers surface later as `evpl_allocator_destroy: buffer ... has N leaked references`.

## Validation

Release build clean; `libevpl/core/*` tests pass. The change only affects the `max_iovecs`-exceeded error return; the success path is unchanged.