### PR TITLE
cmake: include liburing as a system header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,12 @@ find_path(URING_INCLUDE_DIR NAMES liburing/io_uring.h)
 if (URING_LIB AND URING_INCLUDE_DIR)
     message(STATUS "io_uring library ${URING_LIB}")
     message(STATUS "io_uring include ${URING_INCLUDE_DIR}")
-    include_directories(${URING_INCLUDE_DIR})
+    # Treat liburing as a system include: its headers define static-inline
+    # helpers (e.g. io_uring_prep_uring_cmd) that the clang static analyzer
+    # would otherwise analyze as user code and flag with false positives
+    # (a null-deref of an sqe the caller already guards).  SYSTEM also keeps
+    # any third-party-header warnings out of our -Werror build.
+    include_directories(SYSTEM ${URING_INCLUDE_DIR})
     add_definitions(-DHAVE_IO_URING)
     set(HAVE_IO_URING 1)
 


### PR DESCRIPTION
## Problem

When chimera runs `scan-build` over its tree (which includes libevpl), the clang static analyzer reports a false-positive null-pointer dereference inside **`/usr/include/liburing.h`** (`__io_uring_prep_uring_cmd`, `sqe->opcode = ...`), reached only via `evpl_io_uring_nvme_rw` in `io_uring_nvme_block.c`.

The NVMe code is correct — it guards the sqe:

```c
sqe = io_uring_get_sqe(&ctx->ring);
evpl_io_uring_abort_if(!sqe, "io_uring_get_sqe");   /* evpl_abort is noreturn */
...
io_uring_prep_uring_cmd(sqe, NVME_URING_CMD_IO_VEC, dev->fd);
```

The analyzer normally suppresses findings inside system headers. It emits one here because liburing is added with a plain `-I` (`include_directories(${URING_INCLUDE_DIR})`), so its headers are treated as **user code** — and the analyzer then analyzes liburing's `static inline` helpers as standalone entry points with a nullable `sqe` parameter, deref'ing it.

## Fix

Add the liburing include directory as **SYSTEM** (`-isystem`):

```cmake
include_directories(SYSTEM ${URING_INCLUDE_DIR})
```

The analyzer then treats liburing as a third-party header and suppresses reports inside it (the standard remedy for SA false positives in vendored/system headers). It also keeps any liburing header warnings out of our `-Werror` build. No functional change.

Verified configure + build with the NVMe backend still detected and compiled.