### PR TITLE
http: drain disconnect request list without DL_DELETE

### DIFF
--- a/src/http/http.c
+++ b/src/http/http.c
@@ -686,7 +686,7 @@ evpl_http_event(
             break;
         case EVPL_NOTIFY_DISCONNECTED:
         {
-            struct evpl_http_request *request, *tmp;
+            struct evpl_http_request *request, *next;
 
             /* Release any request still in flight on this connection: a
              * partially-parsed request (current_request, e.g. one allocated on
@@ -699,10 +699,16 @@ evpl_http_event(
                 http_conn->current_request = NULL;
             }
 
-            DL_FOREACH_SAFE(http_conn->pending_requests, request, tmp)
-            {
-                DL_DELETE(http_conn->pending_requests, request);
+            /* Walk and free the whole list directly rather than DL_DELETE per
+             * element: there is no need to keep the list consistent while
+             * draining it, and it avoids DL_DELETE's (head)->prev access that
+             * the static analyzer cannot prove is non-NULL. */
+            request                    = http_conn->pending_requests;
+            http_conn->pending_requests = NULL;
+            while (request) {
+                next = request->next;
                 evpl_http_request_free(http_conn->agent, request);
+                request = next;
             }
 
             free(http_conn);

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -703,7 +703,7 @@ evpl_http_event(
              * element: there is no need to keep the list consistent while
              * draining it, and it avoids DL_DELETE's (head)->prev access that
              * the static analyzer cannot prove is non-NULL. */
-            request                    = http_conn->pending_requests;
+            request                     = http_conn->pending_requests;
             http_conn->pending_requests = NULL;
             while (request) {
                 next = request->next;


### PR DESCRIPTION
Follow-up to #74. The per-element `DL_DELETE` in the `EVPL_NOTIFY_DISCONNECTED` drain trips the clang static analyzer in Release/NDEBUG builds:

```
src/http/http.c:704:17: warning: Access to field 'prev' results in a dereference of a null
pointer (loaded from field 'pending_requests') [core.NullDereference]
```

`DL_DELETE` accesses `(head)->prev` while relinking, and the analyzer can't prove `pending_requests` stays non-NULL across it (the NDEBUG build strips the macro's `head != NULL` assert). It's a false positive, but it fails the chimera `Static Analysis ... Release` CI gate.

Since we're freeing the entire list, there's no need to keep it consistent per-delete. Walk it directly — save each `->next` before freeing, null the head once. Functionally identical; the flagged access is gone.

Verified with `clang --analyze` (core.NullDereference, NDEBUG flags): old code reports the warning, new code reports none.