### PR TITLE
Use the stopwatch TSC timer for internal timekeeping and latency metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,9 @@ include_directories(3rdparty)
 include_directories(include)
 
 include_directories(ext/prometheus-c)
+# stopwatch.h is vendored by the prometheus-c submodule; use that single copy
+# so libevpl and prometheus-c always share the same version.
+include_directories(ext/prometheus-c/ext/stopwatch)
 
 add_subdirectory(ext)
 add_subdirectory(src)

--- a/include/evpl/evpl_timer.h
+++ b/include/evpl/evpl_timer.h
@@ -19,8 +19,8 @@ typedef void (*evpl_timer_callback_t)(
 
 struct evpl_timer {
     evpl_timer_callback_t callback;
-    uint64_t              interval;
-    struct timespec       deadline;
+    uint64_t              interval;       /* microseconds */
+    uint64_t              deadline;       /* stopwatch ticks (see evpl_now_ticks) */
     int                   oneshot;
 };
 

--- a/src/core/block.c
+++ b/src/core/block.c
@@ -16,12 +16,12 @@
  * touched only on the queue's own thread, so no locking is required.
  */
 struct evpl_block_op {
-    struct timespec          start;
-    uint64_t                 size;
-    struct evpl_block_queue *queue;
-    evpl_block_callback_t    callback;
-    void                    *private_data;
-    struct evpl_block_op    *next;
+    struct prometheus_stopwatch start;
+    uint64_t                    size;
+    struct evpl_block_queue    *queue;
+    evpl_block_callback_t       callback;
+    void                       *private_data;
+    struct evpl_block_op       *next;
 };
 
 static inline uint64_t
@@ -63,16 +63,8 @@ evpl_block_complete(
     struct evpl_block_queue *queue = op->queue;
     evpl_block_callback_t    callback;
     void                    *callback_private;
-    struct timespec          now;
-    int64_t                  elapsed;
 
-    evpl_get_hf_monotonic_time(evpl, &now);
-    elapsed = evpl_ts_interval(&now, &op->start);
-
-    /* prometheus_histogram_sample() bucketizes via clz, which is
-     * undefined at zero, so floor the latency at one nanosecond.
-     */
-    prometheus_histogram_sample(queue->m_latency, elapsed > 0 ? elapsed : 1);
+    prometheus_time_histogram_sample(queue->m_latency, &op->start);
 
     if (op->size) {
         prometheus_histogram_sample(queue->m_request_size, op->size);
@@ -246,7 +238,7 @@ evpl_block_read(
     op->private_data = private_data;
     op->size         = evpl_block_iov_size(iov, niov);
 
-    evpl_get_hf_monotonic_time(evpl, &op->start);
+    prometheus_stopwatch_start(&op->start);
     prometheus_gauge_add(queue->m_queue_depth, 1);
 
     queue->read(evpl, queue, iov, niov, offset, evpl_block_complete, op);
@@ -270,7 +262,7 @@ evpl_block_write(
     op->private_data = private_data;
     op->size         = evpl_block_iov_size(iov, niov);
 
-    evpl_get_hf_monotonic_time(evpl, &op->start);
+    prometheus_stopwatch_start(&op->start);
     prometheus_gauge_add(queue->m_queue_depth, 1);
 
     queue->write(evpl, queue, iov, niov, offset, sync, evpl_block_complete, op);
@@ -290,7 +282,7 @@ evpl_block_flush(
     op->private_data = private_data;
     op->size         = 0;
 
-    evpl_get_hf_monotonic_time(evpl, &op->start);
+    prometheus_stopwatch_start(&op->start);
     prometheus_gauge_add(queue->m_queue_depth, 1);
 
     queue->flush(evpl, queue, evpl_block_complete, op);

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -112,14 +112,21 @@ evpl_shared_init(struct evpl_global_config *config)
      */
     evpl_shared->metrics = prometheus_metrics_create(NULL, NULL, 0);
 
+    /* Initialize the process-wide TSC clock and anchor it to wall-clock
+     * monotonic time. Captured adjacently so the anchor is tight.
+     */
+    stopwatch_context_init(&evpl_shared->hf_stopwatch);
+    clock_gettime(CLOCK_MONOTONIC, &evpl_shared->hf_base_time);
+    stopwatch_start(&evpl_shared->hf_stopwatch, &evpl_shared->hf_base_sw);
+
     /* Block I/O metric definitions.  Per-device series (labelled by
      * device and type) are created lazily when a device is opened; the
      * histograms use base-2 buckets, so 32 buckets cover up to ~2.1s of
      * latency and ~2GiB of request size.
      */
-    evpl_shared->block_latency = prometheus_metrics_create_histogram_exponential(
+    evpl_shared->block_latency = prometheus_metrics_create_histogram_time(
         evpl_shared->metrics, "evpl_block_latency_nanoseconds",
-        "Block I/O request latency in nanoseconds", 32);
+        "Block I/O request latency in nanoseconds", 34);
 
     evpl_shared->block_request_size = prometheus_metrics_create_histogram_exponential(
         evpl_shared->metrics, "evpl_block_request_bytes",
@@ -404,6 +411,10 @@ evpl_create(struct evpl_thread_config *config)
         evpl->config = evpl_shared->config->thread_default;
     }
 
+    /* Precompute the poll-mode spin grace period in ticks so the event loop
+     * compares it without converting on every iteration. */
+    evpl->spin_ticks = evpl_ns_to_ticks(evpl->config.spin_ns);
+
     evpl_core_init(&evpl->core, 64);
 
     evpl->running = 1;
@@ -432,7 +443,7 @@ evpl_continue(struct evpl *evpl)
     int                   msecs = evpl->config.wait_ms;
     uint64_t              elapsed;
     int64_t               remain;
-    struct timespec       now;
+    uint64_t              now_ticks;
 
     if (evpl->poll_mode && evpl->poll_iterations < evpl->config.poll_iterations) {
 
@@ -445,17 +456,19 @@ evpl_continue(struct evpl *evpl)
 
     } else {
 
-        evpl_get_hf_monotonic_time(evpl, &now);
+        now_ticks = evpl_now_ticks();
 
         if (evpl->num_timers) {
 
             do {
                 timer = evpl->timers[0];
 
-                remain = evpl_ts_interval(&timer->deadline, &now);
+                remain = (int64_t) (timer->deadline - now_ticks);
 
                 if (remain > 0) {
-                    remain /= 1000000;
+                    /* Timer not yet due; convert the remaining ticks to the
+                     * millisecond wait only here, off the busy path. */
+                    remain = (int64_t) (evpl_ticks_to_ns((uint64_t) remain) / 1000000);
 
                     if (remain < msecs || msecs == -1) {
                         msecs = remain;
@@ -480,18 +493,18 @@ evpl_continue(struct evpl *evpl)
         if (evpl->config.poll_mode && evpl->num_poll) {
 
             if (evpl->activity != evpl->last_activity) {
-                evpl->last_activity    = evpl->activity;
-                evpl->last_activity_ts = now;
-                elapsed                = 0;
+                evpl->last_activity       = evpl->activity;
+                evpl->last_activity_ticks = now_ticks;
+                elapsed                   = 0;
             } else {
-                elapsed = evpl_ts_interval(&now, &evpl->last_activity_ts);
+                elapsed = now_ticks - evpl->last_activity_ticks;
             }
         } else {
             elapsed = 0;
         }
 
         if (!evpl->force_poll_mode && !evpl->poll_pin_count &&
-            elapsed > evpl->config.spin_ns) {
+            elapsed > evpl->spin_ticks) {
             if (evpl->poll_mode) {
                 for (i = 0; i < evpl->num_poll; ++i) {
                     poll = &evpl->poll[i];
@@ -591,59 +604,26 @@ evpl_continue(struct evpl *evpl)
 
 } /* evpl_continue */
 
-#define EVPL_TSC_SHIFT        32u
-#define EVPL_TSC_CALIBRATE_NS 100000000ULL     /* 100 ms */
-
 SYMBOL_EXPORT void
 evpl_get_hf_monotonic_time(
     struct evpl     *evpl,
     struct timespec *ts)
 {
-#ifdef __x86_64__
+    (void) evpl;
 
-    if (evpl_shared->config->hf_time_mode > 0) {
-        uint64_t tsc;
+    /* Back the high-frequency clock with the shared stopwatch: absolute
+     * monotonic time = wall-clock anchor + elapsed ticks since the base
+     * stopwatch was started at init. Falls back to clock_gettime when the
+     * stopwatch could not use the TSC or hf_time_mode is disabled.
+     */
+    if (evpl_shared->config->hf_time_mode > 0 &&
+        evpl_shared->hf_stopwatch.use_tsc) {
+        uint64_t delta_ns = stopwatch_elapsed_ns(&evpl_shared->hf_stopwatch,
+                                                 &evpl_shared->hf_base_sw);
 
-        tsc = __rdtsc();
+        uint64_t nsec = evpl_shared->hf_base_time.tv_nsec + (delta_ns % NS_PER_S);
 
-        if (unlikely(evpl->hf_tsc_start.tv_sec == 0)) {
-            /* We need to calibrate TSC rate first */
-            clock_gettime(CLOCK_MONOTONIC, &evpl->hf_tsc_start);
-            evpl->hf_tsc_value = tsc;
-
-            evpl->hf_tsc_mult = 0;
-
-            *ts = evpl->hf_tsc_start;
-            return;
-        }
-
-        /* Calibrate once we have a long-enough baseline (≈100 ms). */
-        if (unlikely(evpl->hf_tsc_mult == 0)) {
-            uint64_t elapsed_ns, tsc_delta;
-
-            clock_gettime(CLOCK_MONOTONIC, ts);
-            elapsed_ns = evpl_ts_interval(ts, &evpl->hf_tsc_start);
-
-            if (elapsed_ns > EVPL_TSC_CALIBRATE_NS) {
-                tsc_delta = tsc - evpl->hf_tsc_value;
-
-                /* mult = round((elapsed_ns << SHIFT) / tsc_delta) */
-                __uint128_t num  = ((__uint128_t) elapsed_ns) << EVPL_TSC_SHIFT;
-                uint64_t    mult = (uint64_t) ((num + (tsc_delta / 2)) / tsc_delta);
-
-                evpl->hf_tsc_mult = mult;
-            }
-
-            return;
-        }
-
-        uint64_t    cycles   = tsc - evpl->hf_tsc_value;
-        __uint128_t prod     = (__uint128_t) cycles * (__uint128_t) evpl->hf_tsc_mult;
-        uint64_t    delta_ns = (uint64_t) (prod >> EVPL_TSC_SHIFT);
-
-        uint64_t    nsec = evpl->hf_tsc_start.tv_nsec + (delta_ns % NS_PER_S);
-
-        ts->tv_sec = evpl->hf_tsc_start.tv_sec + (delta_ns / NS_PER_S);
+        ts->tv_sec = evpl_shared->hf_base_time.tv_sec + (delta_ns / NS_PER_S);
 
         if (nsec >= NS_PER_S) {
             ts->tv_sec++;
@@ -654,12 +634,6 @@ evpl_get_hf_monotonic_time(
     } else {
         clock_gettime(CLOCK_MONOTONIC, ts);
     }
-
-#else  /* __x86_64__ */
-
-    clock_gettime(CLOCK_MONOTONIC, ts);
-
-#endif /* __x86_64__ */
 } /* evpl_get_hf_monotonic_time */
 
 

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -92,14 +92,10 @@ typedef void (*evpl_accept_callback_t)(
 struct evpl {
     struct evpl_core              core; /* must be first */
 
-
-    uint64_t                      hf_tsc_value;
-    uint64_t                      hf_tsc_mult;
-    struct timespec               hf_tsc_start;
-
     uint64_t                      poll_iters;
 
-    struct timespec               last_activity_ts;
+    uint64_t                      last_activity_ticks;
+    uint64_t                      spin_ticks;
     uint64_t                      activity;
     uint64_t                      last_activity;
     uint64_t                      poll_iterations;

--- a/src/core/evpl_shared.h
+++ b/src/core/evpl_shared.h
@@ -11,6 +11,7 @@
 #include "evpl/evpl.h"
 #include "protocol.h"
 #include "allocator.h"
+#include "stopwatch.h"
 
 struct evpl_allocator;
 
@@ -19,6 +20,16 @@ struct evpl_shared {
     struct evpl_global_config   *config;
     struct evpl_numa_config     *numa_config;
     struct evpl_endpoint        *endpoints;
+
+    /* Process-wide TSC clock backing evpl_get_hf_monotonic_time(). The base
+     * stopwatch + CLOCK_MONOTONIC anchor are captured once at init; absolute
+     * monotonic time is anchor + elapsed-ticks-since-base. Read-only after
+     * init, so the time path takes no locks.
+     */
+    struct stopwatch_context     hf_stopwatch;
+    struct stopwatch             hf_base_sw;
+    struct timespec              hf_base_time;
+
     struct prometheus_metrics   *metrics;
     struct prometheus_histogram *block_latency;
     struct prometheus_histogram *block_request_size;
@@ -32,6 +43,30 @@ struct evpl_shared {
 };
 
 extern struct evpl_shared *evpl_shared;
+
+/* Monotonic time in raw stopwatch ticks since init (TSC cycles where the
+ * stopwatch could use the TSC, otherwise nanoseconds). Cheap and lock-free:
+ * a single unfenced rdtsc and subtract on the TSC path. This is the unit the
+ * event loop keeps deadlines and grace periods in so the hot path never calls
+ * clock_gettime or converts to nanoseconds.
+ */
+static inline uint64_t
+evpl_now_ticks(void)
+{
+    return stopwatch_read_ticks(&evpl_shared->hf_stopwatch, &evpl_shared->hf_base_sw);
+} /* evpl_now_ticks */
+
+static inline uint64_t
+evpl_ns_to_ticks(uint64_t ns)
+{
+    return stopwatch_ns_to_ticks(&evpl_shared->hf_stopwatch, ns);
+} /* evpl_ns_to_ticks */
+
+static inline uint64_t
+evpl_ticks_to_ns(uint64_t ticks)
+{
+    return stopwatch_ticks_to_ns(&evpl_shared->hf_stopwatch, ticks);
+} /* evpl_ticks_to_ns */
 
 struct prometheus_gauge_series * evpl_rpc2_queue_depth_create_series(
     const char *role,

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -5,6 +5,7 @@
 #include "core/evpl.h"
 #include "core/timer.h"
 #include "core/macros.h"
+#include "core/evpl_shared.h"
 
 #include "core/timing.h"
 
@@ -18,7 +19,7 @@ evpl_timer_heap_up(
     while (i > 0) {
         int parent = (i - 1) / 2;
 
-        if (evpl_ts_compare(&evpl->timers[parent]->deadline, &evpl->timers[i]->deadline) < 0) {
+        if (evpl->timers[parent]->deadline < evpl->timers[i]->deadline) {
             break;
         }
 
@@ -48,12 +49,12 @@ evpl_timer_heap_down(
 
         child = 2 * i + 2;
         if (child < evpl->num_timers &&
-            evpl_ts_compare(&evpl->timers[child]->deadline, &evpl->timers[min_child]->deadline) < 0) {
+            evpl->timers[child]->deadline < evpl->timers[min_child]->deadline) {
             min_child = child;
         }
 
         if (min_child == -1 ||
-            evpl_ts_compare(&evpl->timers[i]->deadline, &evpl->timers[min_child]->deadline) < 0) {
+            evpl->timers[i]->deadline < evpl->timers[min_child]->deadline) {
             break;
         }
 
@@ -89,9 +90,8 @@ evpl_timer_insert(
 {
     int i;
 
-    clock_gettime(CLOCK_MONOTONIC, &timer->deadline);
-    timer->deadline.tv_sec  += timer->interval / 1000000;
-    timer->deadline.tv_nsec += (timer->interval % 1000000) * 1000;
+    /* interval is in microseconds; arm the deadline in stopwatch ticks. */
+    timer->deadline = evpl_now_ticks() + evpl_ns_to_ticks(timer->interval * 1000);
 
     evpl->timers[evpl->num_timers] = timer;
 

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -77,7 +77,7 @@ struct evpl_rpc2_request {
     struct evpl_rpc2_conn                *conn;
     struct evpl_rpc2_thread              *thread;
     struct evpl_rpc2_program             *program;
-    struct timespec                       timestamp;
+    struct prometheus_stopwatch           timestamp;
     struct prometheus_histogram_instance *metric;
     struct prometheus_gauge_instance     *m_inflight;
     void                                 *callback;
@@ -572,8 +572,6 @@ evpl_rpc2_send_reply(
     struct evpl_iovec            *segment_iov, *reply_segment_iov;
     struct evpl_rpc2_iovec_cursor write_cursor;
     int                           segment_niov;
-    struct timespec               now;
-    uint64_t                      elapsed;
     int                           i, reduce = 0, rdma = request->conn->rdma;
     struct evpl_iovec            *final_reply_iov;
     int                           final_reply_niov, final_reply_length;
@@ -721,12 +719,8 @@ evpl_rpc2_send_reply(
         memcpy(msg_iov[0].data, &hdr, sizeof(hdr));
     }
 
-    evpl_get_hf_monotonic_time(evpl, &now);
-
-    elapsed = evpl_ts_interval(&now, &request->timestamp);
-
     if (request->metric) {
-        prometheus_histogram_sample(request->metric, elapsed);
+        prometheus_time_histogram_sample(request->metric, &request->timestamp);
     }
 
     if (reduce) {
@@ -1012,7 +1006,6 @@ evpl_rpc2_recv_msg(
     struct xdr_write_list           *write_list;
     struct evpl_iovec               *segment_iov;
     int                              segment_offset;
-    struct timespec                  now;
     auth_flavor                      flavor;
     struct authsys_parms            *authsys = NULL;
 
@@ -1020,8 +1013,6 @@ evpl_rpc2_recv_msg(
     msg = evpl_rpc2_msg_alloc(thread);
 
     rdma = rpc2_conn->rdma;
-
-    evpl_get_hf_monotonic_time(evpl, &now);
 
     if (rdma) {
         /* RPC2 on RDMA has no header since its message based,
@@ -1161,7 +1152,7 @@ evpl_rpc2_recv_msg(
             request->xid          = rpc_msg.xid;
             request->encoding.xid = request->xid;
             request->proc         = rpc_msg.body.cbody.proc;
-            request->timestamp    = now;
+            prometheus_stopwatch_start(&request->timestamp);
 
             /* Parse credentials - authsys data is in msg->dbuf which persists */
             flavor = rpc_msg.body.cbody.cred.flavor;


### PR DESCRIPTION
Consolidates libevpl's time handling onto the `stopwatch` TSC timer (the header vendored by the prometheus-c submodule, bumped here to pick up its new time-histogram type), and gets `clock_gettime` off the event-loop hot path.

## Timekeeping
- `evpl_shared` owns a process-wide `stopwatch_context`, anchored to `CLOCK_MONOTONIC` once at init. New `evpl_now_ticks()` / `evpl_ns_to_ticks()` / `evpl_ticks_to_ns()` helpers expose monotonic time in raw stopwatch ticks — a single unfenced `rdtsc` + subtract on the TSC path; `clock_gettime` only in the non-TSC fallback.
- `evpl_get_hf_monotonic_time()` becomes a thin wrapper over that context; the bespoke per-`evpl` TSC calibration (`hf_tsc_*` fields, `EVPL_TSC_*` constants) is removed.
- Timer deadlines are kept in ticks (`evpl_timer.deadline` is now `uint64_t`): the heap compares integers directly and `evpl_timer_insert` arms without `clock_gettime`.
- The poll-mode spin grace period is precomputed to ticks at `evpl_create` and compared in ticks; `last_activity` is tracked in ticks. The only conversion back to milliseconds happens when computing the blocking `evpl_core_wait` timeout — off the busy path.

## Latency metrics
- `block_latency` and the generic rpc2 per-call metric are now time histograms (`PROMETHEUS_HISTOGRAM_TIME`): a caller-owned `prometheus_stopwatch` is started at submit/receive and sampled at completion, bucketed in cycles and converted to nanoseconds only at scrape.

## Notes
- `stopwatch.h` is included from `ext/prometheus-c/ext/stopwatch` so libevpl and prometheus-c always share one version.
- Depends on the prometheus-c submodule bump (already on prometheus-c `main`).

All 63 ctest cases pass (rpc2 / http / tls / socket / timer).