### PR TITLE
block: honor the sync flag in the io_uring and libaio backends

### DIFF
--- a/src/core/io_uring/io_uring_block.c
+++ b/src/core/io_uring/io_uring_block.c
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+#include <linux/fs.h>
 
 #include "core/io_uring/io_uring.h"
 #include "core/io_uring/io_uring_internal.h"
@@ -104,7 +105,10 @@ evpl_io_uring_write(
     struct evpl_io_uring_context *ctx = evpl_framework_private(evpl, EVPL_FRAMEWORK_IO_URING);
     struct io_uring_sqe          *sqe;
     struct evpl_io_uring_request *req;
-    int                           i, need_bounce = 0, flags = 0;
+    int                           i, need_bounce = 0;
+    /* Honor the caller's durability request: O_DIRECT alone does not flush the
+     * device's volatile write cache, so a sync write must carry RWF_DSYNC. */
+    int                           flags = sync ? RWF_DSYNC : 0;
     uint64_t                      bounce_offset;
 
     req = evpl_io_uring_request_alloc(ctx, EVPL_IO_URING_REQ_BLOCK);

--- a/src/core/libaio/libaio_block.c
+++ b/src/core/libaio/libaio_block.c
@@ -87,6 +87,9 @@ evpl_libaio_write(
     struct evpl_libaio_context *ctx = evpl_framework_private(evpl, EVPL_FRAMEWORK_LIBAIO);
     struct evpl_libaio_request *req;
     int                         i, need_bounce = 0;
+    /* Honor the caller's durability request: O_DIRECT alone does not flush the
+     * device's volatile write cache, so a sync write must carry RWF_DSYNC. */
+    int                         rwf = sync ? RWF_DSYNC : 0;
     uint64_t                    bounce_offset;
 
     req = evpl_libaio_request_alloc(ctx);
@@ -119,9 +122,9 @@ evpl_libaio_write(
         req->bounce_iov.iov_base = req->bounce;
         req->bounce_iov.iov_len  = req->length;
 
-        io_prep_pwritev(&req->iocb, dev->fd, &req->bounce_iov, 1, offset);
+        io_prep_pwritev2(&req->iocb, dev->fd, &req->bounce_iov, 1, offset, rwf);
     } else {
-        io_prep_pwritev(&req->iocb, dev->fd, req->iov, req->niov, offset);
+        io_prep_pwritev2(&req->iocb, dev->fd, req->iov, req->niov, offset, rwf);
     }
 
     io_set_eventfd(&req->iocb, ctx->eventfd);


### PR DESCRIPTION
## Summary

`evpl_block_write` takes a `sync` flag, but the **io_uring** and **libaio** backends ignored it. Both open the device `O_DIRECT` (which bypasses the page cache but does **not** flush the device's volatile write cache) and issued the write with no per-IO durability flag, so a caller requesting a synchronous write got no durability guarantee. Only the VFIO/NVMe backend honored `sync` (via the NVMe FUA bit).

## Fix

Pass `RWF_DSYNC` on the write when `sync` is set:
- **io_uring**: set it in the `io_uring_prep_writev2` rw_flags (was hardcoded `0`).
- **libaio**: switch `io_prep_pwritev` -> `io_prep_pwritev2` with the flag.

`sync == 0` is unchanged (flags `0`), so async writes are unaffected.

This was found while auditing the block backends for a chimera diskfs change that adds an `async` mode (submit without FUA) and otherwise relies on `sync` for crash safety.