### PR TITLE
block: add op label to block latency/size histograms

### DIFF
--- a/src/core/block.c
+++ b/src/core/block.c
@@ -19,10 +19,19 @@
 struct evpl_block_op {
     struct prometheus_stopwatch start;
     uint64_t                    size;
+    enum evpl_block_op_kind kind;
     struct evpl_block_queue    *queue;
     evpl_block_callback_t       callback;
     void                       *private_data;
     struct evpl_block_op       *next;
+};
+
+/* "op" label values, indexed by enum evpl_block_op_kind. */
+static const char *const evpl_block_op_names[EVPL_BLOCK_NUM_OP_KIND] = {
+    [EVPL_BLOCK_OP_READ]    = "read",
+    [EVPL_BLOCK_OP_WRITE]   = "write",
+    [EVPL_BLOCK_OP_FLUSH]   = "flush",
+    [EVPL_BLOCK_OP_DISCARD] = "discard",
 };
 
 static inline uint64_t
@@ -65,10 +74,10 @@ evpl_block_complete(
     evpl_block_callback_t    callback;
     void                    *callback_private;
 
-    prometheus_time_histogram_sample(queue->m_latency, &op->start);
+    prometheus_time_histogram_sample(queue->m_latency[op->kind], &op->start);
 
     if (op->size) {
-        prometheus_histogram_sample(queue->m_request_size, op->size);
+        prometheus_histogram_sample(queue->m_request_size[op->kind], op->size);
     }
 
     prometheus_gauge_add(queue->m_queue_depth, -1);
@@ -125,17 +134,20 @@ evpl_block_open_device(
 
     /* Per-device metric series, labelled with the device URI and the
      * protocol type so callers can aggregate across all devices or
-     * break out by device/type.
+     * break out by device/type.  The histograms additionally carry an
+     * "op" label, so one series is created per operation class.
      */
-    blockdev->m_latency = prometheus_histogram_create_series(
-        evpl_shared->block_latency,
-        (const char *[]) { "device", "type" },
-        (const char *[]) { uri, protocol->name }, 2);
+    for (int k = 0; k < EVPL_BLOCK_NUM_OP_KIND; k++) {
+        blockdev->m_latency[k] = prometheus_histogram_create_series(
+            evpl_shared->block_latency,
+            (const char *[]) { "device", "type", "op" },
+            (const char *[]) { uri, protocol->name, evpl_block_op_names[k] }, 3);
 
-    blockdev->m_request_size = prometheus_histogram_create_series(
-        evpl_shared->block_request_size,
-        (const char *[]) { "device", "type" },
-        (const char *[]) { uri, protocol->name }, 2);
+        blockdev->m_request_size[k] = prometheus_histogram_create_series(
+            evpl_shared->block_request_size,
+            (const char *[]) { "device", "type", "op" },
+            (const char *[]) { uri, protocol->name, evpl_block_op_names[k] }, 3);
+    }
 
     blockdev->m_queue_depth = prometheus_gauge_create_series(
         evpl_shared->block_queue_depth,
@@ -148,10 +160,12 @@ evpl_block_open_device(
 SYMBOL_EXPORT void
 evpl_block_close_device(struct evpl_block_device *bdev)
 {
-    prometheus_histogram_destroy_series(evpl_shared->block_latency,
-                                        bdev->m_latency);
-    prometheus_histogram_destroy_series(evpl_shared->block_request_size,
-                                        bdev->m_request_size);
+    for (int k = 0; k < EVPL_BLOCK_NUM_OP_KIND; k++) {
+        prometheus_histogram_destroy_series(evpl_shared->block_latency,
+                                            bdev->m_latency[k]);
+        prometheus_histogram_destroy_series(evpl_shared->block_request_size,
+                                            bdev->m_request_size[k]);
+    }
     prometheus_gauge_destroy_series(evpl_shared->block_queue_depth,
                                     bdev->m_queue_depth);
 
@@ -188,10 +202,12 @@ evpl_block_open_queue(
     /* Each queue gets its own instance of the device's series so the
      * I/O path mutates them lock-free; the scrape sums instances.
      */
-    queue->m_latency = prometheus_histogram_series_create_instance(
-        blockdev->m_latency);
-    queue->m_request_size = prometheus_histogram_series_create_instance(
-        blockdev->m_request_size);
+    for (int k = 0; k < EVPL_BLOCK_NUM_OP_KIND; k++) {
+        queue->m_latency[k] = prometheus_histogram_series_create_instance(
+            blockdev->m_latency[k]);
+        queue->m_request_size[k] = prometheus_histogram_series_create_instance(
+            blockdev->m_request_size[k]);
+    }
     queue->m_queue_depth = prometheus_gauge_series_create_instance(
         blockdev->m_queue_depth);
 
@@ -206,10 +222,12 @@ evpl_block_close_queue(
     struct evpl_block_device *bdev = queue->device;
     struct evpl_block_op     *op;
 
-    prometheus_histogram_series_destroy_instance(bdev->m_latency,
-                                                 queue->m_latency);
-    prometheus_histogram_series_destroy_instance(bdev->m_request_size,
-                                                 queue->m_request_size);
+    for (int k = 0; k < EVPL_BLOCK_NUM_OP_KIND; k++) {
+        prometheus_histogram_series_destroy_instance(bdev->m_latency[k],
+                                                     queue->m_latency[k]);
+        prometheus_histogram_series_destroy_instance(bdev->m_request_size[k],
+                                                     queue->m_request_size[k]);
+    }
     prometheus_gauge_series_destroy_instance(bdev->m_queue_depth,
                                              queue->m_queue_depth);
 
@@ -238,6 +256,7 @@ evpl_block_read(
     op->callback     = callback;
     op->private_data = private_data;
     op->size         = evpl_block_iov_size(iov, niov);
+    op->kind         = EVPL_BLOCK_OP_READ;
 
     prometheus_stopwatch_start(&op->start);
     prometheus_gauge_add(queue->m_queue_depth, 1);
@@ -262,6 +281,7 @@ evpl_block_write(
     op->callback     = callback;
     op->private_data = private_data;
     op->size         = evpl_block_iov_size(iov, niov);
+    op->kind         = EVPL_BLOCK_OP_WRITE;
 
     prometheus_stopwatch_start(&op->start);
     prometheus_gauge_add(queue->m_queue_depth, 1);
@@ -282,6 +302,7 @@ evpl_block_flush(
     op->callback     = callback;
     op->private_data = private_data;
     op->size         = 0;
+    op->kind         = EVPL_BLOCK_OP_FLUSH;
 
     prometheus_stopwatch_start(&op->start);
     prometheus_gauge_add(queue->m_queue_depth, 1);
@@ -311,6 +332,7 @@ evpl_block_discard(
     op->callback     = callback;
     op->private_data = private_data;
     op->size         = length;
+    op->kind         = EVPL_BLOCK_OP_DISCARD;
 
     prometheus_stopwatch_start(&op->start);
     prometheus_gauge_add(queue->m_queue_depth, 1);
@@ -398,6 +420,7 @@ evpl_block_write_zeroes(
         op->callback     = callback;
         op->private_data = private_data;
         op->size         = length;
+        op->kind         = EVPL_BLOCK_OP_WRITE;
 
         prometheus_stopwatch_start(&op->start);
         prometheus_gauge_add(queue->m_queue_depth, 1);

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -160,6 +160,18 @@ struct evpl_protocol {
 
 /* API for a block protocol */
 
+/* Operation classes used to break out the per-device block histograms by
+ * an "op" label.  write_zeroes is accounted as a write.  Kept in sync with
+ * evpl_block_op_names[] in block.c.
+ */
+enum evpl_block_op_kind {
+    EVPL_BLOCK_OP_READ = 0,
+    EVPL_BLOCK_OP_WRITE,
+    EVPL_BLOCK_OP_FLUSH,
+    EVPL_BLOCK_OP_DISCARD,
+    EVPL_BLOCK_NUM_OP_KIND
+};
+
 struct evpl_block_device {
     /* Private data owned by the protocol */
     void                               *private_data;
@@ -176,9 +188,11 @@ struct evpl_block_device {
     /* Per-device metric series, labelled by device URI and protocol
      * type.  Each queue creates its own instance from these so the
      * hot path is mutated lock-free; the scrape aggregates instances.
+     * The histograms are further broken out by operation class via an
+     * "op" label, so they are one series per evpl_block_op_kind.
      */
-    struct prometheus_histogram_series *m_latency;
-    struct prometheus_histogram_series *m_request_size;
+    struct prometheus_histogram_series *m_latency[EVPL_BLOCK_NUM_OP_KIND];
+    struct prometheus_histogram_series *m_request_size[EVPL_BLOCK_NUM_OP_KIND];
     struct prometheus_gauge_series     *m_queue_depth;
 
     /* Open a device queue */
@@ -203,10 +217,11 @@ struct evpl_block_queue {
     struct evpl_block_device             *device;
 
     /* Per-queue metric instances, mutated only on this queue's thread
-     * (lock-free).  Created from the device's series at open.
+     * (lock-free).  Created from the device's series at open.  The
+     * histograms have one instance per evpl_block_op_kind.
      */
-    struct prometheus_histogram_instance *m_latency;
-    struct prometheus_histogram_instance *m_request_size;
+    struct prometheus_histogram_instance *m_latency[EVPL_BLOCK_NUM_OP_KIND];
+    struct prometheus_histogram_instance *m_request_size[EVPL_BLOCK_NUM_OP_KIND];
     struct prometheus_gauge_instance     *m_queue_depth;
 
     /* Freelist of completion-tracking ops; queue-thread-local. */


### PR DESCRIPTION
## What

Adds an `op` label (`read` / `write` / `flush` / `discard`) to the two per-device block histograms:

- `evpl_block_latency_nanoseconds`
- `evpl_block_request_bytes`

Previously these were labelled only by `device` and `type`, so every operation class was summed into a single distribution.

## Why

We're comparing client-observed fio latency against server block-level latency to quantify the transport/server overhead, separately for reads and writes. With no direction dimension on the block latency histogram, that split isn't possible from the metrics — reads, writes, flushes and discards all land in the same buckets. Adding the `op` label lets us break out device-level read vs write latency and overlay it on the client-side read/write distributions.

## How

- New `enum evpl_block_op_kind` (read/write/flush/discard) in `protocol.h`, with a matching name table in `block.c`.
- `evpl_block_device` / `evpl_block_queue` hold one histogram series/instance **per op kind** instead of a single one.
- The op kind is stamped on the in-flight `evpl_block_op` at submit and used to pick the right series at completion, so the I/O path stays lock-free (no shared state added).
- `write_zeroes` is accounted as a `write`.
- The `evpl_block_queue_depth` **gauge** is intentionally left aggregate (`device`/`type` only) — only the histograms gain the label.

Example scrape after the change:

```
evpl_block_latency_nanoseconds_bucket{device="01:00.0",type="vfio",op="read",le="7292"} ...
evpl_block_latency_nanoseconds_bucket{device="01:00.0",type="vfio",op="write",le="7292"} ...
```

## Testing

- `make release` — builds clean, **64/64** tests pass.
- Formatted with `etc/uncrustify.cfg`.

## Notes

- This adds cardinality: block histogram series count goes from `devices × 1` to `devices × 4` (one per op kind). With ~16 devices and 34 latency buckets that's well within normal Prometheus range.