### PR TITLE
rdmacm: check ibv_alloc_td / parent_domain allocation failures

### DIFF
--- a/src/core/rdmacm/rdmacm.c
+++ b/src/core/rdmacm/rdmacm.c
@@ -1042,6 +1042,10 @@ evpl_rdmacm_create(
 
         dev->td = ibv_alloc_td(dev->context, &td_attr);
 
+        evpl_rdmacm_abort_if(!dev->td,
+                             "Failed to allocate thread domain for rdma device: %s",
+                             strerror(errno));
+
         memset(&pd_attr, 0, sizeof(pd_attr));
 
         pd_attr.pd        = dev->parent_pd;
@@ -1051,7 +1055,8 @@ evpl_rdmacm_create(
         dev->pd = ibv_alloc_parent_domain(dev->context, &pd_attr);
 
         evpl_rdmacm_abort_if(!dev->pd,
-                             "Failed to create protection domain for rdma device");
+                             "Failed to allocate parent domain for rdma device: %s",
+                             strerror(errno));
 
         memset(&cq_attr, 0, sizeof(cq_attr));
 


### PR DESCRIPTION
## Summary

`evpl_rdmacm_create()` allocates a per-thread Thread Domain (`ibv_alloc_td`) and parent domain (`ibv_alloc_parent_domain`) for each device, but the return value of `ibv_alloc_td` was never checked. On failure it silently proceeded with a NULL `td`, producing a degraded parent domain and a confusing downstream failure (e.g. `rdma_create_qp` returning `EINVAL`) that masks the real cause.

This adds an explicit `abort_if(!dev->td)` check and includes `strerror(errno)` in both the TD and parent-domain failure messages so allocation failures are surfaced at the point they occur.

## Motivation

Per-thread Thread Domains consume a scarce per-context device resource (UAR / blue-flame registers) on mlx5. When that pool is exhausted as more threads activate their RDMA path, `ibv_alloc_td` can fail — and previously did so silently. This is good hygiene regardless and makes diagnosing resource-exhaustion-at-scale failures straightforward.

No functional change on the success path.