### PR TITLE
build: keep frame pointers in all build types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,11 @@ endif()
 
 message(STATUS "Building ${CMAKE_BUILD_TYPE} for ${CMAKE_SYSTEM_NAME}")
 
+# Keep frame pointers in every build type so that perf and other
+# frame-pointer-based profilers can unwind call stacks (the cost at -O3 is
+# negligible and the unwind reliability is worth it for production profiling).
+add_compile_options(-fno-omit-frame-pointer)
+
 set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};/opt/nvidia")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")


### PR DESCRIPTION
## Summary

Release builds compile with `-O3`, which omits the frame pointer. That breaks frame-pointer-based stack unwinding in `perf` (`--call-graph fp`) and similar profilers against Release binaries — exactly the builds we profile in production.

This adds `-fno-omit-frame-pointer` unconditionally (via `add_compile_options`, right after the build-type banner) so it applies to **every** build type. Debug already enabled it alongside AddressSanitizer; this guarantees Release (and any other config) keeps it too.

## Rationale

The runtime cost of preserving the frame pointer at `-O3` is negligible, while reliable, low-overhead `fp` call-graph profiling (no DWARF stack dumps) is high-value for diagnosing throughput/latency on optimized builds.