### PR TITLE
block: return NULL when a block protocol is not registered

### DIFF
--- a/src/core/block.c
+++ b/src/core/block.c
@@ -110,6 +110,13 @@ evpl_block_open_device(
 
     protocol = evpl_shared->block_protocol[protocol_id];
 
+    if (!protocol) {
+        /* In-range id but the backend was not registered (e.g. gated out at
+         * build time, such as the NVMe uring_cmd backend on older liburing).
+         * Report failure rather than dereferencing a NULL protocol. */
+        return NULL;
+    }
+
     evpl_attach_framework_shared(protocol->framework->id);
 
     protocol_private_data = evpl_shared->framework_private[protocol->framework->


### PR DESCRIPTION
## Problem

`evpl_block_open_device` checks the protocol id against the array bound but then dereferences the slot without checking it was registered:

```c
if (protocol_id >= EVPL_NUM_BLOCK_PROTOCOL) {
    return NULL;
}
protocol = evpl_shared->block_protocol[protocol_id];
evpl_attach_framework_shared(protocol->framework->id);   /* protocol may be NULL */
```

A backend that is gated out at build time leaves its `block_protocol[]` slot NULL. Since #69, the NVMe uring_cmd backend is gated off on older-liburing toolchains, so `block_protocol[EVPL_BLOCK_PROTOCOL_IO_URING_NVME]` is NULL there. Opening that protocol then SEGVs in `evpl_attach_framework_shared` (null deref, address 0x10) instead of failing cleanly.

Surfaced by `io_uring/nvme_open_fail` on chimera CI images where the NVMe backend is gated off (e.g. ubuntu24, rocky10).

## Fix

Return NULL when the requested protocol's slot is unregistered — symmetric with the existing out-of-range check.