### PR TITLE
rpc2: do not abort the process on a malformed peer reply

### DIFF
--- a/include/evpl/evpl_rpc2_program.h
+++ b/include/evpl/evpl_rpc2_program.h
@@ -10,6 +10,16 @@
 #include "evpl/evpl_rpc2.h"
 #define EVPL_RPC2 1
 
+/*
+ * Status passed to a client reply callback when the peer's reply could not be
+ * decoded (truncated, malformed, or wrong length).  The reply argument is NULL
+ * (or a zero value for a by-value reply), so callbacks -- which must check
+ * status before touching the reply -- treat it as a failed call rather than the
+ * connection being torn down by an abort.  Negative so it cannot collide with a
+ * protocol status code.
+ */
+#define EVPL_RPC2_REPLY_DECODE_ERROR (-1)
+
 #include <pthread.h>
 struct prometheus_histogram_instance;
 


### PR DESCRIPTION
## Summary

When a peer's RPC reply failed to decode (truncated, malformed, or `len != length`), the generated client reply dispatcher returned a nonzero code and `rpc2.c` turned it into `evpl_rpc2_abort()` — **a peer could crash the whole process** — while the per-request completion callback never ran (so the caller would also hang/leak).

This adds `EVPL_RPC2_REPLY_DECODE_ERROR` (the status the dispatcher now hands to the request callback for an undecodable reply; reply is `NULL`, or a zero value for a by-value reply) and bumps `ext/xdrzcc` to the matching codegen change (chimera-nas/xdrzcc#8). The caller's completion now runs and treats it as a failed call — callbacks already check `status` before touching the reply.

## Depends on

- chimera-nas/xdrzcc#8 (the codegen change). The `ext/xdrzcc` bump here points at that branch; it should be re-pointed to the squashed/merged commit when #8 lands.

## Testing

Validated in chimera: a peer (a pynfs callback server that died mid-reply) returning a malformed `CB_COMPOUND` reply previously aborted the chimera server with `evpl_rpc2_abort("Failed to dispatch rpc2 reply: 2")`; with this change the server delivers the error to the recall completion and stays up (clean shutdown), under the AddressSanitizer build.