### PR TITLE
core: add per-thread event-loop hooks (iteration_end / pre_wait / post_wait)

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -96,6 +96,39 @@ Stop a running event loop. Causes `evpl_run()` to return.
 
 **Thread Safety:** Can be called from any thread
 
+#### `evpl_set_loop_hooks`
+
+```c
+typedef void (*evpl_loop_callback_t)(struct evpl *evpl, void *private_data);
+
+struct evpl_loop_hooks {
+    evpl_loop_callback_t iteration_end; /* end of every evpl_continue() pass */
+    evpl_loop_callback_t pre_wait;      /* before the core wait (may block)  */
+    evpl_loop_callback_t post_wait;     /* after the core wait returns       */
+    void                *private_data;
+};
+
+void evpl_set_loop_hooks(struct evpl *evpl, const struct evpl_loop_hooks *hooks);
+```
+
+Install (or replace) a set of callbacks that `evpl_continue()` invokes at fixed points in each iteration of the loop, so an application can interleave per-iteration bookkeeping with the loop without taking it over. Passing `NULL` clears any previously installed hooks.
+
+The hooks are copied into the event loop. Each member is optional — a `NULL` member is skipped — so there is no cost unless a hook is set, and applications that never call this function are unaffected.
+
+| Hook | Invoked |
+| --- | --- |
+| `iteration_end` | At the end of every `evpl_continue()` pass. |
+| `pre_wait` | Immediately before the (possibly blocking) core wait. |
+| `post_wait` | Immediately after the core wait returns. |
+
+**Parameters:**
+- `evpl` - Event loop to install the hooks on
+- `hooks` - Hook set to install (copied), or `NULL` to clear
+
+**Thread Safety:** Must be called from the same thread that owns the event loop.
+
+**Example — userspace-RCU (QSBR):** a reader thread maps `iteration_end` to `rcu_quiescent_state()` and brackets the core wait with `pre_wait` → `rcu_thread_offline()` and `post_wait` → `rcu_thread_online()`, so a thread asleep in the wait announces no quiescent states yet does not hold up RCU grace periods for other threads.
+
 ---
 
 ### Metrics

--- a/include/evpl/evpl_core.h
+++ b/include/evpl/evpl_core.h
@@ -75,6 +75,32 @@ void evpl_continue(
 void evpl_run(
     struct evpl *evpl);
 
+typedef void (*evpl_loop_callback_t)(
+    struct evpl *evpl,
+    void        *private_data);
+
+/*
+ * Per-thread event-loop hooks, invoked by evpl_continue() at fixed points so an
+ * application can interleave per-iteration bookkeeping with the loop.  All
+ * members are optional (NULL is skipped), so there is no cost unless set.
+ *
+ * The motivating use is userspace-RCU in QSBR mode: iteration_end maps to
+ * rcu_quiescent_state(), and pre_wait/post_wait bracket the (possibly blocking)
+ * core wait with rcu_thread_offline()/rcu_thread_online() so a thread asleep in
+ * the wait does not hold up grace periods.
+ */
+struct evpl_loop_hooks {
+    evpl_loop_callback_t iteration_end; /* end of every evpl_continue() pass   */
+    evpl_loop_callback_t pre_wait;      /* before the core wait (may block)    */
+    evpl_loop_callback_t post_wait;     /* after the core wait returns         */
+    void                *private_data;
+};
+
+/* Install (replace, or clear with NULL) this thread's loop hooks. */
+void evpl_set_loop_hooks(
+    struct evpl                  *evpl,
+    const struct evpl_loop_hooks *hooks);
+
 void evpl_stop(
     struct evpl *evpl);
 

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -535,7 +535,15 @@ evpl_continue(struct evpl *evpl)
             msecs = 0;
         }
 
+        if (evpl->loop_hooks.pre_wait) {
+            evpl->loop_hooks.pre_wait(evpl, evpl->loop_hooks.private_data);
+        }
+
         n = evpl_core_wait(&evpl->core, msecs);
+
+        if (evpl->loop_hooks.post_wait) {
+            evpl->loop_hooks.post_wait(evpl, evpl->loop_hooks.private_data);
+        }
 
         if (evpl->pending_close_binds && n == 0) {
             struct evpl_bind *next;
@@ -602,6 +610,10 @@ evpl_continue(struct evpl *evpl)
         deferral->callback(evpl, deferral->private_data);
     }
 
+    if (evpl->loop_hooks.iteration_end) {
+        evpl->loop_hooks.iteration_end(evpl, evpl->loop_hooks.private_data);
+    }
+
 } /* evpl_continue */
 
 SYMBOL_EXPORT void
@@ -644,6 +656,18 @@ evpl_run(struct evpl *evpl)
         evpl_continue(evpl);
     }
 } /* evpl_run */
+
+SYMBOL_EXPORT void
+evpl_set_loop_hooks(
+    struct evpl                  *evpl,
+    const struct evpl_loop_hooks *hooks)
+{
+    if (hooks) {
+        evpl->loop_hooks = *hooks;
+    } else {
+        memset(&evpl->loop_hooks, 0, sizeof(evpl->loop_hooks));
+    }
+} /* evpl_set_loop_hooks */
 
 SYMBOL_EXPORT void
 evpl_stop(struct evpl *evpl)

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -145,6 +145,8 @@ struct evpl {
 
     struct evpl_thread_config     config;
 
+    struct evpl_loop_hooks        loop_hooks;
+
     void                         *protocol_private[EVPL_NUM_PROTO];
     void                         *framework_private[EVPL_NUM_FRAMEWORK];
 };


### PR DESCRIPTION
Adds `evpl_set_loop_hooks()`, letting an application register up to three optional callbacks that `evpl_continue()` invokes at fixed points in the event loop:

| hook | when |
|---|---|
| `iteration_end` | end of every `evpl_continue()` pass |
| `pre_wait` | immediately before the (possibly blocking) core wait |
| `post_wait` | immediately after the core wait returns |

```c
struct evpl_loop_hooks {
    evpl_loop_callback_t iteration_end;
    evpl_loop_callback_t pre_wait;
    evpl_loop_callback_t post_wait;
    void                *private_data;
};
void evpl_set_loop_hooks(struct evpl *evpl, const struct evpl_loop_hooks *hooks);
```

All members are optional (NULL is skipped) and the hooks struct lives by value in `struct evpl` (zero-initialized at create), so there is no cost and no behavior change unless an application sets them.

## Motivation

The consumer is chimera's move to userspace-RCU **QSBR** mode, where read-side locks become free but every registered thread must announce quiescent states (or step out of the grace-period quorum while blocked). A reader maps:

- `iteration_end → rcu_quiescent_state()` — announce a quiescent state once per loop pass.
- `pre_wait → rcu_thread_offline()`, `post_wait → rcu_thread_online()` — bracket the core wait so a thread asleep in `epoll` (chimera's default `wait_ms` is -1) doesn't hold up grace periods for every other thread.

libevpl itself has no RCU dependency; this is a generic loop-callback mechanism that just happens to be exactly what a QSBR integration needs.