### PR TITLE
rpc2: make the RDMA write-chunk destination an explicit call argument

### DIFF
--- a/include/evpl/evpl_rpc2.h
+++ b/include/evpl/evpl_rpc2.h
@@ -95,15 +95,6 @@ struct evpl_rpc2_conn {
     int                              reasm_niov;
     int                              reasm_cap;
     uint32_t                         reasm_length;
-
-    /* One-shot armed write-chunk destination (RDMA read-into).  When set, the
-     * next evpl_rpc2_call on this connection lands its RDMA write-chunk reply
-     * data directly in these caller-owned buffers (borrow -- the caller keeps
-     * ownership) instead of an internally allocated chunk.  Set immediately
-     * before the call via evpl_rpc2_conn_set_write_chunk_dest(); the call
-     * consumes and clears it.  See that function for constraints. */
-    struct evpl_iovec               *write_chunk_dest_iov;
-    int                              write_chunk_dest_niov;
 };
 
 typedef void (*evpl_rpc2_notify_callback_t)(

--- a/include/evpl/evpl_rpc2_program.h
+++ b/include/evpl/evpl_rpc2_program.h
@@ -137,6 +137,18 @@ struct evpl_rpc2_program {
         int                          length);
 };
 
+/*
+ * Issue an RPC call.
+ *
+ * write_chunk_iov/write_chunk_niov (optional, NULL/0 to omit) supply a
+ * caller-owned buffer for the reply's RDMA write chunk to land in directly
+ * (zero-copy read-into) instead of an internally allocated one.  Borrow
+ * semantics: the caller keeps ownership, must keep the buffer alive until the
+ * reply, and releases it itself; libevpl never releases it.  Only honored over
+ * RDMA and only when niov == 1 (a single contiguous, RDMA-registered buffer);
+ * otherwise an internal chunk is allocated.  max_rdma_write_chunk still gives
+ * the advertised chunk length.
+ */
 int
 evpl_rpc2_call(
     struct evpl                 *evpl,
@@ -149,27 +161,11 @@ evpl_rpc2_call(
     int                          req_length,
     struct evpl_rpc2_rdma_chunk *rdma_chunk,
     int                          max_rdma_write_chunk,
+    struct evpl_iovec           *write_chunk_iov,
+    int                          write_chunk_niov,
     int                          max_rdma_reply_chunk,
     void                        *callback,
     void                        *private_data);
-
-/*
- * Arm the next evpl_rpc2_call on `conn` to land its RDMA write-chunk reply data
- * directly in the caller-provided buffer (read-into) instead of an internally
- * allocated chunk.  Borrow semantics: the caller keeps ownership of the buffer,
- * must keep it alive until the reply, and releases it itself; libevpl never
- * releases it.  Consumed (and cleared) by the very next call on this conn --
- * call it immediately before the matching send_call, with no intervening
- * evpl_rpc2_call on the same connection.  Only honored over RDMA and only when
- * niov == 1 (a single contiguous, RDMA-registered buffer); otherwise the call
- * falls back to an internally allocated chunk.  Passing iov == NULL / niov == 0
- * disarms.
- */
-void
-evpl_rpc2_conn_set_write_chunk_dest(
-    struct evpl_rpc2_conn *conn,
-    struct evpl_iovec     *iov,
-    int                    niov);
 
 /*
  * Transfer ownership of read_chunk iovecs to the caller.

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -1755,6 +1755,8 @@ evpl_rpc2_call(
     int                          req_length,
     struct evpl_rpc2_rdma_chunk *rdma_chunk,
     int                          max_rdma_write_chunk,
+    struct evpl_iovec           *write_chunk_iov,
+    int                          write_chunk_niov,
     int                          max_rdma_reply_chunk,
     void                        *callback,
     void                        *private_data)
@@ -1773,14 +1775,6 @@ evpl_rpc2_call(
     int                       pay_length = req_length - program->reserve;
     int                       total_length;
     int                       rdma = conn->rdma;
-
-    /* Consume any one-shot armed write-chunk destination (read-into) up front,
-     * regardless of transport, so a stale arm can never leak to a later call. */
-    struct evpl_iovec        *wc_dest_iov  = conn->write_chunk_dest_iov;
-    int                       wc_dest_niov = conn->write_chunk_dest_niov;
-
-    conn->write_chunk_dest_iov  = NULL;
-    conn->write_chunk_dest_niov = 0;
 
     /* Allocate request for the exchange */
     request = evpl_rpc2_request_alloc(thread);
@@ -1871,7 +1865,7 @@ evpl_rpc2_call(
 
             evpl_rpc2_abort_if(request->write_chunk.iov == NULL, "Failed to allocate write chunk iovec");
 
-            if (wc_dest_iov && wc_dest_niov == 1) {
+            if (write_chunk_iov && write_chunk_niov == 1) {
                 /* read-into: borrow the caller's buffer as the write-chunk
                  * destination so the server RDMA-writes the reply data straight
                  * into it (zero copy).  Shallow-copy the iovec (no ref taken --
@@ -1879,7 +1873,7 @@ evpl_rpc2_call(
                  * reply); write_chunk_borrowed keeps the free path from releasing
                  * it.  evpl_rdma_get_address reads the registration off the
                  * caller's (same-evpl, registered) buffer below. */
-                request->write_chunk.iov[0]   = wc_dest_iov[0];
+                request->write_chunk.iov[0]   = write_chunk_iov[0];
                 request->write_chunk.niov     = 1;
                 request->write_chunk.length   = max_rdma_write_chunk;
                 request->write_chunk_borrowed = 1;
@@ -1938,16 +1932,6 @@ evpl_rpc2_call(
 
     return 0;
 } /* evpl_rpc2_call */
-
-SYMBOL_EXPORT void
-evpl_rpc2_conn_set_write_chunk_dest(
-    struct evpl_rpc2_conn *conn,
-    struct evpl_iovec     *iov,
-    int                    niov)
-{
-    conn->write_chunk_dest_iov  = iov;
-    conn->write_chunk_dest_niov = niov;
-} /* evpl_rpc2_conn_set_write_chunk_dest */
 
 SYMBOL_EXPORT void
 evpl_rpc2_conn_get_local_address(

--- a/src/rpc2/tests/builtin_bool.c
+++ b/src/rpc2/tests/builtin_bool.c
@@ -180,7 +180,7 @@ main(
 
     /* Make RPC call */
     evpl_test_info("Client sending PING request");
-    prog.send_call_PING(&prog.rpc2, evpl, conn, NULL, request, 0, 0, 0, client_recv_reply_ping, &state);
+    prog.send_call_PING(&prog.rpc2, evpl, conn, NULL, request, 0, 0, NULL, 0, 0, client_recv_reply_ping, &state);
 
     /* Wait for reply */
     while (!state.test_complete) {

--- a/src/rpc2/tests/hello_world.c
+++ b/src/rpc2/tests/hello_world.c
@@ -185,7 +185,7 @@ main(
 
     /* Make RPC call */
     evpl_test_info("Client sending GREET request");
-    prog.send_call_GREET(&prog.rpc2, evpl, conn, NULL, &request, 0, 0, 0, client_recv_reply_greet, &state);
+    prog.send_call_GREET(&prog.rpc2, evpl, conn, NULL, &request, 0, 0, NULL, 0, 0, client_recv_reply_greet, &state);
 
     /* Wait for reply */
     while (!state.test_complete) {

--- a/src/rpc2/tests/rdma_ddp.c
+++ b/src/rpc2/tests/rdma_ddp.c
@@ -438,7 +438,7 @@ main(
     read_req.offset = 0;
     read_req.count  = READ_SIZE;
     /* Enable DDP: ddp=1, no write chunk, reply chunk of READ_SIZE */
-    prog.send_call_READ(&prog.rpc2, evpl, conn, NULL, &read_req, 1, 0, READ_SIZE,
+    prog.send_call_READ(&prog.rpc2, evpl, conn, NULL, &read_req, 1, 0, NULL, 0, READ_SIZE,
                         client_recv_reply_read, &state);
 
     /* Test 2: WRITE operation - uses write chunk for DDP */
@@ -451,14 +451,14 @@ main(
     write_req_iov.length = WRITE_SIZE;
     xdr_set_ref(&write_req, data, &write_req_iov, 1, WRITE_SIZE);
     /* Enable DDP: ddp=1, no write chunk (write_chunk is for READ), no reply chunk */
-    prog.send_call_WRITE(&prog.rpc2, evpl, conn, NULL, &write_req, 1, 0, 0,
+    prog.send_call_WRITE(&prog.rpc2, evpl, conn, NULL, &write_req, 1, 0, NULL, 0, 0,
                          client_recv_reply_write, &state);
 
     /* Test 3: REDUCE operation - large reply to trigger reply chunk */
     evpl_test_info("Client sending REDUCE request");
     reduce_req.response_size = REDUCE_SIZE;
     /* Enable DDP: ddp=1, no write chunk, reply chunk of REDUCE_SIZE */
-    prog.send_call_REDUCE(&prog.rpc2, evpl, conn, NULL, &reduce_req, 1, 0, REDUCE_SIZE,
+    prog.send_call_REDUCE(&prog.rpc2, evpl, conn, NULL, &reduce_req, 1, 0, NULL, 0, REDUCE_SIZE,
                           client_recv_reply_reduce, &state);
 
     /* Wait for all replies */
@@ -466,7 +466,7 @@ main(
         evpl_continue(evpl);
     }
 
-    /* Test 4 (RDMA only): READ_INTO -- arm a caller-owned buffer as the RDMA
+    /* Test 4 (RDMA only): READ_INTO -- pass a caller-owned buffer as the RDMA
      * write-chunk destination so the server RDMA-writes the reply data straight
      * into it (zero copy).  Over TCP there is no write chunk (data arrives
      * inline), so this path only applies to RDMA. */
@@ -479,10 +479,9 @@ main(
         read_into_req.offset = 0;
         read_into_req.count  = READ_SIZE;
 
-        evpl_rpc2_conn_set_write_chunk_dest(conn, &read_into_dest, 1);
-
-        /* ddp=0, max_rdma_write_chunk=READ_SIZE (write chunk), reply_chunk=0 */
-        prog.send_call_READ(&prog.rpc2, evpl, conn, NULL, &read_into_req, 0, READ_SIZE, 0,
+        /* ddp=0, max_rdma_write_chunk=READ_SIZE, write_chunk_iov=our buffer */
+        prog.send_call_READ(&prog.rpc2, evpl, conn, NULL, &read_into_req, 0, READ_SIZE,
+                            &read_into_dest, 1, 0,
                             client_recv_reply_read_into, &state);
 
         while (!read_into_done) {
@@ -498,7 +497,7 @@ main(
         state.read_done = 0;
         read_req.offset = 0;
         read_req.count  = READ_SIZE;
-        prog.send_call_READ(&prog.rpc2, evpl, conn, NULL, &read_req, 1, 0, READ_SIZE,
+        prog.send_call_READ(&prog.rpc2, evpl, conn, NULL, &read_req, 1, 0, NULL, 0, READ_SIZE,
                             client_recv_reply_read, &state);
         while (!state.read_done) {
             evpl_continue(evpl);


### PR DESCRIPTION
## What

Follow-up to #85 (zero-copy read-into). #85 plumbed the caller-supplied RDMA write-chunk destination through a **one-shot connection side-channel** (`evpl_rpc2_conn_set_write_chunk_dest`) specifically to avoid changing the RPC call signature. This replaces that with an **explicit, optional argument** — clearer intent, no hidden per-connection state:

```c
evpl_rpc2_call(..., int max_rdma_write_chunk,
               struct evpl_iovec *write_chunk_iov, int write_chunk_niov,
               int max_rdma_reply_chunk, ...)
```

and the same two args on every generated `send_call_*` (right after `max_rdma_write_chunk`). When supplied (RDMA, single contiguous registered iovec), the reply's RDMA write chunk lands directly in the caller's buffer; `NULL`/`0` keeps the internally-allocated chunk (prior behaviour).

## Changes
- `evpl_rpc2_call` gains `write_chunk_iov`/`write_chunk_niov`; the borrow path uses them directly.
- **xdrzcc bumped** (chimera-nas/xdrzcc#9) to emit and forward the two params on every `send_call_*`.
- Removed `evpl_rpc2_conn_set_write_chunk_dest` and the `conn->write_chunk_dest_*` fields.
- rpc2 test call sites pass `NULL`/`0`; `rdma_ddp` read_into passes its buffer through the new argument.

Net **−30 lines** vs the side-channel. The TCP_RDMA emulation send-framing fix from #85 is untouched. All 7 rpc2 tests pass (incl. the `rdma_ddp` read_into + follow-up regression guard).

## Dependencies
- Bumps `ext/xdrzcc` to chimera-nas/xdrzcc#9 (re-bump to xdrzcc main after it merges).
- Consumed by chimera's read_into Phase 2 PR (all ~70 NFS `send_call` sites updated there).