### PR TITLE
core/poll: export evpl_activity / evpl_poll_pin / evpl_poll_unpin

### DIFF
--- a/docs/api/polls.md
+++ b/docs/api/polls.md
@@ -30,6 +30,8 @@ falling back to system-call-based waiting.
   (RDMA CQ, io_uring CQE, VFIO-NVMe, libaio, XLIO).
 - Pinning a worker thread on-CPU for a configured duration after the last
   request, in anticipation of more work.
+- Keeping a thread on-CPU for as long as it has work outstanding that can
+  only be reaped by polling (see [`evpl_poll_pin`](#evpl_poll_pin)).
 
 **Relation to doorbells:** a doorbell ring counts as activity, so it
 re-enters poll mode automatically. Combining a doorbell (for the wake) with
@@ -90,6 +92,83 @@ Detach a previously registered poll callback.
 **Parameters:**
 - `evpl` - Event loop the poll was attached to.
 - `poll` - Handle returned by `evpl_add_poll`.
+
+**Thread Safety:** Must be called from the thread that owns `evpl`.
+
+---
+
+### `evpl_poll_pin`
+
+```c
+void
+evpl_poll_pin(
+    struct evpl *evpl);
+```
+
+Pin the calling thread into poll mode. While the (refcounted) pin count is
+non-zero the event loop will not fall back to event-driven waiting after
+`spin_ns` of idleness — it keeps spinning and calling poll callbacks.
+
+Use this when the thread has work outstanding that can **only** be observed
+by polling — for example a request handed to another thread whose completion
+this thread reaps from a polled ring (RDMA CQ, io_uring CQE, VFIO-NVMe). If
+the loop were allowed to sleep in `epoll_wait()`, that completion would never
+wake it and the work would stall.
+
+**Parameters:**
+- `evpl` - Event loop to pin.
+
+**Thread Safety:** Must be called from the thread that owns `evpl`.
+
+**Behavior notes:**
+- Refcounted, so multiple independent sources of outstanding work on one
+  thread compose correctly. Each `evpl_poll_pin` must be balanced by exactly
+  one `evpl_poll_unpin`.
+- Pinning forces poll mode regardless of activity; it does not register a
+  poll callback. Pair it with `evpl_add_poll` to actually drain the polled
+  resource each iteration.
+
+---
+
+### `evpl_poll_unpin`
+
+```c
+void
+evpl_poll_unpin(
+    struct evpl *evpl);
+```
+
+Release one poll-mode pin taken with `evpl_poll_pin`. When the pin count
+returns to zero the loop is again free to fall back to event-driven waiting
+after `spin_ns` of idleness.
+
+**Parameters:**
+- `evpl` - Event loop to unpin.
+
+**Thread Safety:** Must be called from the thread that owns `evpl`.
+
+---
+
+### `evpl_activity`
+
+```c
+void
+evpl_activity(
+    struct evpl *evpl);
+```
+
+Mark that the loop did useful work this iteration. This resets the idleness
+timer that governs the fall-back from poll mode to event-driven waiting, so
+a poll-mode thread does not drop out of poll mode after `spin_ns` of
+*apparent* inactivity when it is in fact making progress.
+
+Call it after a poll callback services a polled resource (e.g. drains entries
+from a ring). Sources that already feed the event loop — sockets, doorbells,
+timers — record activity on their own; `evpl_activity` is for work discovered
+by polling that the loop would otherwise not see as activity.
+
+**Parameters:**
+- `evpl` - Event loop that did work.
 
 **Thread Safety:** Must be called from the thread that owns `evpl`.
 

--- a/include/evpl/evpl_poll.h
+++ b/include/evpl/evpl_poll.h
@@ -34,3 +34,23 @@ void
 evpl_remove_poll(
     struct evpl      *evpl,
     struct evpl_poll *poll);
+
+/* Mark loop activity so a poll-mode thread does not fall back to event mode
+ * after spin_ns of apparent inactivity (e.g. after servicing a polled ring). */
+void
+evpl_activity(
+    struct evpl *evpl);
+
+/*
+ * Pin the calling thread into poll mode while the (refcounted) pin count is
+ * non-zero.  Use when a thread has work outstanding that can only be observed
+ * by polling -- e.g. a request handed to another thread whose completion this
+ * thread reaps from a polled ring -- so the loop never sleeps and misses it.
+ */
+void
+evpl_poll_pin(
+    struct evpl *evpl);
+
+void
+evpl_poll_unpin(
+    struct evpl *evpl);

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -219,29 +219,17 @@ void
 evpl_destroy_close_bind(
     struct evpl *evpl);
 
-static inline void
-evpl_activity(struct evpl *evpl)
-{
-    evpl->activity++;
-} /* evpl_activity */
+/* Exported (defined in poll.c); also declared in the public evpl/evpl_poll.h so
+ * out-of-tree consumers can use them.  See evpl_poll.h for semantics. */
+void
+evpl_activity(
+    struct evpl *evpl);
 
-/*
- * Pin the calling thread into poll mode for as long as the pin count is
- * non-zero.  Used by frameworks (e.g. VFIO/NVMe in poll mode) that have an
- * outstanding request which can only be reaped by polling, since the loop
- * would otherwise fall back to interrupt/event mode after spin_ns of
- * inactivity and never reap the completion.  Refcounted so that multiple
- * queues on one thread compose correctly.
- */
-static inline void
-evpl_poll_pin(struct evpl *evpl)
-{
-    evpl->poll_pin_count++;
-} /* evpl_poll_pin */
+void
+evpl_poll_pin(
+    struct evpl *evpl);
 
-static inline void
-evpl_poll_unpin(struct evpl *evpl)
-{
-    evpl->poll_pin_count--;
-} /* evpl_poll_unpin */
+void
+evpl_poll_unpin(
+    struct evpl *evpl);
 

--- a/src/core/poll.c
+++ b/src/core/poll.c
@@ -40,3 +40,29 @@ evpl_remove_poll(
     evpl->num_poll--;
 
 } /* evpl_remove_poll */
+
+SYMBOL_EXPORT void
+evpl_activity(struct evpl *evpl)
+{
+    evpl->activity++;
+} /* evpl_activity */
+
+/*
+ * Pin the calling thread into poll mode for as long as the pin count is
+ * non-zero.  Used by frameworks (e.g. VFIO/NVMe in poll mode) that have an
+ * outstanding request which can only be reaped by polling, since the loop
+ * would otherwise fall back to interrupt/event mode after spin_ns of
+ * inactivity and never reap the completion.  Refcounted so that multiple
+ * queues on one thread compose correctly.
+ */
+SYMBOL_EXPORT void
+evpl_poll_pin(struct evpl *evpl)
+{
+    evpl->poll_pin_count++;
+} /* evpl_poll_pin */
+
+SYMBOL_EXPORT void
+evpl_poll_unpin(struct evpl *evpl)
+{
+    evpl->poll_pin_count--;
+} /* evpl_poll_unpin */


### PR DESCRIPTION
These three helpers were `static inline` in the internal `core/evpl.h`, so only in-tree code could use them.

Out-of-tree consumers need them too. Specifically the chimera diskfs intent-log is being converted to a fully poll-driven commit path, where a worker must:

- pin itself into poll mode (`evpl_poll_pin` / `evpl_poll_unpin`, refcounted) while it has a commit handed to another thread whose completion it reaps from a polled ring — so the loop never sleeps and misses it, and
- mark loop activity (`evpl_activity`) after servicing a polled ring, so a poll-mode thread does not fall back to event mode after `spin_ns` of apparent inactivity.

This promotes them to real `SYMBOL_EXPORT` functions in `core/poll.c` and declares them in the public `evpl/evpl_poll.h` (with doc comments). `core/evpl.h` keeps `extern` declarations for in-tree callers. No behavioral change — the bodies are identical to the former inline versions.