### PR TITLE
vfio: zero the NVMe CQ buffer at queue creation

### DIFF
--- a/src/core/vfio/vfio.c
+++ b/src/core/vfio/vfio.c
@@ -656,6 +656,18 @@ evpl_vfio_queue_alloc(
     queue->cq_doorbell = queue->sq_doorbell + device->dbstride;
     queue->callbacks   = evpl_zalloc(size * sizeof(struct evpl_vfio_callback_ctx));
 
+    /*
+     * The CQ buffer comes from evpl_valloc(), which does not zero memory.  The
+     * NVMe phase-bit protocol requires the CQ to start zeroed: a slot is a fresh
+     * completion when its phase bit differs from queue->cq_phase (which starts 0
+     * here via evpl_zalloc).  An uninitialized slot with a stale phase bit of 1
+     * is otherwise read as a bogus completion (garbage cid -> out-of-bounds
+     * callbacks[] access) before the controller ever writes a real one.  This
+     * only bites once enough queues have been created that the allocator hands
+     * back recycled, non-zero memory.
+     */
+    memset(queue->cq, 0, size * sizeof(struct nvme_cq_entry));
+
     if (id > 0) {
         queue->eventfd = device->eventfds[id - 1];
     } else {


### PR DESCRIPTION
The completion-queue buffer is allocated via `evpl_valloc()`, which returns uninitialized memory, and was never zeroed.

The NVMe phase-bit protocol requires the CQ to start zeroed: `poll_queue` treats a slot as a fresh completion when its phase bit differs from `queue->cq_phase` (which starts at 0 via `evpl_zalloc`). An uninitialized slot whose stale phase bit happens to be 1 is read as a bogus completion before the controller ever writes a real one — yielding a garbage `cid` (observed in the wild: `26219`, far past the queue depth) that then indexes `queue->callbacks[]` out of bounds, crashing or hanging I/O on that queue.

This only manifests once enough I/O queues have been created that the allocator starts handing back recycled, non-zero memory — e.g. the userspace fio engine driving diskfs directly, which opens a queue per `(thread, device)` across many threads. Early queues get fresh zeroed pages and work; later queues get dirty memory and read a phantom completion on the first poll. Processes that create their queues once at startup (e.g. a long-lived server) rarely churn the allocator enough to hit it, which is why this hid for so long.

The fix zeroes the CQ buffer in `evpl_vfio_queue_alloc`, which covers both the admin and I/O completion queues (shared path). The SQ needs no equivalent change: it is host-written/controller-read (no phase-bit read-before-write hazard), and every submitter fully initializes its command — the admin builders `memset` the command, and the read/write/flush builders set every dword explicitly.