### PR TITLE
rpc2: drop per-call AUTH_SYS debug log

### DIFF
--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -1803,11 +1803,6 @@ evpl_rpc2_call(
         rpc_msg.body.cbody.cred.authsys.gid             = cred->authsys.gid;
         rpc_msg.body.cbody.cred.authsys.num_gids        = cred->authsys.num_gids;
         rpc_msg.body.cbody.cred.authsys.gids            = cred->authsys.gids;
-
-        evpl_rpc2_debug("AUTH_SYS: machinename=%.*s (len=%d) uid=%u gid=%u num_gids=%u",
-                        cred->authsys.machinename_len, cred->authsys.machinename,
-                        cred->authsys.machinename_len, cred->authsys.uid,
-                        cred->authsys.gid, cred->authsys.num_gids);
     } else {
         rpc_msg.body.cbody.cred.flavor = AUTH_NONE;
     }


### PR DESCRIPTION
`evpl_rpc2_call()` emitted an `AUTH_SYS: machinename=...` debug line on **every** RPC send.

`evpl_debug()` is not level-gated — it unconditionally invokes the registered log callback — so once a consumer registers a log function (e.g. Chimera), this fires for every call and serializes the RPC hot path behind the logger's lock. Under a high-IOPS NFS client workload it floods the log and distorts throughput measurements.

It was leftover instrumentation with no diagnostic value on the steady-state path. Remove it.

No functional change; the AUTH_SYS credential fields are still populated identically.