### PR TITLE
core/thread: stop managed threads via an evpl_thread-owned eventfd

### DIFF
--- a/src/core/thread/thread.c
+++ b/src/core/thread/thread.c
@@ -6,6 +6,7 @@
 #include <sys/eventfd.h>
 #include <unistd.h>
 #include <errno.h>
+#include <string.h>
 
 #include "core/evpl.h"
 #include "evpl/evpl.h"
@@ -37,6 +38,14 @@ struct evpl_thread {
     pthread_mutex_t                 lock;
     pthread_cond_t                  cond;
     int                             ready;
+    /* Stop signal.  Owned by evpl_thread (this struct outlives the worker's
+     * evpl, since it is freed only after pthread_join), so evpl_thread_destroy
+     * can stop the worker by writing this fd without ever dereferencing the
+     * worker's evpl -- which the worker creates, runs, and destroys entirely on
+     * its own thread.  The event is registered on the worker's evpl and its
+     * handler clears running from the worker thread. */
+    int                             stop_eventfd;
+    struct evpl_event               stop_event;
     struct evpl_thread_config      *config;
     struct evpl                    *evpl;
     evpl_thread_init_callback_t     init_callback;
@@ -49,6 +58,12 @@ struct evpl_threadpool {
     int                  nthreads;
 };
 
+/*
+ * Read handler for a thread's stop_eventfd, registered on the worker's own evpl.
+ * Runs on the worker thread, so it clears running directly (the same thread
+ * evpl_run() reads it on); the loop exits on its next iteration.  Direct
+ * assignment rather than evpl_stop() so it is idempotent if signaled twice.
+ */
 void
 evpl_thread_event(
     struct evpl       *evpl,
@@ -65,6 +80,7 @@ evpl_thread_event(
         evpl_event_mark_unreadable(evpl, event);
     }
 
+    evpl->running = 0;
 } /* evpl_thread_event */
 
 void *
@@ -76,6 +92,14 @@ evpl_thread_function(void *ptr)
     evpl = evpl_create(evpl_thread->config);
 
     evpl_thread->evpl = evpl;
+
+    /* Register the stop fd (created by evpl_thread_create) on our own evpl, so
+     * a write from evpl_thread_destroy wakes us and clears running on this
+     * thread.  Done before signaling ready so the event is always live by the
+     * time a destroyer can run. */
+    evpl_add_event(evpl, &evpl_thread->stop_event, evpl_thread->stop_eventfd,
+                   evpl_thread_event, NULL, NULL);
+    evpl_event_read_interest(evpl, &evpl_thread->stop_event);
 
     if (evpl_thread->init_callback) {
         evpl_thread->private_data = evpl_thread->init_callback(
@@ -89,6 +113,8 @@ evpl_thread_function(void *ptr)
     pthread_mutex_unlock(&evpl_thread->lock);
 
     evpl_run(evpl);
+
+    evpl_remove_event(evpl, &evpl_thread->stop_event);
 
     evpl_destroy_close_bind(evpl);
 
@@ -119,6 +145,10 @@ evpl_thread_create(
     evpl_thread->shutdown_callback = shutdown_function;
     evpl_thread->private_data      = private_data;
 
+    evpl_thread->stop_eventfd = eventfd(0, EFD_NONBLOCK);
+    evpl_thread_abort_if(evpl_thread->stop_eventfd < 0,
+                         "evpl_thread_create: eventfd failed");
+
     pthread_mutex_init(&evpl_thread->lock, NULL);
     pthread_cond_init(&evpl_thread->cond, NULL);
 
@@ -139,10 +169,23 @@ evpl_thread_create(
 SYMBOL_EXPORT void
 evpl_thread_destroy(struct evpl_thread *evpl_thread)
 {
-    evpl_stop(evpl_thread->evpl);
+    uint64_t value = 1;
+    ssize_t  len;
 
+    /* Signal stop via our own fd (never touch the worker's evpl, which the
+     * worker frees on its own thread); the worker's stop_event handler clears
+     * running.  Then join and only then close the fd. */
+    do {
+        len = write(evpl_thread->stop_eventfd, &value, sizeof(value));
+    } while (len < 0 && errno == EINTR);
+
+    evpl_thread_abort_if(len != sizeof(value),
+                         "evpl_thread_destroy: write to stop_eventfd failed: "
+                         "len=%zd errno=%d (%s)", len, errno, strerror(errno));
 
     pthread_join(evpl_thread->thread, NULL);
+
+    close(evpl_thread->stop_eventfd);
 
     evpl_free(evpl_thread);
 } /* evpl_thread_destroy */


### PR DESCRIPTION
## Problem

`evpl_thread_destroy()` stops a worker by calling `evpl_stop()` on the worker's `evpl`. `evpl_stop()` sets `running = 0` and *then* dereferences the evpl again to wake it:

```c
evpl->running = 0;
__sync_synchronize();
write(evpl->eventfd, ...)   // ← dereferences evpl after running=0
```

The worker loop is `while (evpl->running) evpl_continue(evpl)`, and on return it `evpl_destroy()`s its own evpl (freeing the struct and closing the eventfd). So between `running = 0` and the trailing `write(evpl->eventfd)`, the worker can observe the flag, exit `evpl_run()`, and free the evpl — and the destroyer thread's `evpl_stop()` then reads freed memory. ASan catches it as a flaky **heap-use-after-free in `evpl_stop`** at shutdown (it needs the preemption window between the two derefs).

## Approach

`evpl_destroy()` has to stay on the worker thread — it fires framework/bind teardown callbacks that aren't safe to run from another thread. So rather than patch the one window, make a managed thread's `evpl` **strictly thread-confined**: created, run, and destroyed entirely by its own worker, never touched by anyone else.

The stop is delivered through an eventfd **owned by `struct evpl_thread`** (whose lifetime the destroyer controls — it's freed only after `pthread_join`):

- `evpl_thread_create` creates `stop_eventfd`.
- The worker registers it on its own evpl (`evpl_add_event` + read interest), before signaling `ready`. The handler — the previously **dead** `evpl_thread_event`, now wired up — drains the fd and clears `running` on the worker thread.
- `evpl_thread_destroy` just `write()`s `stop_eventfd`, then `pthread_join`, then `close()`s it. It **never dereferences the worker's evpl**.

The UAF is gone by construction: nothing but the worker ever touches its evpl. (This also activates scaffolding that was already present-but-unused — `evpl_thread_event` — which suggests this was the originally intended shape.)

`evpl_stop()` is unchanged and still exported for standalone `evpl_run()` embedders; it just no longer has an internal caller.

## Validation

- `thread_basic` and `thread_threadpool_basic` pass; the threadpool create/run/destroy path runs clean **8×/8 under ASan** (Debug), including the new stop handshake.
- Motivating consumer: chimera's per-distro `Test` jobs were flaking on this exact `evpl_stop` UAF at shutdown (cthon/posix/s3 teardown); they should go green once the submodule is bumped.

No API or behavior change for existing callers; the change is internal to the managed-thread path.