### PR TITLE
block: add discard (deallocate) and write_zeroes ops

### DIFF
--- a/include/evpl/evpl_block.h
+++ b/include/evpl/evpl_block.h
@@ -65,3 +65,32 @@ void evpl_block_flush(
     struct evpl_block_queue *queue,
     evpl_block_callback_t    callback,
     void                    *private_data);
+
+/*
+ * Discard (deallocate / unmap / TRIM) the byte range [offset, offset+length).
+ * This is an advisory hint that the range is no longer needed: the backend may
+ * drop its mappings for it (NVMe Dataset Management Deallocate), but is not
+ * required to, and the data read back afterwards is unspecified.  Backends that
+ * cannot discard treat it as a successful no-op.
+ */
+void evpl_block_discard(
+    struct evpl             *evpl,
+    struct evpl_block_queue *queue,
+    uint64_t                 offset,
+    uint64_t                 length,
+    evpl_block_callback_t    callback,
+    void                    *private_data);
+
+/*
+ * Write zeros to the byte range [offset, offset+length).  Unlike discard this
+ * is a data guarantee: the range reads back as zeros afterwards.  Backends with
+ * native support use it (NVMe Write Zeroes); the rest emulate it with an
+ * ordinary write from an internal zero buffer.
+ */
+void evpl_block_write_zeroes(
+    struct evpl             *evpl,
+    struct evpl_block_queue *queue,
+    uint64_t                 offset,
+    uint64_t                 length,
+    evpl_block_callback_t    callback,
+    void                    *private_data);

--- a/src/core/block.c
+++ b/src/core/block.c
@@ -4,6 +4,7 @@
 
 #include <pthread.h>
 #include <time.h>
+#include <string.h>
 
 #include "core/evpl_shared.h"
 #include "core/macros.h"
@@ -287,3 +288,147 @@ evpl_block_flush(
 
     queue->flush(evpl, queue, evpl_block_complete, op);
 } /* evpl_block_flush */
+
+SYMBOL_EXPORT void
+evpl_block_discard(
+    struct evpl *evpl,
+    struct evpl_block_queue *queue,
+    uint64_t offset,
+    uint64_t length,
+    void ( *callback )(struct evpl *evpl, int status, void *private_data),
+    void *private_data)
+{
+    struct evpl_block_op *op;
+
+    if (!queue->discard) {
+        /* Advisory hint; a backend that cannot discard succeeds as a no-op. */
+        callback(evpl, 0, private_data);
+        return;
+    }
+
+    op               = evpl_block_op_get(queue);
+    op->queue        = queue;
+    op->callback     = callback;
+    op->private_data = private_data;
+    op->size         = length;
+
+    prometheus_stopwatch_start(&op->start);
+    prometheus_gauge_add(queue->m_queue_depth, 1);
+
+    queue->discard(evpl, queue, offset, length, evpl_block_complete, op);
+} /* evpl_block_discard */
+
+/* Emulated write-zeroes: an ordinary write from an internal zero buffer, for
+ * backends without a native zeroing op.  One reusable zero chunk is written
+ * across the range; the chunk's view length is trimmed for a short final
+ * write.  Serial (one write outstanding) -- this is a cold/setup path. */
+struct evpl_block_wz_emul {
+    struct evpl_block_queue *queue;
+    struct evpl_iovec        zero;
+    uint64_t                 offset;
+    uint64_t                 remaining;
+    unsigned int             chunk;
+    int                      status;
+    evpl_block_callback_t    callback;
+    void                    *private_data;
+};
+
+static void evpl_block_wz_emul_step(
+    struct evpl               *evpl,
+    struct evpl_block_wz_emul *e);
+
+static void
+evpl_block_wz_emul_done(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct evpl_block_wz_emul *e = private_data;
+
+    if (status) {
+        e->status = status;
+    }
+
+    if (e->status || e->remaining == 0) {
+        evpl_block_callback_t callback     = e->callback;
+        void                 *cb_private   = e->private_data;
+        int                   final_status = e->status;
+
+        evpl_iovec_release(evpl, &e->zero);
+        evpl_free(e);
+        callback(evpl, final_status, cb_private);
+        return;
+    }
+
+    evpl_block_wz_emul_step(evpl, e);
+} /* evpl_block_wz_emul_done */
+
+static void
+evpl_block_wz_emul_step(
+    struct evpl               *evpl,
+    struct evpl_block_wz_emul *e)
+{
+    uint64_t n   = e->remaining < e->chunk ? e->remaining : e->chunk;
+    uint64_t off = e->offset;
+
+    e->zero.length = (unsigned int) n;
+    e->offset     += n;
+    e->remaining  -= n;
+
+    evpl_block_write(evpl, e->queue, &e->zero, 1, off, 0,
+                     evpl_block_wz_emul_done, e);
+} /* evpl_block_wz_emul_step */
+
+SYMBOL_EXPORT void
+evpl_block_write_zeroes(
+    struct evpl *evpl,
+    struct evpl_block_queue *queue,
+    uint64_t offset,
+    uint64_t length,
+    void ( *callback )(struct evpl *evpl, int status, void *private_data),
+    void *private_data)
+{
+    struct evpl_block_op      *op;
+    struct evpl_block_wz_emul *e;
+    unsigned int               chunk;
+
+    if (queue->write_zeroes) {
+        op               = evpl_block_op_get(queue);
+        op->queue        = queue;
+        op->callback     = callback;
+        op->private_data = private_data;
+        op->size         = length;
+
+        prometheus_stopwatch_start(&op->start);
+        prometheus_gauge_add(queue->m_queue_depth, 1);
+
+        queue->write_zeroes(evpl, queue, offset, length,
+                            evpl_block_complete, op);
+        return;
+    }
+
+    if (length == 0) {
+        callback(evpl, 0, private_data);
+        return;
+    }
+
+    /* No native support: write a zero buffer through the ordinary write path,
+     * chunked at the device's maximum request size.  The underlying writes
+     * carry their own op-tracking/metrics, so no block_op is taken here. */
+    chunk = (unsigned int) (length < queue->device->max_request_size ?
+                            length : queue->device->max_request_size);
+
+    e               = evpl_zalloc(sizeof(*e));
+    e->queue        = queue;
+    e->offset       = offset;
+    e->remaining    = length;
+    e->chunk        = chunk;
+    e->status       = 0;
+    e->callback     = callback;
+    e->private_data = private_data;
+
+    evpl_iovec_alloc(evpl, chunk, 4096, 1, 0, &e->zero);
+    memset(e->zero.data, 0, chunk);
+
+    evpl_block_wz_emul_step(evpl, e);
+} /* evpl_block_write_zeroes */

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -244,6 +244,24 @@ struct evpl_block_queue {
         struct evpl_block_queue *queue,
         evpl_block_callback_t    callback,
         void                    *private_data);
+
+    /* Discard/deallocate a range (optional; NULL => core treats as no-op). */
+    void                                  (*discard)(
+        struct evpl             *evpl,
+        struct evpl_block_queue *queue,
+        uint64_t                 offset,
+        uint64_t                 length,
+        evpl_block_callback_t    callback,
+        void                    *private_data);
+
+    /* Write zeros to a range (optional; NULL => core emulates via write). */
+    void                                  (*write_zeroes)(
+        struct evpl             *evpl,
+        struct evpl_block_queue *queue,
+        uint64_t                 offset,
+        uint64_t                 length,
+        evpl_block_callback_t    callback,
+        void                    *private_data);
 };
 
 struct evpl_block_protocol {

--- a/src/core/vfio/vfio.c
+++ b/src/core/vfio/vfio.c
@@ -1396,6 +1396,133 @@ evpl_vfio_flush(
 } /* evpl_vfio_flush */
 
 static void
+evpl_vfio_discard(
+    struct evpl             *evpl,
+    struct evpl_block_queue *bqueue,
+    uint64_t                 offset,
+    uint64_t                 length,
+    evpl_block_callback_t    callback,
+    void                    *private_data)
+{
+    struct evpl_vfio_queue  *queue  = bqueue->private_data;
+    struct evpl_vfio_device *device = queue->device;
+    struct nvme_command_dsm *cmd;
+    struct nvme_dsm_range   *ranges;
+    uint64_t                 slba = offset >> device->sector_shift;
+    uint64_t                 nlba = length >> device->sector_shift;
+    int                      cid, nr = 0;
+
+    evpl_activity(evpl);
+
+    if (queue->poll_mode) {
+        evpl_poll_pin(evpl);
+    }
+
+    cid = evpl_vfio_alloc_cid(queue, callback, private_data);
+
+    /* Build the deallocate range list in this cid's 4 KiB prplist scratch.
+     * A DSM range length is a 32-bit LBA count, so split larger spans; the
+     * list is bounded to 256 ranges (one page), which covers any single
+     * device in one command. */
+    ranges = (struct nvme_dsm_range *) (queue->prplist->buffer + (cid << 12));
+
+    while (nlba && nr < 256) {
+        uint64_t this_lba = nlba > 0xFFFFFFFFULL ? 0xFFFFFFFFULL : nlba;
+
+        ranges[nr].attrs  = 0;
+        ranges[nr].length = (uint32_t) this_lba;
+        ranges[nr].lba    = slba;
+
+        slba += this_lba;
+        nlba -= this_lba;
+        nr++;
+    }
+
+    evpl_vfio_abort_if(nlba, "Discard range too large for one DSM command "
+                       "(%lu LBAs remain after 256 ranges)", nlba);
+
+    cmd = &queue->sq[cid].dsm;
+
+    cmd->common.opc    = NVME_CMD_DATASET_MANAGEMENT;
+    cmd->common.fuse   = 0;
+    cmd->common.rsvd   = 0;
+    cmd->common.psdt   = 0;
+    cmd->common.cid    = cid;
+    cmd->common.cdw2_3 = 0;
+    cmd->common.mptr   = 0;
+    cmd->common.nsid   = 1;
+    cmd->common.prp1   = queue->prplist->iova + (cid << 12);
+    cmd->common.prp2   = 0;
+    cmd->nr            = nr - 1;
+    cmd->idr           = 0;
+    cmd->idw           = 0;
+    cmd->ad            = 1;
+    cmd->rsrvd11       = 0;
+    cmd->rsrvd12[0]    = 0;
+    cmd->rsrvd12[1]    = 0;
+    cmd->rsrvd12[2]    = 0;
+    cmd->rsrvd12[3]    = 0;
+
+    evpl_defer(evpl, &queue->ring_sq);
+} /* evpl_vfio_discard */
+
+static void
+evpl_vfio_write_zeroes(
+    struct evpl             *evpl,
+    struct evpl_block_queue *bqueue,
+    uint64_t                 offset,
+    uint64_t                 length,
+    evpl_block_callback_t    callback,
+    void                    *private_data)
+{
+    struct evpl_vfio_queue  *queue  = bqueue->private_data;
+    struct evpl_vfio_device *device = queue->device;
+    struct nvme_command_wz  *cmd;
+    uint64_t                 nlba = length >> device->sector_shift;
+    int                      cid;
+
+    evpl_activity(evpl);
+
+    if (queue->poll_mode) {
+        evpl_poll_pin(evpl);
+    }
+
+    /* NLB is a 16-bit, 0's-based LBA count: one command spans 1..65536 LBAs.
+     * Callers needing a larger span issue multiple write-zeroes. */
+    evpl_vfio_abort_if(nlba == 0 || nlba > 0x10000ULL,
+                       "Write-zeroes span %lu LBAs out of range (1..65536)",
+                       nlba);
+
+    cid = evpl_vfio_alloc_cid(queue, callback, private_data);
+
+    cmd = &queue->sq[cid].wz;
+
+    cmd->common.opc    = NVME_CMD_WRITE_ZEROES;
+    cmd->common.fuse   = 0;
+    cmd->common.rsvd   = 0;
+    cmd->common.psdt   = 0;
+    cmd->common.cid    = cid;
+    cmd->common.cdw2_3 = 0;
+    cmd->common.mptr   = 0;
+    cmd->common.nsid   = 1;
+    cmd->common.prp1   = 0;
+    cmd->common.prp2   = 0;
+    cmd->slba          = offset >> device->sector_shift;
+    cmd->nlb           = (uint16_t) (nlba - 1);
+    cmd->rsvd12        = 0;
+    cmd->deac          = 0;
+    cmd->prinfo        = 0;
+    cmd->fua           = 0;
+    cmd->lr            = 0;
+    cmd->rsvd13        = 0;
+    cmd->eilbrt        = 0;
+    cmd->elbat         = 0;
+    cmd->elbatm        = 0;
+
+    evpl_defer(evpl, &queue->ring_sq);
+} /* evpl_vfio_write_zeroes */
+
+static void
 evpl_vfio_close_queue(
     struct evpl             *evpl,
     struct evpl_block_queue *bqueue)
@@ -1572,6 +1699,8 @@ evpl_vfio_open_queue(
     bqueue->read         = evpl_vfio_read;
     bqueue->write        = evpl_vfio_write;
     bqueue->flush        = evpl_vfio_flush;
+    bqueue->discard      = evpl_vfio_discard;
+    bqueue->write_zeroes = evpl_vfio_write_zeroes;
 
     /*
      * In poll mode the completion queue is reaped by the poll callback and the


### PR DESCRIPTION
Adds two block-layer data ops alongside `read`/`write`/`flush`:

- `evpl_block_discard(offset, length)` — advisory deallocate / unmap / TRIM. A hint that the range is no longer needed; the post-discard read value is unspecified.
- `evpl_block_write_zeroes(offset, length)` — a data guarantee: the range reads back as zeros.

## Design

The queue gains two optional function pointers (`discard`, `write_zeroes`), and the core provides fallbacks so a backend only implements what it can do natively:

- **discard** with no backend support → successful **no-op** (it is only a hint, and a deallocated range reads back unspecified anyway).
- **write_zeroes** with no backend support → **emulated** with an ordinary `write` from an internal zero buffer, chunked at the device's max request size, so every backend honors the zero-on-read guarantee.

## Backends

- **VFIO/NVMe** implements both natively:
  - discard → **Dataset Management Deallocate** (opc `0x09`, `AD=1`). The range list is built in the existing per-cid `prplist` scratch page; a span is split across 32-bit-LBA ranges (≤256 ranges = one page), which covers any single device in one command.
  - write_zeroes → **Write Zeroes** (opc `0x08`) for a span up to one 16-bit `NLB` command (1..65536 LBAs); larger spans issue multiple commands.
- **libaio / io_uring / io_uring_nvme** leave both pointers NULL and inherit the core fallbacks (no-op discard, write-emulated write_zeroes). Their queue structs are `evpl_zalloc`'d, so the pointers are reliably NULL.

The structs were already present in `nvme.h` (`nvme_command_dsm`, `nvme_dsm_range`, `nvme_command_wz`); this wires the ops up.

The motivating consumer is diskfs, which will deallocate whole devices at `initialize` (mkfs) to start each run on a clean slate (drops stale FTL mappings → resets GC/wear state → reproducible cold-cache behavior). That lands in a chimera PR once this merges and the submodule is bumped.