### PR TITLE
core: configurable hugetlb page size for slab allocation

### DIFF
--- a/include/evpl/evpl_config.h
+++ b/include/evpl/evpl_config.h
@@ -37,6 +37,15 @@ void evpl_global_config_set_huge_pages(
     struct evpl_global_config *config,
     int                        huge_pages);
 
+/* Select the hugetlb page size used to back slabs when huge pages are enabled.
+ * Must be a power-of-two size of a hugetlb pool the kernel exposes (e.g.
+ * 2 MiB or 1 GiB); invalid sizes are rejected and the default (2 MiB) kept.
+ * The slab size should be a multiple of this, or the mapping falls back to
+ * base pages. */
+void evpl_global_config_set_huge_page_size(
+    struct evpl_global_config *config,
+    uint64_t                   size);
+
 void evpl_global_config_set_rdmacm_tos(
     struct evpl_global_config *config,
     uint8_t                    tos);

--- a/src/core/allocator.c
+++ b/src/core/allocator.c
@@ -18,6 +18,11 @@
 #include "core/protocol.h"
 #include "core/macros.h"
 
+/* Encodes the log2 of a specific hugetlb page size into the mmap flags so a
+ * non-default pool (e.g. 1 GiB) can be selected; see mmap(2) MAP_HUGE_*. */
+#ifndef MAP_HUGE_SHIFT
+#define MAP_HUGE_SHIFT 26
+#endif /* ifndef MAP_HUGE_SHIFT */
 
 extern struct evpl_shared *evpl_shared;
 
@@ -223,14 +228,26 @@ evpl_allocator_build_slab(
  again:
 
     if (hugepages) {
+        uint64_t huge_page_size = evpl_shared->config->huge_page_size;
+        int      flags          = MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB;
 
-        slab->data = mmap(NULL, evpl_shared->config->slab_size,
+        /* Pin the mapping to a specific hugetlb pool (validated to be a
+         * power of two in evpl_global_config_set_huge_page_size).  The slab
+         * size must be a multiple of it, or the kernel rejects the mapping and
+         * we fall back to base pages below. */
+        if (huge_page_size) {
+            flags |= (__builtin_ctzll(huge_page_size) << MAP_HUGE_SHIFT);
+        }
+
+        slab->data = mmap(NULL, slab->size,
                           PROT_READ | PROT_WRITE,
-                          MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB,
+                          flags,
                           -1, 0);
 
         if (slab->data == MAP_FAILED) {
-            evpl_core_info("Could not allocate huge pages, disabling...");
+            evpl_core_info(
+                "Could not allocate %llu-byte huge pages, disabling...",
+                (unsigned long long) huge_page_size);
             allocator->hugepages = 0;
             hugepages            = 0;
             goto again;

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <unistd.h>
+#include <stdio.h>
 #include <string.h>
 #include <pthread.h>
 
@@ -28,6 +29,7 @@ evpl_global_config_init(void)
     config->max_poll_fd            = 16;
     config->max_num_iovec          = 128;
     config->huge_pages             = 0;
+    config->huge_page_size         = 2 * 1024 * 1024;
     config->buffer_size            = 2 * 1024 * 1024;
     config->slab_size              = 1 * 1024 * 1024 * 1024;
     config->refcnt                 = 1;
@@ -148,6 +150,44 @@ evpl_global_config_set_huge_pages(
 {
     config->huge_pages = huge_pages;
 } /* evpl_global_config_set_huge_pages */
+
+SYMBOL_EXPORT void
+evpl_global_config_set_huge_page_size(
+    struct evpl_global_config *config,
+    uint64_t                   size)
+{
+    char path[64];
+
+    /* A hugetlb page size is always a power of two strictly larger than the
+     * base page.  Bound it sanely (the largest real page on any arch today is
+     * 16 GiB) so a bogus value can never be encoded into MAP_HUGE_* or used to
+     * size a slab. */
+    if (size == 0 || (size & (size - 1)) != 0 ||
+        size <= (uint64_t) config->page_size ||
+        size > (16ULL << 30)) {
+        evpl_core_error(
+            "Ignoring invalid huge page size %llu: must be a power of two in "
+            "(%u, 16GiB]; keeping %llu",
+            (unsigned long long) size,
+            config->page_size,
+            (unsigned long long) config->huge_page_size);
+        return;
+    }
+
+    /* Warn (but accept) if the running kernel exposes no hugetlb pool of this
+     * size: the slab mmap will simply fall back to base pages.  This is a soft
+     * check so a sandboxed /sys does not block a legitimate size. */
+    snprintf(path, sizeof(path), "/sys/kernel/mm/hugepages/hugepages-%llukB",
+             (unsigned long long) (size / 1024));
+    if (access(path, F_OK) != 0) {
+        evpl_core_info(
+            "No %llukB hugetlb pool on this system (%s); slab allocation will "
+            "fall back to base pages unless one is reserved",
+            (unsigned long long) (size / 1024), path);
+    }
+
+    config->huge_page_size = size;
+} /* evpl_global_config_set_huge_page_size */
 
 SYMBOL_EXPORT void
 evpl_global_config_set_rdmacm_tos(

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -37,6 +37,7 @@ struct evpl_global_config {
     unsigned int              max_num_iovec;
     unsigned int              buffer_size;
     unsigned int              huge_pages;
+    uint64_t                  huge_page_size;
     uint64_t                  slab_size;
     unsigned int              page_size;
     unsigned int              max_datagram_size;


### PR DESCRIPTION
## Summary

Make the hugetlb page size used to back slabs configurable.

Slabs are mapped with `MAP_HUGETLB`, which only ever draws from the kernel's
`default_hugepagesz` pool. On a host that reserves a *non-default* huge page
size — e.g. 1 GiB pages for DMA — the allocator still asked for the default
(typically 2 MiB) and, when that pool had no free pages on the allocating NUMA
node, logged "Could not allocate huge pages, disabling..." and fell back to
base pages. The reserved memory was then stranded and unusable, shrinking the
process's effective RAM.

## Change

- Add `huge_page_size` to `evpl_global_config` (default **2 MiB**) and a setter
  `evpl_global_config_set_huge_page_size()`.
- The setter validates the value is a power of two, larger than the base page,
  and within a sane ceiling (≤ 16 GiB); invalid values are rejected and the
  default kept. It also warns (but accepts) if the kernel exposes no matching
  `/sys/kernel/mm/hugepages/hugepages-<N>kB` pool, since a sandboxed `/sys`
  shouldn't block a legitimate size — the mapping just falls back to base pages.
- The allocator encodes the size into the `mmap` flags via
  `MAP_HUGE_<log2(size)>` (with a `MAP_HUGE_SHIFT` fallback define), so a
  specific pool (e.g. 1 GiB) is selected. The slab size should be a multiple of
  the chosen page size; if the mapping fails, the existing fallback to base
  pages is unchanged.

Default behavior is unchanged on a system whose default huge page size is 2 MiB.

## Notes

- NUMA still applies: `MAP_HUGETLB` allocates node-local with no spill, so the
  chosen size must be reserved on the node the allocating thread runs on. This
  change selects the pool; node-aware slab placement is a separate concern.
