### PR TITLE
http: free in-flight requests on connection disconnect

### DIFF
--- a/src/http/http.c
+++ b/src/http/http.c
@@ -685,8 +685,29 @@ evpl_http_event(
         case EVPL_NOTIFY_CONNECTED:
             break;
         case EVPL_NOTIFY_DISCONNECTED:
+        {
+            struct evpl_http_request *request, *tmp;
+
+            /* Release any request still in flight on this connection: a
+             * partially-parsed request (current_request, e.g. one allocated on
+             * a final read that returned EOF) and any received requests whose
+             * response has not yet completed (pending_requests). Otherwise
+             * tearing down the connection leaks them. */
+            if (http_conn->current_request) {
+                evpl_http_request_free(http_conn->agent,
+                                       http_conn->current_request);
+                http_conn->current_request = NULL;
+            }
+
+            DL_FOREACH_SAFE(http_conn->pending_requests, request, tmp)
+            {
+                DL_DELETE(http_conn->pending_requests, request);
+                evpl_http_request_free(http_conn->agent, request);
+            }
+
             free(http_conn);
-            break;
+        }
+        break;
         case EVPL_NOTIFY_RECV_DATA:
             if (http_conn->is_server) {
                 evpl_http_server_handle_data(http_conn);


### PR DESCRIPTION
## Problem

`evpl_http_event`'s `EVPL_NOTIFY_DISCONNECTED` case frees the `evpl_http_conn` but not the request objects still attached to it:

- `conn->current_request` — a request being parsed, e.g. one allocated speculatively on a final read that returns EOF on an otherwise-idle keep-alive connection, and
- anything left on `conn->pending_requests` — requests fully received whose response had not yet completed.

Tearing the connection down in that state leaks the `evpl_http_request` struct and its `recv_ring`/`send_ring` iovec buffers.

## Fix

Before `free(http_conn)`, return `current_request` and drain `pending_requests` through `evpl_http_request_free()` (which reclaims them to the agent free list, freed at agent destroy).

## How it surfaced

The chimera REST server is the first HTTP server consumer exercised under an AddressSanitizer test run. Hitting any endpoint and then letting the (idle, keep-alive) connection be torn down at shutdown leaked exactly one request per connection. With this change LSan reports clean.

A single request/response followed by an immediate hard teardown did not leak; the leak needs the connection to reach the EOF-read / idle-keepalive teardown path, which is why it went unnoticed until now.