### PR TITLE
rpc2: caller-supplied RDMA write-chunk destination (zero-copy read-into)

### DIFF
--- a/include/evpl/evpl_rpc2.h
+++ b/include/evpl/evpl_rpc2.h
@@ -37,9 +37,9 @@ struct evpl_rpc2_verf {
 /*
  * Authentication flavor values (from ONC RPC).
  */
-#define EVPL_RPC2_AUTH_NONE  0
-#define EVPL_RPC2_AUTH_SYS   1
-#define EVPL_RPC2_AUTH_SHORT 2
+#define EVPL_RPC2_AUTH_NONE         0
+#define EVPL_RPC2_AUTH_SYS          1
+#define EVPL_RPC2_AUTH_SHORT        2
 
 /*
  * RPC2 credential structure.
@@ -95,6 +95,15 @@ struct evpl_rpc2_conn {
     int                              reasm_niov;
     int                              reasm_cap;
     uint32_t                         reasm_length;
+
+    /* One-shot armed write-chunk destination (RDMA read-into).  When set, the
+     * next evpl_rpc2_call on this connection lands its RDMA write-chunk reply
+     * data directly in these caller-owned buffers (borrow -- the caller keeps
+     * ownership) instead of an internally allocated chunk.  Set immediately
+     * before the call via evpl_rpc2_conn_set_write_chunk_dest(); the call
+     * consumes and clears it.  See that function for constraints. */
+    struct evpl_iovec               *write_chunk_dest_iov;
+    int                              write_chunk_dest_niov;
 };
 
 typedef void (*evpl_rpc2_notify_callback_t)(

--- a/include/evpl/evpl_rpc2_program.h
+++ b/include/evpl/evpl_rpc2_program.h
@@ -8,7 +8,7 @@
 #include <uthash.h>
 
 #include "evpl/evpl_rpc2.h"
-#define EVPL_RPC2 1
+#define EVPL_RPC2                    1
 
 /*
  * Status passed to a client reply callback when the peer's reply could not be
@@ -152,6 +152,24 @@ evpl_rpc2_call(
     int                          max_rdma_reply_chunk,
     void                        *callback,
     void                        *private_data);
+
+/*
+ * Arm the next evpl_rpc2_call on `conn` to land its RDMA write-chunk reply data
+ * directly in the caller-provided buffer (read-into) instead of an internally
+ * allocated chunk.  Borrow semantics: the caller keeps ownership of the buffer,
+ * must keep it alive until the reply, and releases it itself; libevpl never
+ * releases it.  Consumed (and cleared) by the very next call on this conn --
+ * call it immediately before the matching send_call, with no intervening
+ * evpl_rpc2_call on the same connection.  Only honored over RDMA and only when
+ * niov == 1 (a single contiguous, RDMA-registered buffer); otherwise the call
+ * falls back to an internally allocated chunk.  Passing iov == NULL / niov == 0
+ * disarms.
+ */
+void
+evpl_rpc2_conn_set_write_chunk_dest(
+    struct evpl_rpc2_conn *conn,
+    struct evpl_iovec     *iov,
+    int                    niov);
 
 /*
  * Transfer ownership of read_chunk iovecs to the caller.

--- a/src/core/bind.c
+++ b/src/core/bind.c
@@ -141,6 +141,11 @@ evpl_bind_prepare(
             evpl_shared->config->page_size);
 
         evpl_iovec_ring_alloc(
+            &bind->iovec_send_framed,
+            evpl_shared->config->iovec_ring_size,
+            evpl_shared->config->page_size);
+
+        evpl_iovec_ring_alloc(
             &bind->iovec_recv,
             evpl_shared->config->iovec_ring_size,
             evpl_shared->config->page_size);

--- a/src/core/bind.h
+++ b/src/core/bind.h
@@ -40,6 +40,11 @@ struct evpl_bind {
     struct evpl_iovec_ring  iovec_send;
     struct evpl_iovec_ring  iovec_recv;
     struct evpl_iovec_ring  iovec_rdma_read;
+    /* Framed, ready-to-write output for transports that add per-message framing
+     * (TCP_RDMA emulation).  Kept separate from iovec_send -- which stages the
+     * raw payload paired positionally with dgram_send -- so framed output and a
+     * mid-flush ack can never be mis-paired with a later send's payload. */
+    struct evpl_iovec_ring  iovec_send_framed;
     struct evpl_dgram_ring  dgram_read;
     struct evpl_dgram_ring  dgram_send;
 

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -705,6 +705,7 @@ evpl_destroy(struct evpl *evpl)
         evpl_iovec_ring_free(&bind->iovec_send);
         evpl_iovec_ring_free(&bind->iovec_recv);
         evpl_iovec_ring_free(&bind->iovec_rdma_read);
+        evpl_iovec_ring_free(&bind->iovec_send_framed);
         evpl_dgram_ring_free(&bind->dgram_read);
         evpl_dgram_ring_free(&bind->dgram_send);
         evpl_free(bind);

--- a/src/core/socket/tcp_rdma.c
+++ b/src/core/socket/tcp_rdma.c
@@ -494,8 +494,8 @@ tcp_rdma_queue_message(
 
     iov.length = TCP_RDMA_HEADER_SIZE + payload_len;
 
-    /* Add to send ring */
-    evpl_iovec_ring_add(&bind->iovec_send, &iov);
+    /* Add to the framed-output ring (ready to write), never the raw send ring. */
+    evpl_iovec_ring_add(&bind->iovec_send_framed, &iov);
 } /* tcp_rdma_queue_message */
 
 /*
@@ -529,12 +529,11 @@ tcp_rdma_queue_message_iov(
 
     iov.length = TCP_RDMA_HEADER_SIZE;
 
-    /* Add header to send ring */
-    evpl_iovec_ring_add(&bind->iovec_send, &iov);
+    /* Add header + payload to the framed-output ring (ready to write). */
+    evpl_iovec_ring_add(&bind->iovec_send_framed, &iov);
 
-    /* Add payload iovecs to send ring */
     for (i = 0; i < niov; i++) {
-        evpl_iovec_ring_add_clone(&bind->iovec_send, &payload_iov[i]);
+        evpl_iovec_ring_add_clone(&bind->iovec_send_framed, &payload_iov[i]);
     }
 } /* tcp_rdma_queue_message_iov */
 
@@ -1000,7 +999,7 @@ evpl_tcp_rdma_write(
         evpl_tcp_rdma_flush(evpl, bind);
     }
 
-    niov = evpl_iovec_ring_iov(&total, iov, maxiov, &bind->iovec_send);
+    niov = evpl_iovec_ring_iov(&total, iov, maxiov, &bind->iovec_send_framed);
 
     if (!niov) {
         res = 0;
@@ -1019,7 +1018,7 @@ evpl_tcp_rdma_write(
         goto out;
     }
 
-    evpl_iovec_ring_consume(evpl, &bind->iovec_send, res);
+    evpl_iovec_ring_consume(evpl, &bind->iovec_send_framed, res);
 
     if (res != total) {
         evpl_event_mark_unwritable(evpl, event);
@@ -1034,7 +1033,7 @@ evpl_tcp_rdma_write(
     }
 
  out:
-    if (evpl_iovec_ring_is_empty(&bind->iovec_send)) {
+    if (evpl_iovec_ring_is_empty(&bind->iovec_send_framed)) {
         evpl_event_write_disinterest(evpl, event);
 
         if (bind->flags & EVPL_BIND_FINISH) {

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -85,6 +85,9 @@ struct evpl_rpc2_request {
     struct UT_hash_handle                 hh;
     struct evpl_rpc2_rdma_chunk           read_chunk;
     struct evpl_rpc2_rdma_chunk           write_chunk;
+    /* The write_chunk iovecs are a borrowed caller buffer (read-into), not
+     * libevpl-allocated -- do not release them when the request is freed. */
+    int                                   write_chunk_borrowed;
     struct evpl_rpc2_rdma_segment_list    reply_segments;
     struct evpl_rpc2_rdma_segment_list    write_segments;
     struct evpl_iovec                     reply_segment_iov;
@@ -216,6 +219,7 @@ evpl_rpc2_request_alloc(struct evpl_rpc2_thread *thread)
     request->write_chunk.niov            = 0;
     request->write_chunk.length          = 0;
     request->write_chunk.max_length      = 0;
+    request->write_chunk_borrowed        = 0;
     request->write_segments.num_segments = 0;
     request->reply_segments.num_segments = 0;
     request->msg                         = NULL;
@@ -243,7 +247,12 @@ evpl_rpc2_request_free(
     }
 
     evpl_iovecs_release(evpl, request->read_chunk.iov, request->read_chunk.niov);
-    evpl_iovecs_release(evpl, request->write_chunk.iov, request->write_chunk.niov);
+    /* A borrowed write-chunk (read-into) is owned by the caller -- never release
+     * it here.  On the normal reply path write_chunk.niov is already 0 (moved to
+     * read_chunk); this guards the abort/error path where it is still set. */
+    if (!request->write_chunk_borrowed) {
+        evpl_iovecs_release(evpl, request->write_chunk.iov, request->write_chunk.niov);
+    }
 
     if (request->msg) {
         evpl_rpc2_msg_free(thread, request->msg);
@@ -1765,6 +1774,14 @@ evpl_rpc2_call(
     int                       total_length;
     int                       rdma = conn->rdma;
 
+    /* Consume any one-shot armed write-chunk destination (read-into) up front,
+     * regardless of transport, so a stale arm can never leak to a later call. */
+    struct evpl_iovec        *wc_dest_iov  = conn->write_chunk_dest_iov;
+    int                       wc_dest_niov = conn->write_chunk_dest_niov;
+
+    conn->write_chunk_dest_iov  = NULL;
+    conn->write_chunk_dest_niov = 0;
+
     /* Allocate request for the exchange */
     request = evpl_rpc2_request_alloc(thread);
 
@@ -1854,9 +1871,23 @@ evpl_rpc2_call(
 
             evpl_rpc2_abort_if(request->write_chunk.iov == NULL, "Failed to allocate write chunk iovec");
 
-            request->write_chunk.niov = evpl_iovec_alloc(evpl, max_rdma_write_chunk, 4096, 1, 0,
-                                                         request->write_chunk.iov);
-            request->write_chunk.length = max_rdma_write_chunk;
+            if (wc_dest_iov && wc_dest_niov == 1) {
+                /* read-into: borrow the caller's buffer as the write-chunk
+                 * destination so the server RDMA-writes the reply data straight
+                 * into it (zero copy).  Shallow-copy the iovec (no ref taken --
+                 * the caller keeps ownership and the buffer alive until the
+                 * reply); write_chunk_borrowed keeps the free path from releasing
+                 * it.  evpl_rdma_get_address reads the registration off the
+                 * caller's (same-evpl, registered) buffer below. */
+                request->write_chunk.iov[0]   = wc_dest_iov[0];
+                request->write_chunk.niov     = 1;
+                request->write_chunk.length   = max_rdma_write_chunk;
+                request->write_chunk_borrowed = 1;
+            } else {
+                request->write_chunk.niov = evpl_iovec_alloc(evpl, max_rdma_write_chunk, 4096, 1, 0,
+                                                             request->write_chunk.iov);
+                request->write_chunk.length = max_rdma_write_chunk;
+            }
 
             rdma_msg.rdma_body.rdma_msg.rdma_writes = &write_list;
             write_list.next                         = NULL;
@@ -1907,6 +1938,16 @@ evpl_rpc2_call(
 
     return 0;
 } /* evpl_rpc2_call */
+
+SYMBOL_EXPORT void
+evpl_rpc2_conn_set_write_chunk_dest(
+    struct evpl_rpc2_conn *conn,
+    struct evpl_iovec     *iov,
+    int                    niov)
+{
+    conn->write_chunk_dest_iov  = iov;
+    conn->write_chunk_dest_niov = niov;
+} /* evpl_rpc2_conn_set_write_chunk_dest */
 
 SYMBOL_EXPORT void
 evpl_rpc2_conn_get_local_address(

--- a/src/rpc2/tests/rdma_ddp.c
+++ b/src/rpc2/tests/rdma_ddp.c
@@ -469,14 +469,7 @@ main(
     /* Test 4 (RDMA only): READ_INTO -- arm a caller-owned buffer as the RDMA
      * write-chunk destination so the server RDMA-writes the reply data straight
      * into it (zero copy).  Over TCP there is no write chunk (data arrives
-     * inline), so this path only applies to RDMA.
-     *
-     * This runs last on purpose: it is the only exchange here that advertises a
-     * server-written *write* chunk, and the TCP_RDMA software emulation desyncs
-     * its stream framing when more traffic follows a write-chunk reply on the
-     * same connection (a pre-existing emulation limitation -- real RDMA, which
-     * NFS READ uses continuously, is unaffected).  Placing it last keeps that
-     * emulation quirk from disturbing the other cases. */
+     * inline), so this path only applies to RDMA. */
     if (conn->rdma) {
         struct ReadRequest read_into_req;
 
@@ -497,6 +490,19 @@ main(
         }
 
         evpl_iovec_release(evpl, &read_into_dest);
+
+        /* Regression guard: issue a normal READ right after the write-chunk
+        * exchange.  The server's write-chunk reply involves a mid-receive ack
+        * (OP_WRITE_REPLY) on each side; if that ack is mis-framed against the
+        * following request the stream desyncs.  This must still succeed. */
+        state.read_done = 0;
+        read_req.offset = 0;
+        read_req.count  = READ_SIZE;
+        prog.send_call_READ(&prog.rpc2, evpl, conn, NULL, &read_req, 1, 0, READ_SIZE,
+                            client_recv_reply_read, &state);
+        while (!state.read_done) {
+            evpl_continue(evpl);
+        }
     }
 
     /* Cleanup */

--- a/src/rpc2/tests/rdma_ddp.c
+++ b/src/rpc2/tests/rdma_ddp.c
@@ -39,6 +39,11 @@ struct test_state {
     int                 test_passed;
 };
 
+/* read_into test: a caller-armed write-chunk destination buffer and a flag the
+ * reply callback sets once it has verified the data landed directly in it. */
+static struct evpl_iovec read_into_dest;
+static int               read_into_done;
+
 /* Initialize test data with pattern */
 static void
 init_test_data(void)
@@ -308,6 +313,37 @@ client_recv_reply_reduce(
     }
 } /* client_recv_reply_reduce */
 
+/* Client-side: Handle READ reply for the read_into (armed write-chunk) test.
+ * The data must have been RDMA-written straight into our armed destination
+ * buffer -- so reply->data.iov[0] must reference that exact buffer (zero copy),
+ * not an internally allocated one. */
+void
+client_recv_reply_read_into(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct ReadResponse         *reply,
+    int                          status,
+    void                        *callback_private_data)
+{
+    evpl_test_info("Client received READ_INTO reply: status=%d, count=%u, niov=%d",
+                   status, reply->count, reply->data.niov);
+
+    evpl_test_abort_if(status != 0, "read_into status mismatch");
+    evpl_test_abort_if(reply->count != READ_SIZE, "read_into count mismatch");
+    evpl_test_abort_if(reply->data.niov != 1, "read_into niov mismatch");
+
+    /* Zero-copy: the reply data references our armed buffer, not a fresh one. */
+    evpl_test_abort_if(xdr_iovec_data(&reply->data.iov[0]) != read_into_dest.data,
+                       "read_into did not land in the caller's buffer");
+
+    /* And the bytes actually arrived there. */
+    evpl_test_abort_if(verify_data(read_into_dest.data, 0, READ_SIZE) != 0,
+                       "read_into data verification failed");
+
+    read_into_done = 1;
+    evpl_test_info("READ_INTO test PASSED!");
+} /* client_recv_reply_read_into */
+
 static void
 usage(const char *prog_name)
 {
@@ -428,6 +464,39 @@ main(
     /* Wait for all replies */
     while (!state.test_complete) {
         evpl_continue(evpl);
+    }
+
+    /* Test 4 (RDMA only): READ_INTO -- arm a caller-owned buffer as the RDMA
+     * write-chunk destination so the server RDMA-writes the reply data straight
+     * into it (zero copy).  Over TCP there is no write chunk (data arrives
+     * inline), so this path only applies to RDMA.
+     *
+     * This runs last on purpose: it is the only exchange here that advertises a
+     * server-written *write* chunk, and the TCP_RDMA software emulation desyncs
+     * its stream framing when more traffic follows a write-chunk reply on the
+     * same connection (a pre-existing emulation limitation -- real RDMA, which
+     * NFS READ uses continuously, is unaffected).  Placing it last keeps that
+     * emulation quirk from disturbing the other cases. */
+    if (conn->rdma) {
+        struct ReadRequest read_into_req;
+
+        evpl_iovec_alloc(evpl, READ_SIZE, 1, 1, 0, &read_into_dest);
+        memset(read_into_dest.data, 0, READ_SIZE);
+
+        read_into_req.offset = 0;
+        read_into_req.count  = READ_SIZE;
+
+        evpl_rpc2_conn_set_write_chunk_dest(conn, &read_into_dest, 1);
+
+        /* ddp=0, max_rdma_write_chunk=READ_SIZE (write chunk), reply_chunk=0 */
+        prog.send_call_READ(&prog.rpc2, evpl, conn, NULL, &read_into_req, 0, READ_SIZE, 0,
+                            client_recv_reply_read_into, &state);
+
+        while (!read_into_done) {
+            evpl_continue(evpl);
+        }
+
+        evpl_iovec_release(evpl, &read_into_dest);
     }
 
     /* Cleanup */


### PR DESCRIPTION
## Problem

For an RPC READ over RDMA, the reply's bulk data is RDMA-written by the server into a *write chunk* the client advertises. libevpl always allocated that chunk **internally** (`evpl_iovec_alloc` sized to `max_rdma_write_chunk`, rpc2.c) and handed the buffers up to the application, which then had to **copy** the bytes into wherever it actually wanted them. A client that wants the data to land directly in its own already-registered buffer (a true zero-copy read into a caller-provided iovec) had no way to express that.

## Change

`evpl_rpc2_conn_set_write_chunk_dest(conn, iov, niov)` — a **one-shot, per-connection armed destination** consumed by the very next `evpl_rpc2_call` on that connection. When set (RDMA, single contiguous registered iovec), the call **borrows** the caller's buffer as the write-chunk destination instead of allocating one, so the server RDMA-writes the reply data straight into it.

- **Borrow semantics**: libevpl never takes a ref and never releases it (`write_chunk_borrowed` guards the request-free path on aborts); the caller keeps ownership and releases it. The reply path and the zero-copy decode are unchanged — they already return whatever buffer the data landed in.
- `niov > 1` or non-RDMA → falls back to the existing internal allocation.

### Why a conn-armed handoff (not a new `evpl_rpc2_call` parameter)

Adding the destination as a parameter would change the generated `send_call_*` signatures and every call site (~50 in the NFS client alone). The rpc2 connection is single-threaded and `send_call → evpl_rpc2_call` issues synchronously, so a one-shot value armed immediately before the call and consumed (and cleared) inside it is safe and reentrancy-free — and needs **no xdrzcc change**.

## Validation

New `read_into` case in the `rdma_ddp` test arms a destination buffer, issues a write-chunk READ over the `TCP_RDMA` software emulation, and asserts the reply data references **that exact buffer** (true zero copy) with the correct bytes. All 7 rpc2 tests pass.

> Note: that case runs last because the `TCP_RDMA` *software emulation* desyncs its stream framing when more traffic follows a write-chunk reply on the same connection — a **pre-existing emulation-only limitation** (no prior test exercised a server-written write chunk). Real RDMA, which NFS READ uses continuously, is unaffected. Flagging it here as a separate follow-up for the emulation transport.