### PR TITLE
rdmacm: record local address on the client connect path

### DIFF
--- a/src/core/rdmacm/rdmacm.c
+++ b/src/core/rdmacm/rdmacm.c
@@ -420,6 +420,18 @@ evpl_rdmacm_event_callback(
                 rdmacm_id->resolve_addr = NULL;
 
             } else {
+                /* On the connecting (client) side bind->local was never
+                 * populated; the accept path sets it, but connect() does not.
+                 * Now that the connection is established the cm_id's route
+                 * holds the resolved local address and port, so record it
+                 * (mirrors the server attach path) before notifying the
+                 * upper layer, which may query the local address. */
+                if (!bind->local) {
+                    bind->local = evpl_address_init(
+                        &cm_event->id->route.addr.src_addr,
+                        sizeof(cm_event->id->route.addr.src_addr));
+                }
+
                 notify.notify_type   = EVPL_NOTIFY_CONNECTED;
                 notify.notify_status = 0;
 


### PR DESCRIPTION
## Summary

The connecting (client) side of the RDMA CM transport never populated `bind->local`, so the local address read back via the bind (e.g. `evpl_rpc2_conn_get_local_address`) came back NULL. This is why chimera's NFS client logs RDMA connections as `Disconnected from (NULL) to <server>:20049` while TCP connections show a real local address.

The accept (server) path already sets `bind->local` from the cm_id's `route.addr.src_addr` (in `evpl_rdmacm_attach`), and the TCP transports set it via `getsockname()`. Only the RDMA client connect path was missing it.

## Fix

At `RDMA_CM_EVENT_ESTABLISHED` on the connecting side, populate `bind->local` from `cm_event->id->route.addr.src_addr` — the resolved local address and port — mirroring the server attach path. It's set before the `EVPL_NOTIFY_CONNECTED` callback so the upper layer sees a valid local address on connect as well as disconnect, and guarded by `!bind->local` so the server side (which sets it earlier) is untouched.

Purely cosmetic/observability; no behavioral change to the data path.