### PR TITLE
core: clear iovec_send_framed on bind teardown (fixes nfs3rdma read crash)

### DIFF
--- a/src/core/bind.c
+++ b/src/core/bind.c
@@ -201,7 +201,11 @@ evpl_finish(
 
     bind->flags |= EVPL_BIND_FINISH;
 
-    if (evpl_iovec_ring_is_empty(&bind->iovec_send)) {
+    /* Close once nothing is left to send.  Transports that frame their output
+     * (TCP_RDMA) hold ready-to-write bytes in iovec_send_framed, so it must be
+     * drained too, not just the raw iovec_send staging ring. */
+    if (evpl_iovec_ring_is_empty(&bind->iovec_send) &&
+        evpl_iovec_ring_is_empty(&bind->iovec_send_framed)) {
         evpl_close(evpl, bind);
     }
 
@@ -226,6 +230,7 @@ evpl_bind_destroy(
 
     evpl_iovec_ring_clear(evpl, &bind->iovec_recv);
     evpl_iovec_ring_clear(evpl, &bind->iovec_send);
+    evpl_iovec_ring_clear(evpl, &bind->iovec_send_framed);
     evpl_dgram_ring_clear(evpl, &bind->dgram_send);
     evpl_dgram_ring_clear(evpl, &bind->dgram_read);
 


### PR DESCRIPTION
## Bug

#85 added `bind->iovec_send_framed` — the framed, ready-to-write output ring the TCP_RDMA emulation drains — but didn't give it the same teardown handling as the sibling `iovec_send` ring:

- **`evpl_bind_destroy()` cleared `iovec_send` but not `iovec_send_framed`.** A bind torn down with framed output still queued (the common case under connection churn — the last reply not yet on the wire) leaked those iovec refs and, because the ring head/tail were never reset, left **stale entries that the next connection to recycle the bind drains → use-after-free.** This is the intermittent crash on `nfs3rdma` read tests, which churn connections and frame every READ reply into a write chunk.
- **`evpl_finish()` closed once `iovec_send` was empty**, but a framing transport's pending bytes live in `iovec_send_framed`, so it could close with reply data still unsent.

Both surfaced as intermittent `posix/*_nfs3rdma_*` failures (test logic passes, then the process aborts during teardown/reconnect) — e.g. `fgets_nfs3rdma_diskfs_io_uring`, `frewind_nfs3rdma_linux`.

## Fix

Clear and check `iovec_send_framed` alongside `iovec_send` in `evpl_bind_destroy()` and `evpl_finish()`. Non-framing transports never populate it, so the added checks are no-ops for them.

## Validation

Full `nfs3rdma` posix suite (**274 tests**) runs clean under Debug/**ASan** in parallel (the bind-recycle path heavily exercised); Release green. The original crash is connection-recycle-timing dependent and didn't reproduce locally, but the omission is unambiguous against the sibling ring's handling.

Follow-up to #85 / #87.