### PR TITLE
rpc2: grant RDMA credits by echoing client request

### DIFF
--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -209,6 +209,7 @@ evpl_rpc2_request_alloc(struct evpl_rpc2_thread *thread)
 
     request->thread                      = thread;
     request->m_inflight                  = NULL;
+    request->rdma_credits                = 1;
     request->pending_reads               = 0;
     request->read_chunk.niov             = 0;
     request->read_chunk.length           = 0;
@@ -1084,6 +1085,15 @@ evpl_rpc2_recv_msg(
             } /* switch */
 
             if (rdma) {
+                /* Grant the requester exactly the credit it asked for.  Per
+                 * RFC 8166 this is the max number of RPCs the client may keep
+                 * outstanding on this connection; previously we shipped an
+                 * uninitialized request->rdma_credits (always 0), which the
+                 * Linux client floored to 1 -- serializing each connection.
+                 * NOTE: experimental echo with no server-side ceiling; a
+                 * proper grant should clamp to receive capacity. */
+                request->rdma_credits = rdma_msg.rdma_credit ? rdma_msg.rdma_credit : 1;
+
                 if (rdma_msg.rdma_body.proc == RDMA_MSG) {
 
                     read_list = rdma_msg.rdma_body.rdma_msg.rdma_reads;


### PR DESCRIPTION
## Summary

The RPC-over-RDMA reply shipped `request->rdma_credits`, which was **never initialized** in `evpl_rpc2_request_alloc` and **never set** from the inbound CALL — so every reply advertised a credit of `0`.

Per RFC 8166 the `rdma_credit` field in a reply is the responder's grant: the maximum number of RPCs the requester may keep outstanding on that connection. The Linux NFS/RDMA client floors a `0` grant to `1`, so each connection was capped at a **single outstanding RPC**, serializing all I/O.

Observed against an NFSv3/RDMA `nconnect=16` random-read workload: READ `backlog wait` 1.5 ms vs RTT ~84 µs, ~0.67 RPCs in flight per connection, and throughput pinned at ~158K IOPS. With this change throughput rises to ~560K (the next ceiling is elsewhere).

## Change

- Initialize `request->rdma_credits = 1` in `evpl_rpc2_request_alloc` so no path ships an uninitialized value.
- On the inbound RDMA CALL, copy the client's requested credit into the request, so the reply echoes it back.

## Caveat / follow-up

This is an **experimental echo**: it grants exactly what the client asks for, with no server-side ceiling tied to actual receive capacity. A proper grant should clamp the echoed value to the connection's receive-buffer/SRQ capacity. Filed as a first step to unblock the per-connection serialization; the credit-vs-capacity accounting is left as a follow-up.
