### PR TITLE
libaio: handle partial io_submit instead of dropping iocbs

### DIFF
--- a/src/core/libaio/libaio.c
+++ b/src/core/libaio/libaio.c
@@ -23,15 +23,37 @@ evpl_libaio_flush_submit(
     struct evpl_libaio_context *ctx = private_data;
     int                         rc;
 
+    (void) evpl;
+
     if (ctx->num_pending == 0) {
         return;
     }
 
-    rc = io_submit(ctx->io_ctx, ctx->num_pending, ctx->pending_iocbs);
+    do {
+        rc = io_submit(ctx->io_ctx, ctx->num_pending, ctx->pending_iocbs);
+    } while (rc == -EINTR);
+
+    /* Ring saturated by in-flight requests: nothing accepted this round.
+     * Leave the iocbs queued; a completion frees ring slots and re-arms this
+     * flush (see evpl_libaio_complete), so the remainder goes out on a later
+     * event-loop iteration rather than spinning here. */
+    if (rc == -EAGAIN) {
+        rc = 0;
+    }
 
     evpl_libaio_abort_if(rc < 0, "io_submit failed: %d", rc);
 
-    ctx->num_pending = 0;
+    /* io_submit() accepts iocbs one at a time and may take fewer than
+     * requested (a short submit) under load.  Keep the unsubmitted tail for a
+     * later attempt rather than dropping it -- a dropped iocb never completes,
+     * so its callback never runs and the caller hangs forever. */
+    if (rc < ctx->num_pending) {
+        ctx->num_pending -= rc;
+        memmove(ctx->pending_iocbs, &ctx->pending_iocbs[rc],
+                ctx->num_pending * sizeof(ctx->pending_iocbs[0]));
+    } else {
+        ctx->num_pending = 0;
+    }
 } /* evpl_libaio_flush_submit */
 
 static void *
@@ -107,6 +129,13 @@ evpl_libaio_complete(
 
     if (n) {
         evpl_activity(evpl);
+
+        /* Reaping freed ring slots: resubmit any iocbs that hit backpressure
+        * on an earlier flush.  Gating the re-arm on n > 0 means we only retry
+        * after a completion actually made room, so this never busy-spins. */
+        if (ctx->num_pending) {
+            evpl_defer(evpl, &ctx->flush);
+        }
     }
 
     return n;


### PR DESCRIPTION
## Problem

`io_submit(2)` queues iocbs one at a time and returns the count it **actually accepted**, which can be fewer than requested (a short submit) or `-EAGAIN` once the kernel AIO ring (sized by `io_setup(libaio_max_pending)`, default 256) is saturated by in-flight requests.

`evpl_libaio_flush_submit()` only checked for `rc < 0` and then unconditionally reset `num_pending = 0`:

```c
rc = io_submit(ctx->io_ctx, ctx->num_pending, ctx->pending_iocbs);
evpl_libaio_abort_if(rc < 0, "io_submit failed: %d", rc);
ctx->num_pending = 0;
```

On a **short submit** (`0 < rc < num_pending`) the iocbs past `rc` were silently discarded — never issued to the kernel, so their completions never fired, their callbacks never ran, and any caller waiting on them hung forever. A **fully saturated** ring (`-EAGAIN`, nothing submitted) additionally aborted the process.

## Symptom

Intermittent hang under concurrent load — `fsstress` over NFSv4.1 on the chimera `diskfs` **aio** backend. A write op's block I/O was dropped on a short submit, so the NFS reply was never sent and the client blocked indefinitely in `rpc_wait`. Load-dependent (the ring only saturates under a concurrency burst) and libaio-specific, which is why the same test passed in seconds on sibling runs.

## Fix

Loop over `io_submit`, advancing past the accepted iocbs. On a short submit or `-EAGAIN`, retain the unsubmitted remainder (shifted to the front of `pending_iocbs`) and re-arm the flush deferral so it retries once in-flight completions free ring slots. Retry on `-EINTR`.