### PR TITLE
rpc2: expose request xid in encoding

### DIFF
--- a/include/evpl/evpl_rpc2_program.h
+++ b/include/evpl/evpl_rpc2_program.h
@@ -76,6 +76,7 @@ struct evpl_rpc2_encoding {
     struct xdr_dbuf             *dbuf;        /* Dynamic buffer for allocations */
     struct evpl_rpc2_rdma_chunk *read_chunk;  /* RDMA read chunk (for writes) */
     struct evpl_rpc2_rdma_chunk *write_chunk; /* RDMA write chunk (for replies) */
+    uint32_t                     xid;         /* RPC transaction id for this request */
     /* Optional reply-capture hook -- see evpl_rpc2_reply_capture_cb_t.
      * NULL means "do not capture". */
     evpl_rpc2_reply_capture_cb_t reply_capture_cb;

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -1056,11 +1056,12 @@ evpl_rpc2_recv_msg(
             request->m_inflight = thread->m_inflight[EVPL_RPC2_ROLE_SERVER];
             prometheus_gauge_add(request->m_inflight, 1);
 
-            request->conn      = rpc2_conn;
-            request->bind      = bind;
-            request->xid       = rpc_msg.xid;
-            request->proc      = rpc_msg.body.cbody.proc;
-            request->timestamp = now;
+            request->conn         = rpc2_conn;
+            request->bind         = bind;
+            request->xid          = rpc_msg.xid;
+            request->encoding.xid = request->xid;
+            request->proc         = rpc_msg.body.cbody.proc;
+            request->timestamp    = now;
 
             /* Parse credentials - authsys data is in msg->dbuf which persists */
             flavor = rpc_msg.body.cbody.cred.flavor;


### PR DESCRIPTION
Expose the server-side RPC transaction ID through `evpl_rpc2_encoding`.

This lets upper-layer protocol code key duplicate request caches without reaching into libevpl internals. The field is populated when a CALL is received before dispatching to the generated handler.

Validation:
- `cmake --build build --target chimera`
- Chimera v4.0 DRC prototype using this field passes the pynfs replay/sequence replay slice.
