### PR TITLE
http: HTTP/2 client and server, plus an HTTP/1.1 client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,19 @@ else()
     message(STATUS "xlio library not found.")
 endif()
 
+find_library(NGHTTP2_LIB NAMES nghttp2)
+find_path(NGHTTP2_INCLUDE_DIR NAMES nghttp2/nghttp2.h)
+
+if (NGHTTP2_LIB AND NGHTTP2_INCLUDE_DIR)
+    message(STATUS "nghttp2 library ${NGHTTP2_LIB}")
+    message(STATUS "nghttp2 include ${NGHTTP2_INCLUDE_DIR}")
+    include_directories(SYSTEM ${NGHTTP2_INCLUDE_DIR})
+    add_definitions(-DHAVE_NGHTTP2)
+    set(HAVE_NGHTTP2 1)
+else()
+    message(STATUS "nghttp2 library not found; HTTP/2 support disabled.")
+endif()
+
 add_definitions(-g -Wall -Werror -Wno-unused-function -DEVPL_MECH=${EVPL_MECH})
 add_definitions(-fvisibility=hidden)
 

--- a/include/evpl/evpl_http.h
+++ b/include/evpl/evpl_http.h
@@ -26,6 +26,18 @@ enum evpl_http_notify_type {
     EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE,
     EVPL_HTTP_NOTIFY_WANT_DATA,
     EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE,
+    /* Client direction only: the response status line and headers have been
+     * received and may be queried (evpl_http_request_status /
+     * evpl_http_response_header).  Fired before any RECEIVE_DATA. */
+    EVPL_HTTP_NOTIFY_RESPONSE_HEADERS,
+};
+
+/* Protocol version selection for a client connection. */
+enum evpl_http_version {
+    EVPL_HTTP_VERSION_AUTO,   /* HTTP/1.1, upgrading to h2 only if ALPN selects it */
+    EVPL_HTTP_VERSION_HTTP1,  /* force HTTP/1.1 */
+    EVPL_HTTP_VERSION_HTTP2,  /* force HTTP/2 (h2c prior-knowledge on TCP, or
+                               * require "h2" via ALPN on TLS) */
 };
 
 enum evpl_http_request_type {
@@ -135,3 +147,64 @@ void
 evpl_http_server_dispatch_default(
     struct evpl_http_request *request,
     int                       status);
+
+/*
+ * Client API
+ *
+ * The same request lifecycle and notify callbacks are used as for the server,
+ * but in the response direction:
+ *   EVPL_HTTP_NOTIFY_RESPONSE_HEADERS  - status + response headers received
+ *   EVPL_HTTP_NOTIFY_RECEIVE_DATA      - a chunk of the response body arrived
+ *   EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE  - the full response body was received
+ *   EVPL_HTTP_NOTIFY_WANT_DATA         - the request body may be extended
+ *   EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE - the request was fully transmitted
+ */
+
+struct evpl_http_conn *
+evpl_http_client_connect(
+    struct evpl_http_agent *agent,
+    enum evpl_protocol_id   protocol_id,
+    struct evpl_endpoint   *endpoint,
+    enum evpl_http_version  version,
+    void                   *private_data);
+
+void
+evpl_http_client_close(
+    struct evpl_http_agent *agent,
+    struct evpl_http_conn  *conn);
+
+struct evpl_http_request *
+evpl_http_request_create(
+    struct evpl_http_conn      *conn,
+    enum evpl_http_request_type method,
+    const char                 *url);
+
+void
+evpl_http_client_set_request_length(
+    struct evpl_http_request *request,
+    uint64_t                  content_length);
+
+void
+evpl_http_client_set_request_chunked(
+    struct evpl_http_request *request);
+
+void
+evpl_http_request_dispatch(
+    struct evpl_http_request   *request,
+    evpl_http_notify_callback_t notify_callback,
+    void                       *notify_data);
+
+int
+evpl_http_request_status(
+    struct evpl_http_request *request);
+
+const char *
+evpl_http_response_header(
+    struct evpl_http_request *request,
+    const char               *name);
+
+void
+evpl_http_response_header_iterate(
+    struct evpl_http_request     *request,
+    evpl_http_request_header_cb_t callback,
+    void                         *private_data);

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -203,6 +203,9 @@ void * evpl_zalloc(
 void * evpl_calloc(
     unsigned int n,
     unsigned int size);
+void * evpl_realloc(
+    void        *p,
+    unsigned int size);
 void * evpl_valloc(
     unsigned int size,
     unsigned int alignment);

--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -45,6 +45,20 @@ evpl_calloc(
 } /* evpl_calloc */
 
 SYMBOL_EXPORT void *
+evpl_realloc(
+    void        *p,
+    unsigned int size)
+{
+    void *np = realloc(p, size);
+
+    if (!np && size) {
+        evpl_core_fatal("Failed to reallocate %u bytes\n", size);
+    }
+
+    return np;
+} /* evpl_realloc */
+
+SYMBOL_EXPORT void *
 evpl_valloc(
     unsigned int size,
     unsigned int alignment)

--- a/src/core/tls/tls.c
+++ b/src/core/tls/tls.c
@@ -67,14 +67,94 @@ struct evpl_tls {
     struct evpl_event         event;
     int                       fd;
     SSL                      *ssl;
-    enum evpl_tls_state state;
+    enum evpl_tls_state       state;
     int                       is_server;
     int                       is_attached;
     int                       ktls_checked;
     struct evpl_tls_datagram *free_datagrams;
     struct evpl_iovec         recv1;
     struct evpl_iovec         recv2;
+    int                       alpn_len;
+    char                      alpn[16];
 };
+
+/*
+ * ALPN protocol list in OpenSSL wire format (each entry: 1-byte length followed
+ * by the protocol name), in client-preference / server-selection order.
+ * Process-wide; configured via evpl_tls_set_alpn_protocols() before the first
+ * TLS connection.
+ */
+static unsigned char evpl_tls_alpn_wire[256];
+static unsigned int  evpl_tls_alpn_wire_len;
+
+SYMBOL_EXPORT void
+evpl_tls_set_alpn_protocols(
+    const char *const *protocols,
+    int                count)
+{
+    unsigned int off = 0;
+    int          i;
+    size_t       plen;
+
+    for (i = 0; i < count; i++) {
+        plen = strlen(protocols[i]);
+        evpl_tls_abort_if(plen == 0 || plen > 255, "invalid ALPN protocol");
+        evpl_tls_abort_if(off + 1 + plen > sizeof(evpl_tls_alpn_wire),
+                          "ALPN protocol list too long");
+        evpl_tls_alpn_wire[off++] = (unsigned char) plen;
+        memcpy(&evpl_tls_alpn_wire[off], protocols[i], plen);
+        off += plen;
+    }
+
+    evpl_tls_alpn_wire_len = off;
+} /* evpl_tls_set_alpn_protocols */
+
+static int
+evpl_tls_alpn_select_cb(
+    SSL                  *ssl,
+    const unsigned char **out,
+    unsigned char        *outlen,
+    const unsigned char  *in,
+    unsigned int          inlen,
+    void                 *arg)
+{
+    /* SSL_select_next_proto wants a non-const "server" list; ours is static. */
+    if (evpl_tls_alpn_wire_len == 0) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    if (SSL_select_next_proto((unsigned char **) out, outlen,
+                              evpl_tls_alpn_wire, evpl_tls_alpn_wire_len,
+                              in, inlen) != OPENSSL_NPN_NEGOTIATED) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    return SSL_TLSEXT_ERR_OK;
+} /* evpl_tls_alpn_select_cb */
+
+SYMBOL_EXPORT int
+evpl_tls_get_alpn(
+    struct evpl_bind *bind,
+    char             *buf,
+    int               len)
+{
+    struct evpl_tls *t = evpl_bind_private(bind);
+    int              n = t->alpn_len;
+
+    if (n >= len) {
+        n = len - 1;
+    }
+
+    if (n > 0) {
+        memcpy(buf, t->alpn, n);
+    }
+
+    if (len > 0) {
+        buf[n > 0 ? n : 0] = '\0';
+    }
+
+    return t->alpn_len;
+} /* evpl_tls_get_alpn */
 
 #define evpl_event_tls(eventp) container_of((eventp), struct evpl_tls, event)
 
@@ -203,6 +283,10 @@ evpl_tls_create_ctx(int is_server)
         /* Default cipher list for kTLS */
         rc = SSL_CTX_set_cipher_list(ctx, "AES128-GCM-SHA256");
         evpl_tls_abort_if(rc <= 0, "Failed to set cipher list: AES128-GCM-SHA256");
+    }
+
+    if (is_server && evpl_tls_alpn_wire_len > 0) {
+        SSL_CTX_set_alpn_select_cb(ctx, evpl_tls_alpn_select_cb, NULL);
     }
 
     if (is_server) {
@@ -350,10 +434,21 @@ evpl_tls_handshake(
     }
 
     if (ret == 1) {
+        const unsigned char *alpn     = NULL;
+        unsigned int         alpn_len = 0;
+
         t->state = EVPL_TLS_STATE_CONNECTED;
         // Initially interested in both read and write
         evpl_event_read_interest(evpl, &t->event);
         evpl_event_write_interest(evpl, &t->event);
+
+        SSL_get0_alpn_selected(t->ssl, &alpn, &alpn_len);
+
+        if (alpn_len > 0 && alpn_len < sizeof(t->alpn)) {
+            memcpy(t->alpn, alpn, alpn_len);
+            t->alpn[alpn_len] = '\0';
+            t->alpn_len       = alpn_len;
+        }
 
         notify.notify_type   = EVPL_NOTIFY_CONNECTED;
         notify.notify_status = 0;
@@ -843,8 +938,13 @@ evpl_tls_init(
     t->ssl          = SSL_new(ssl_ctx);
     t->is_attached  = 0;
     t->ktls_checked = 0;
+    t->alpn_len     = 0;
 
     evpl_tls_abort_if(!t->ssl, "Failed to create SSL object");
+
+    if (!is_server && !is_listen && evpl_tls_alpn_wire_len > 0) {
+        SSL_set_alpn_protos(t->ssl, evpl_tls_alpn_wire, evpl_tls_alpn_wire_len);
+    }
 
     flags = fcntl(t->fd, F_GETFL, 0);
     evpl_tls_abort_if(flags < 0, "Failed to get socket flags: %s", strerror(errno));

--- a/src/core/tls/tls.h
+++ b/src/core/tls/tls.h
@@ -6,6 +6,30 @@
 
 struct evpl_protocol;
 struct evpl_framework;
+struct evpl_bind;
 
 extern struct evpl_framework evpl_framework_tls;
 extern struct evpl_protocol  evpl_socket_tls;
+
+/*
+ * Configure the ALPN protocol list (in client preference / server selection
+ * order, e.g. {"h2", "http/1.1"}) advertised on TLS connections.  Process-wide
+ * and intended to be set before the first TLS connection is established; the
+ * HTTP layer calls this to enable "h2" negotiation over TLS.  Passing count==0
+ * disables ALPN.
+ */
+void
+evpl_tls_set_alpn_protocols(
+    const char *const *protocols,
+    int                count);
+
+/*
+ * Return the ALPN protocol negotiated on a TLS bind into buf (NUL-terminated).
+ * Returns the protocol length, 0 if none was negotiated (or the bind is not a
+ * TLS connection that has completed its handshake).
+ */
+int
+evpl_tls_get_alpn(
+    struct evpl_bind *bind,
+    char             *buf,
+    int               len);

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -2,9 +2,19 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
-add_library(evpl_http SHARED http.c)
+set(HTTP_SRC http.c)
+
+if (HAVE_NGHTTP2)
+    set(HTTP_SRC ${HTTP_SRC} http2.c)
+endif()
+
+add_library(evpl_http SHARED ${HTTP_SRC})
 
 target_link_libraries(evpl_http evpl)
+
+if (HAVE_NGHTTP2)
+    target_link_libraries(evpl_http ${NGHTTP2_LIB})
+endif()
 
 install(TARGETS evpl_http DESTINATION lib)
 

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -5,105 +5,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <utlist.h>
 
-#include "core/evpl.h"
-#include "evpl/evpl.h"
-#include "core/iovec_ring.h"
-#include "evpl/evpl_http.h"
-
-#define evpl_http_debug(...) evpl_debug("http", __FILE__, __LINE__, __VA_ARGS__)
-#define evpl_http_info(...)  evpl_info("http", __FILE__, __LINE__, __VA_ARGS__)
-#define evpl_http_error(...) evpl_error("http", __FILE__, __LINE__, __VA_ARGS__)
-#define evpl_http_fatal(...) evpl_fatal("http", __FILE__, __LINE__, __VA_ARGS__)
-#define evpl_http_abort(...) evpl_abort("http", __FILE__, __LINE__, __VA_ARGS__)
-
-#define evpl_http_fatal_if(cond, ...) \
-        evpl_fatal_if(cond, "http", __FILE__, __LINE__, __VA_ARGS__)
-
-#define evpl_http_abort_if(cond, ...) \
-        evpl_abort_if(cond, "http", __FILE__, __LINE__, __VA_ARGS__)
-
-enum evpl_http_request_state {
-    EVPL_HTTP_REQUEST_STATE_INIT,
-    EVPL_HTTP_REQUEST_STATE_HEADERS,
-    EVPL_HTTP_REQUEST_STATE_BODY,
-    EVPL_HTTP_REQUEST_STATE_COMPLETE,
-};
-
-enum evpl_http_request_http_version {
-    EVPL_HTTP_REQUEST_HTTP_VERSION_1_0,
-    EVPL_HTTP_REQUEST_HTTP_VERSION_1_1,
-};
-
-enum evpl_http_request_transfer_encoding {
-    EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT,
-    EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED,
-};
-
-struct evpl_http_request_header {
-    struct evpl_http_request_header *prev;
-    struct evpl_http_request_header *next;
-    char                             name[256];
-    char                             value[16384];
-};
-
-#define EVPL_HTTP_REQUEST_WANTS_CONTINUE    0x01
-#define EVPL_HTTP_REQUEST_EXPECT_CHUNK_NL   0x02
-#define EVPL_HTTP_REQUEST_RESPONSE_READY    0x04
-#define EVPL_HTTP_REQUEST_RESPONSE_HDR_SENT 0x08
-#define EVPL_HTTP_REQUEST_RESPONSE_FINISHED 0x10
-
-struct evpl_http_request {
-    enum evpl_http_request_type              request_type;
-    enum evpl_http_request_state             request_state;
-    enum evpl_http_request_http_version      http_version;
-    enum evpl_http_request_transfer_encoding request_transfer_encoding;
-    enum evpl_http_request_transfer_encoding response_transfer_encoding;
-    evpl_http_notify_callback_t              notify_callback;
-    void                                    *notify_data;
-    uint64_t                                 request_length;
-    uint64_t                                 request_left;
-    uint64_t                                 request_chunk_left;
-    uint64_t                                 response_length;
-    uint64_t                                 response_left;
-    uint64_t                                 request_flags;
-    int                                      status;
-    int                                      uri_len;
-    struct evpl_http_conn                   *conn;
-    struct evpl_iovec_ring                   send_ring;
-    struct evpl_iovec_ring                   recv_ring;
-    struct evpl_http_request_header         *request_headers;
-    struct evpl_http_request_header         *response_headers;
-    struct evpl_http_request                *prev;
-    struct evpl_http_request                *next;
-    char                                     uri[16384];
-};
-
-struct evpl_http_conn {
-    int                       is_server;
-    struct evpl_http_server  *server;
-    struct evpl_http_agent   *agent;
-    struct evpl_bind         *bind;
-    struct evpl_deferral      flush;
-    struct evpl_http_request *current_request;
-    struct evpl_http_request *pending_requests;
-    void                     *private_data;
-};
-
-struct evpl_http_server {
-    struct evpl_http_agent       *agent;
-    struct evpl_listener         *listener;
-    struct evpl_listener_binding *binding;
-    void                         *private_data;
-    evpl_http_dispatch_callback_t dispatch_callback;
-};
-
-struct evpl_http_agent {
-    struct evpl_http_request        *free_requests;
-    struct evpl_http_request_header *free_headers;
-    struct evpl                     *evpl;
-};
+#include "http_internal.h"
+#include "core/tls/tls.h"
 
 static const char *http_version_string[] = {
     "HTTP/1.0",
@@ -201,86 +105,6 @@ evpl_http_response_status_string(int status)
     } /* switch */
 } /* evpl_http_response_status_string */
 
-static inline struct evpl_http_request_header *
-evpl_http_request_header_alloc(struct evpl_http_agent *agent)
-{
-    struct evpl_http_request_header *header;
-
-    header = agent->free_headers;
-
-    if (header) {
-        agent->free_headers = header->next;
-    } else {
-        header = evpl_zalloc(sizeof(*header));
-    }
-
-    return header;
-} /* evpl_http_request_header_alloc */
-
-static inline void
-evpl_http_request_header_free(
-    struct evpl_http_agent          *agent,
-    struct evpl_http_request_header *header)
-{
-    LL_PREPEND(agent->free_headers, header);
-} /* evpl_http_request_header_free */
-
-static inline struct evpl_http_request *
-evpl_http_request_alloc(struct evpl_http_agent *agent)
-{
-    struct evpl_http_request *request;
-
-    request = agent->free_requests;
-
-    if (request) {
-        agent->free_requests = request->next;
-    } else {
-        request = evpl_zalloc(sizeof(*request));
-        evpl_iovec_ring_alloc(&request->send_ring, 1024, 4096);
-        evpl_iovec_ring_alloc(&request->recv_ring, 1024, 4096);
-    }
-
-    request->request_type               = EVPL_HTTP_REQUEST_TYPE_UNKNOWN;
-    request->request_state              = EVPL_HTTP_REQUEST_STATE_INIT;
-    request->request_transfer_encoding  = EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT;
-    request->response_transfer_encoding = EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT;
-    request->request_length             = 0;
-    request->request_left               = 0;
-    request->request_chunk_left         = 0;
-    request->response_length            = 0;
-    request->response_left              = 0;
-    request->request_flags              = 0;
-    request->notify_callback            = NULL;
-    request->request_headers            = NULL;
-    request->response_headers           = NULL;
-    return request;
-} /* evpl_http_request_alloc */
-
-static inline void
-evpl_http_request_free(
-    struct evpl_http_agent   *agent,
-    struct evpl_http_request *request)
-{
-    struct evpl_http_request_header *header;
-
-    while (request->request_headers) {
-        header = request->request_headers;
-        DL_DELETE(request->request_headers, header);
-        evpl_http_request_header_free(agent, header);
-    }
-
-    while (request->response_headers) {
-        header = request->response_headers;
-        DL_DELETE(request->response_headers, header);
-        evpl_http_request_header_free(agent, header);
-    }
-
-    evpl_iovec_ring_clear(agent->evpl, &request->recv_ring);
-    evpl_iovec_ring_clear(agent->evpl, &request->send_ring);
-
-    LL_PREPEND(agent->free_requests, request);
-} /* evpl_http_request_free */
-
 SYMBOL_EXPORT struct evpl_http_agent *
 evpl_http_init(struct evpl *evpl)
 {
@@ -361,28 +185,114 @@ evpl_http_parse_line(
     return -1;
 } /* evpl_http_parse_line */
 
-static inline int
-evpl_copy_string(
-    char       *dst,
-    const char *src,
-    int         maxlen)
+/*
+ * Parse a body (Content-Length or chunked) from the wire into request->recv_ring
+ * and emit RECEIVE_DATA / RECEIVE_COMPLETE notifications.  Shared by the server
+ * (request body) and client (response body) HTTP/1.x paths: the only
+ * differences are which list the request lives on when complete (the caller
+ * handles that via the COMPLETE transition) and the private data passed to the
+ * callback.  Returns 0 on success, -1 if the connection was closed.
+ */
+static int
+evpl_http_handle_body(
+    struct evpl_http_conn    *conn,
+    struct evpl_http_request *request)
 {
-    const char *sp = src;
-    char       *dp = dst;
+    struct evpl_http_agent *agent = conn->agent;
+    struct evpl            *evpl  = agent->evpl;
+    struct evpl_bind       *bind  = conn->bind;
+    void                   *priv  = evpl_http_priv(conn);
+    int                     rc;
+    char                    line[4096];
 
-    while (*sp) {
+    if (request->request_transfer_encoding == EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT) {
+        int               niov;
+        struct evpl_iovec iov;
 
-        if (unlikely(dp - dst >= maxlen - 1)) {
-            return -1;
+        while (!evpl_iovec_ring_is_full(&request->recv_ring) && request->request_left > 0) {
+            niov = evpl_recvv(evpl, bind, &iov, 1, request->request_left, NULL);
+
+            if (niov == 0) {
+                break;
+            }
+
+            request->request_left -= iov.length;
+
+            evpl_iovec_ring_add(&request->recv_ring, &iov);
         }
 
-        *dp++ = *sp++;
+        if (request->notify_callback && evpl_iovec_ring_elements(&request->recv_ring) > 0) {
+            request->notify_callback(evpl, agent, request,
+                                     EVPL_HTTP_NOTIFY_RECEIVE_DATA,
+                                     request->request_type, request->uri,
+                                     request->notify_data, priv);
+        }
+
+        if (request->request_left == 0) {
+            request->request_state = EVPL_HTTP_REQUEST_STATE_COMPLETE;
+        }
+    } else {
+        int               niov;
+        uint64_t          received = 0;
+        struct evpl_iovec iov;
+
+        while (!evpl_iovec_ring_is_full(&request->recv_ring)) {
+
+            if (request->request_chunk_left > 0) {
+                niov = evpl_recvv(evpl, bind, &iov, 1, request->request_chunk_left, NULL);
+
+                if (niov == 0) {
+                    break;
+                }
+
+                request->request_chunk_left -= iov.length;
+                received                    += iov.length;
+
+                evpl_iovec_ring_add(&request->recv_ring, &iov);
+
+            } else {
+
+                rc = evpl_http_parse_line(evpl, bind, line, sizeof(line));
+
+                if (unlikely(rc == -2)) {
+                    evpl_close(evpl, bind);
+                    return -1;
+                }
+
+                if (rc == -1) {
+                    break;
+                }
+
+                if (request->request_flags & EVPL_HTTP_REQUEST_EXPECT_CHUNK_NL) {
+                    if (line[0] != '\0') {
+                        evpl_close(evpl, bind);
+                        return -1;
+                    }
+                    request->request_flags &= ~EVPL_HTTP_REQUEST_EXPECT_CHUNK_NL;
+                    continue;
+                }
+
+                request->request_chunk_left = strtoul(line, NULL, 16);
+                request->request_flags     |= EVPL_HTTP_REQUEST_EXPECT_CHUNK_NL;
+
+                if (request->request_chunk_left == 0) {
+                    request->request_state = EVPL_HTTP_REQUEST_STATE_COMPLETE;
+                    break;
+                }
+            }
+        }
+
+        if (request->notify_callback && received &&
+            request->request_state != EVPL_HTTP_REQUEST_STATE_COMPLETE) {
+            request->notify_callback(evpl, agent, request,
+                                     EVPL_HTTP_NOTIFY_RECEIVE_DATA,
+                                     request->request_type, request->uri,
+                                     request->notify_data, priv);
+        }
     }
 
-    *dp = '\0';
-
-    return dp - dst;
-} /* evpl_copy_string */
+    return 0;
+} /* evpl_http_handle_body */
 
 static void
 evpl_http_server_handle_data(struct evpl_http_conn *conn)
@@ -426,17 +336,9 @@ evpl_http_server_handle_data(struct evpl_http_conn *conn)
             return;
         }
 
-        if (strncmp(token, "GET", 3) == 0) {
-            request->request_type = EVPL_HTTP_REQUEST_TYPE_GET;
-        } else if (strncmp(token, "HEAD", 4) == 0) {
-            request->request_type = EVPL_HTTP_REQUEST_TYPE_HEAD;
-        } else if (strncmp(token, "POST", 4) == 0) {
-            request->request_type = EVPL_HTTP_REQUEST_TYPE_POST;
-        } else if (strncmp(token, "PUT", 3) == 0) {
-            request->request_type = EVPL_HTTP_REQUEST_TYPE_PUT;
-        } else if (strncmp(token, "DELETE", 6) == 0) {
-            request->request_type = EVPL_HTTP_REQUEST_TYPE_DELETE;
-        } else {
+        request->request_type = evpl_http_method_from_string(token);
+
+        if (request->request_type == EVPL_HTTP_REQUEST_TYPE_UNKNOWN) {
             evpl_http_debug("unsupported request type: %s", token);
             evpl_close(evpl, bind);
             return;
@@ -545,132 +447,278 @@ evpl_http_server_handle_data(struct evpl_http_conn *conn)
         goto again;
 
     } else if (request->request_state == EVPL_HTTP_REQUEST_STATE_BODY) {
-        if (request->request_transfer_encoding == EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT) {
-            int               niov;
-            struct evpl_iovec iov;
 
-            while (!evpl_iovec_ring_is_full(&request->recv_ring) && request->request_left > 0) {
-                niov = evpl_recvv(evpl, bind, &iov, 1, request->request_left, NULL);
+        if (evpl_http_handle_body(conn, request) < 0) {
+            return;
+        }
 
-                if (niov == 0) {
-                    break;
-                }
+        if (request->request_state == EVPL_HTTP_REQUEST_STATE_COMPLETE) {
+            DL_APPEND(conn->pending_requests, request);
+            conn->current_request = NULL;
 
-                request->request_left -= iov.length;
-
-                evpl_iovec_ring_add(&request->recv_ring, &iov);
-            }
-
-            if (request->notify_callback && evpl_iovec_ring_elements(&request->recv_ring) > 0) {
-                request->notify_callback(evpl,
-                                         agent,
-                                         request,
-                                         EVPL_HTTP_NOTIFY_RECEIVE_DATA,
-                                         request->request_type,
-                                         request->uri,
+            if (request->notify_callback) {
+                request->notify_callback(evpl, agent, request,
+                                         EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE,
+                                         request->request_type, request->uri,
                                          request->notify_data,
                                          server->private_data);
             }
-
-            if (request->request_left == 0) {
-                request->request_state = EVPL_HTTP_REQUEST_STATE_COMPLETE;
-                DL_APPEND(conn->pending_requests, request);
-                conn->current_request = NULL;
-
-                if (request->notify_callback) {
-                    request->notify_callback(evpl,
-                                             agent,
-                                             request,
-                                             EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE,
-                                             request->request_type,
-                                             request->uri,
-                                             request->notify_data,
-                                             server->private_data);
-                }
-            }
-        } else if (request->request_transfer_encoding == EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED) {
-            int               niov;
-            uint64_t          received = 0;
-            struct evpl_iovec iov;
-
-            while (!evpl_iovec_ring_is_full(&request->recv_ring)) {
-
-                if (request->request_chunk_left > 0) {
-                    niov = evpl_recvv(evpl, bind, &iov, 1, request->request_chunk_left, NULL);
-
-                    if (niov == 0) {
-                        break;
-                    }
-
-                    request->request_chunk_left -= iov.length;
-                    received                    += iov.length;
-
-                    evpl_iovec_ring_add(&request->recv_ring, &iov);
-
-                } else {
-
-                    rc = evpl_http_parse_line(evpl, bind, line, sizeof(line));
-
-                    if (unlikely(rc == -2)) {
-                        evpl_close(evpl, bind);
-                        return;
-                    }
-
-                    if (rc == -1) {
-                        break;
-                    }
-
-                    if (request->request_flags & EVPL_HTTP_REQUEST_EXPECT_CHUNK_NL) {
-                        if (line[0] != '\0') {
-                            evpl_close(evpl, bind);
-                            return;
-                        }
-                        request->request_flags &= ~EVPL_HTTP_REQUEST_EXPECT_CHUNK_NL;
-                        continue;
-                    }
-
-                    request->request_chunk_left = strtoul(line, NULL, 16);
-                    request->request_flags     |= EVPL_HTTP_REQUEST_EXPECT_CHUNK_NL;
-
-                    if (request->request_chunk_left == 0) {
-                        request->request_state = EVPL_HTTP_REQUEST_STATE_COMPLETE;
-                        break;
-                    }
-                }
-            }
-
-            if (request->notify_callback) {
-                if (request->request_state == EVPL_HTTP_REQUEST_STATE_COMPLETE) {
-                    DL_APPEND(conn->pending_requests, request);
-                    conn->current_request = NULL;
-
-                    request->notify_callback(evpl,
-                                             agent,
-                                             request,
-                                             EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE,
-                                             request->request_type,
-                                             request->uri,
-                                             request->notify_data,
-                                             server->private_data);
-                } else if (received) {
-                    request->notify_callback(evpl,
-                                             agent,
-                                             request,
-                                             EVPL_HTTP_NOTIFY_RECEIVE_DATA,
-                                             request->request_type,
-                                             request->uri,
-                                             request->notify_data,
-                                             server->private_data);
-                }
-            }
-
-        } else {
-            abort();
         }
     } else {
         abort();
     }
 } /* evpl_http_server_handle_data */
+
+static void
+evpl_http_client_handle_data(struct evpl_http_conn *conn)
+{
+    struct evpl_http_agent          *agent = conn->agent;
+    struct evpl                     *evpl  = agent->evpl;
+    struct evpl_bind                *bind  = conn->bind;
+    struct evpl_http_request        *request;
+    struct evpl_http_request_header *header;
+    char                             line[4096];
+    int                              rc;
+    char                            *token, *saveptr;
+
+    if (!conn->current_request) {
+        if (!conn->pending_requests) {
+            evpl_http_debug("response data with no pending request");
+            evpl_close(evpl, bind);
+            return;
+        }
+        /* HTTP/1.x responses arrive in request order: the head of the queue. */
+        conn->current_request = conn->pending_requests;
+    }
+
+    request = conn->current_request;
+
+ again:
+
+    if (request->request_state == EVPL_HTTP_REQUEST_STATE_INIT) {
+        rc = evpl_http_parse_line(evpl, bind, line, sizeof(line));
+
+        if (unlikely(rc == -2)) {
+            evpl_close(evpl, bind);
+            return;
+        }
+
+        if (rc == -1) {
+            return;
+        }
+
+        token = strtok_r(line, " \t", &saveptr);
+
+        if (!token) {
+            evpl_http_debug("missing status line version");
+            evpl_close(evpl, bind);
+            return;
+        }
+
+        if (strncmp(token, "HTTP/1.1", 8) == 0) {
+            request->http_version = EVPL_HTTP_REQUEST_HTTP_VERSION_1_1;
+        } else if (strncmp(token, "HTTP/1.0", 8) == 0) {
+            request->http_version = EVPL_HTTP_REQUEST_HTTP_VERSION_1_0;
+        } else {
+            evpl_http_debug("unsupported http version: %s", token);
+            evpl_close(evpl, bind);
+            return;
+        }
+
+        token = strtok_r(NULL, " \t", &saveptr);
+
+        if (!token) {
+            evpl_http_debug("missing status code");
+            evpl_close(evpl, bind);
+            return;
+        }
+
+        request->status        = atoi(token);
+        request->request_state = EVPL_HTTP_REQUEST_STATE_HEADERS;
+
+        goto again;
+
+    } else if (request->request_state == EVPL_HTTP_REQUEST_STATE_HEADERS) {
+        rc = evpl_http_parse_line(evpl, bind, line, sizeof(line));
+
+        if (unlikely(rc == -2)) {
+            evpl_close(evpl, bind);
+            return;
+        }
+
+        if (rc == -1) {
+            return;
+        }
+
+        if (line[0] == '\0') {
+            request->request_state = EVPL_HTTP_REQUEST_STATE_BODY;
+
+            if (request->notify_callback) {
+                request->notify_callback(evpl, agent, request,
+                                         EVPL_HTTP_NOTIFY_RESPONSE_HEADERS,
+                                         request->request_type, request->uri,
+                                         request->notify_data,
+                                         conn->private_data);
+            }
+
+            goto again;
+        } else {
+            header = evpl_http_request_header_alloc(agent);
+
+            token = strtok_r(line, ":", &saveptr);
+
+            if (!token) {
+                evpl_http_debug("malformed header line");
+                evpl_close(evpl, bind);
+                return;
+            }
+
+            strncpy(header->name, token, sizeof(header->name) - 1);
+
+            token = strtok_r(NULL, "", &saveptr);
+
+            if (!token) {
+                evpl_http_debug("missing header value");
+                evpl_close(evpl, bind);
+                return;
+            }
+
+            while (*token == ' ') {
+                token++;
+            }
+            strncpy(header->value, token, sizeof(header->value) - 1);
+
+            DL_APPEND(request->response_headers, header);
+
+            if (strncasecmp(header->name, "Content-Length", 15) == 0) {
+                request->request_length = strtoul(header->value, NULL, 10);
+                request->request_left   = request->request_length;
+            } else if (strncasecmp(header->name, "Transfer-Encoding", 18) == 0) {
+                if (strncasecmp(header->value, "chunked", 6) == 0) {
+                    request->request_transfer_encoding = EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED;
+                }
+            }
+        }
+
+        goto again;
+
+    } else if (request->request_state == EVPL_HTTP_REQUEST_STATE_BODY) {
+
+        if (evpl_http_handle_body(conn, request) < 0) {
+            return;
+        }
+
+        if (request->request_state == EVPL_HTTP_REQUEST_STATE_COMPLETE) {
+            DL_DELETE(conn->pending_requests, request);
+            conn->current_request = NULL;
+
+            if (request->notify_callback) {
+                request->notify_callback(evpl, agent, request,
+                                         EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE,
+                                         request->request_type, request->uri,
+                                         request->notify_data,
+                                         conn->private_data);
+            }
+
+            evpl_http_request_free(agent, request);
+        }
+    } else {
+        abort();
+    }
+} /* evpl_http_client_handle_data */
+
+static void
+evpl_http_conn_connected(struct evpl_http_conn *conn)
+{
+    struct evpl          *evpl = conn->agent->evpl;
+    enum evpl_protocol_id pid  = evpl_bind_get_protocol(conn->bind);
+
+    conn->connected = 1;
+
+    if (conn->proto == EVPL_HTTP_PROTO_UNKNOWN) {
+        if (pid == EVPL_STREAM_SOCKET_TLS) {
+            char alpn[16];
+
+            evpl_tls_get_alpn(conn->bind, alpn, sizeof(alpn));
+
+#ifdef HAVE_NGHTTP2
+            if (strcmp(alpn, "h2") == 0) {
+                conn->proto = EVPL_HTTP_PROTO_H2;
+            } else {
+                conn->proto = EVPL_HTTP_PROTO_H1;
+            }
+#else  /* ifdef HAVE_NGHTTP2 */
+            conn->proto = EVPL_HTTP_PROTO_H1;
+#endif /* ifdef HAVE_NGHTTP2 */
+        } else if (!conn->is_server) {
+            /* Plain TCP client: prior-knowledge selection from requested version */
+#ifdef HAVE_NGHTTP2
+            if (conn->version == EVPL_HTTP_VERSION_HTTP2) {
+                conn->proto = EVPL_HTTP_PROTO_H2;
+            } else {
+                conn->proto = EVPL_HTTP_PROTO_H1;
+            }
+#else  /* ifdef HAVE_NGHTTP2 */
+            conn->proto = EVPL_HTTP_PROTO_H1;
+#endif /* ifdef HAVE_NGHTTP2 */
+        }
+        /* Plain TCP server: leave UNKNOWN, decided by preface sniff on first read */
+    }
+
+#ifdef HAVE_NGHTTP2
+    if (conn->proto == EVPL_HTTP_PROTO_H2) {
+        struct evpl_http_request *request, *tmp;
+
+        evpl_http2_conn_init(conn);
+
+        /* Submit any requests the client queued before the connection
+         * completed. */
+        DL_FOREACH_SAFE(conn->pending_requests, request, tmp)
+        {
+            DL_DELETE(conn->pending_requests, request);
+            evpl_http2_dispatch(request);
+        }
+
+        evpl_defer(evpl, &conn->flush);
+        return;
+    }
+#endif /* ifdef HAVE_NGHTTP2 */
+
+    if (!conn->is_server && conn->pending_requests) {
+        evpl_defer(evpl, &conn->flush);
+    }
+} /* evpl_http_conn_connected */
+
+#ifdef HAVE_NGHTTP2
+/*
+ * Detect the HTTP/2 client connection preface ("PRI * HTTP/2.0\r\n...") on a
+ * plain-TCP server connection without consuming it.  Returns 1 if it is h2c, 0
+ * if it is HTTP/1.x, and -1 if not enough bytes have arrived to decide yet.
+ */
+static int
+evpl_http_sniff_h2c(struct evpl_http_conn *conn)
+{
+    static const char preface[] = "PRI * HTTP/2.0\r\n";
+    char              buf[16];
+    int               n;
+
+    n = evpl_peek(conn->agent->evpl, conn->bind, buf, (int) sizeof(buf));
+
+    if (n <= 0) {
+        return -1;
+    }
+
+    if (memcmp(buf, preface, n < (int) sizeof(buf) ? n : (int) sizeof(buf)) != 0) {
+        return 0;
+    }
+
+    if (n < (int) sizeof(buf)) {
+        return -1;
+    }
+
+    return 1;
+} /* evpl_http_sniff_h2c */
+#endif /* ifdef HAVE_NGHTTP2 */
 
 static void
 evpl_http_event(
@@ -683,10 +731,17 @@ evpl_http_event(
 
     switch (notify->notify_type) {
         case EVPL_NOTIFY_CONNECTED:
+            evpl_http_conn_connected(http_conn);
             break;
         case EVPL_NOTIFY_DISCONNECTED:
         {
             struct evpl_http_request *request, *next;
+
+#ifdef HAVE_NGHTTP2
+            if (http_conn->proto == EVPL_HTTP_PROTO_H2) {
+                evpl_http2_conn_destroy(http_conn);
+            }
+#endif /* ifdef HAVE_NGHTTP2 */
 
             /* Release any request still in flight on this connection: a
              * partially-parsed request (current_request, e.g. one allocated on
@@ -711,14 +766,39 @@ evpl_http_event(
                 request = next;
             }
 
-            free(http_conn);
+            evpl_free(http_conn);
         }
         break;
         case EVPL_NOTIFY_RECV_DATA:
+
+#ifdef HAVE_NGHTTP2
+            if (http_conn->is_server &&
+                http_conn->proto == EVPL_HTTP_PROTO_UNKNOWN) {
+                int r = evpl_http_sniff_h2c(http_conn);
+
+                if (r < 0) {
+                    return; /* need more bytes to decide */
+                }
+
+                if (r) {
+                    http_conn->proto     = EVPL_HTTP_PROTO_H2;
+                    http_conn->connected = 1;
+                    evpl_http2_conn_init(http_conn);
+                } else {
+                    http_conn->proto = EVPL_HTTP_PROTO_H1;
+                }
+            }
+
+            if (http_conn->proto == EVPL_HTTP_PROTO_H2) {
+                evpl_http2_recv(http_conn);
+                break;
+            }
+#endif /* ifdef HAVE_NGHTTP2 */
+
             if (http_conn->is_server) {
                 evpl_http_server_handle_data(http_conn);
             } else {
-                abort();
+                evpl_http_client_handle_data(http_conn);
             }
             break;
         default:
@@ -771,19 +851,134 @@ evpl_http_server_send_headers(
 } /* evpl_http_server_send_headers */
 
 static void
-evpl_http_server_flush(
-    struct evpl *evpl,
-    void        *arg)
+evpl_http_client_send_headers(
+    struct evpl              *evpl,
+    struct evpl_http_request *request)
 {
-    struct evpl_http_conn    *conn   = arg;
+    struct evpl_http_conn           *conn = request->conn;
+    struct evpl_bind                *bind = conn->bind;
+    struct evpl_http_request_header *header;
+    struct evpl_iovec                iov;
+    int                              niov;
+    char                            *rsp_base, *rsp;
+
+    niov = evpl_iovec_alloc(evpl, 4096, 4096, 1, 0, &iov);
+
+    evpl_http_abort_if(niov < 0, "failed to allocate iovec");
+
+    rsp_base = iov.data;
+    rsp      = rsp_base;
+
+    rsp += snprintf(rsp, 4096, "%s %s HTTP/1.1\r\n",
+                    evpl_http_method_to_wire(request->request_type),
+                    request->uri);
+
+    DL_FOREACH(request->request_headers, header)
+    {
+        rsp += snprintf(rsp, 4096 - (rsp - rsp_base), "%s: %s\r\n", header->name, header->value);
+    }
+
+    if (request->response_transfer_encoding == EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED) {
+        rsp += snprintf(rsp, 4096 - (rsp - rsp_base), "Transfer-Encoding: chunked\r\n");
+    } else {
+        rsp += snprintf(rsp, 4096 - (rsp - rsp_base), "Content-Length: %lu\r\n", request->response_length);
+    }
+
+    rsp += snprintf(rsp, 4096 - (rsp - rsp_base), "\r\n");
+
+    iov.length = rsp - rsp_base;
+
+    evpl_sendv(evpl, bind, &iov, 1, iov.length, EVPL_SEND_FLAG_TAKE_REF);
+} /* evpl_http_client_send_headers */
+
+/*
+ * Send the body staged in request->send_ring to the wire, honoring the
+ * configured transfer encoding.  Shared by the server (response body) and
+ * client (request body) HTTP/1.x paths.  Returns 1 if the body has been fully
+ * sent, 0 if more data is needed (a WANT_DATA notification was emitted).
+ */
+static int
+evpl_http_send_body(
+    struct evpl              *evpl,
+    struct evpl_http_request *request)
+{
+    struct evpl_http_conn *conn = request->conn;
+    struct evpl_bind      *bind = conn->bind;
+    struct evpl_iovec     *iovp;
+    struct evpl_iovec      iov;
+    uint64_t               chunk_length;
+    int                    chunk_hdr_len, niov;
+
+    if (request->response_transfer_encoding == EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT) {
+
+        while (request->response_left && !evpl_iovec_ring_is_empty(&request->send_ring)) {
+            iovp = evpl_iovec_ring_tail(&request->send_ring);
+            evpl_sendv(evpl, bind, iovp, 1, iovp->length, EVPL_SEND_FLAG_TAKE_REF);
+
+            request->response_left -= iovp->length;
+            evpl_iovec_ring_remove(&request->send_ring);
+        }
+
+        return request->response_left == 0;
+    } else {
+
+        chunk_length = evpl_iovec_ring_bytes(&request->send_ring);
+
+        if (chunk_length) {
+
+            niov = evpl_iovec_alloc(evpl, 64, 0, 1, 0, &iov);
+
+            chunk_hdr_len = snprintf(iov.data, 64, "%lx\r\n", chunk_length);
+
+            evpl_http_abort_if(niov < 0, "failed to allocate iovec");
+
+            evpl_sendv(evpl, bind, &iov, 1, chunk_hdr_len, EVPL_SEND_FLAG_TAKE_REF);
+
+            while (!evpl_iovec_ring_is_empty(&request->send_ring)) {
+                iovp = evpl_iovec_ring_tail(&request->send_ring);
+                evpl_sendv(evpl, bind, iovp, 1, iovp->length, EVPL_SEND_FLAG_TAKE_REF);
+                evpl_iovec_ring_remove(&request->send_ring);
+            }
+
+            niov = evpl_iovec_alloc(evpl, 2, 0, 1, 0, &iov);
+
+            evpl_http_abort_if(niov < 0, "failed to allocate iovec");
+
+            ((char *) iov.data)[0] = '\r';
+            ((char *) iov.data)[1] = '\n';
+
+            evpl_sendv(evpl, bind, &iov, 1, 2, EVPL_SEND_FLAG_TAKE_REF);
+        }
+
+        if (request->request_flags & EVPL_HTTP_REQUEST_RESPONSE_FINISHED) {
+            niov = evpl_iovec_alloc(evpl, 5, 0, 1, 0, &iov);
+
+            evpl_http_abort_if(niov < 0, "failed to allocate iovec");
+
+            ((char *) iov.data)[0] = '0';
+            ((char *) iov.data)[1] = '\r';
+            ((char *) iov.data)[2] = '\n';
+            ((char *) iov.data)[3] = '\r';
+            ((char *) iov.data)[4] = '\n';
+
+            evpl_sendv(evpl, bind, &iov, 1, 5, EVPL_SEND_FLAG_TAKE_REF);
+
+            return 1;
+        }
+
+        return 0;
+    }
+} /* evpl_http_send_body */
+
+static void
+evpl_http_server_flush(
+    struct evpl           *evpl,
+    struct evpl_http_conn *conn)
+{
     struct evpl_http_agent   *agent  = conn->agent;
     struct evpl_http_server  *server = conn->server;
-    struct evpl_bind         *bind   = conn->bind;
     struct evpl_http_request *request, *tmp;
-    struct evpl_iovec        *iovp;
-    uint64_t                  chunk_length;
-    int                       chunk_hdr_len, niov;
-    struct evpl_iovec         iov;
+    int                       done;
 
     DL_FOREACH_SAFE(conn->pending_requests, request, tmp)
     {
@@ -797,106 +992,105 @@ evpl_http_server_flush(
             request->request_flags |= EVPL_HTTP_REQUEST_RESPONSE_HDR_SENT;
         }
 
-        if (request->response_transfer_encoding == EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT) {
+        done = evpl_http_send_body(evpl, request);
 
-            while (request->response_left  && !evpl_iovec_ring_is_empty(&request->send_ring)) {
-                iovp = evpl_iovec_ring_tail(&request->send_ring);
-                evpl_sendv(evpl, bind, iovp, 1, iovp->length, EVPL_SEND_FLAG_TAKE_REF);
-
-                request->response_left -= iovp->length;
-                evpl_iovec_ring_remove(&request->send_ring);
-            }
-
-            if (request->response_left == 0) {
-                request->notify_callback(evpl,
-                                         agent,
-                                         request,
-                                         EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE,
-                                         request->request_type,
-                                         request->uri,
-                                         request->notify_data,
-                                         server->private_data);
-                DL_DELETE(conn->pending_requests, request);
-                evpl_http_request_free(conn->agent, request);
-            } else {
-                request->notify_callback(evpl,
-                                         agent,
-                                         request,
-                                         EVPL_HTTP_NOTIFY_WANT_DATA,
-                                         request->request_type,
-                                         request->uri,
-                                         request->notify_data,
-                                         server->private_data);
-                break;
-            }
-
-        } else {
-
-            chunk_length = evpl_iovec_ring_bytes(&request->send_ring);
-
-            if (chunk_length) {
-
-                niov = evpl_iovec_alloc(evpl, 64, 0, 1, 0, &iov);
-
-                chunk_hdr_len = snprintf(iov.data, 64, "%lx\r\n", chunk_length);
-
-                evpl_http_abort_if(niov < 0, "failed to allocate iovec");
-
-                evpl_sendv(evpl, bind, &iov, 1, chunk_hdr_len, EVPL_SEND_FLAG_TAKE_REF);
-
-                while (!evpl_iovec_ring_is_empty(&request->send_ring)) {
-                    iovp = evpl_iovec_ring_tail(&request->send_ring);
-                    evpl_sendv(evpl, bind, iovp, 1, iovp->length, EVPL_SEND_FLAG_TAKE_REF);
-                    evpl_iovec_ring_remove(&request->send_ring);
-                }
-
-                niov = evpl_iovec_alloc(evpl, 2, 0, 1, 0, &iov);
-
-                evpl_http_abort_if(niov < 0, "failed to allocate iovec");
-
-                ((char *) iov.data)[0] = '\r';
-                ((char *) iov.data)[1] = '\n';
-
-                evpl_sendv(evpl, bind, &iov, 1, 2, EVPL_SEND_FLAG_TAKE_REF);
-            }
-
-            if (request->request_flags & EVPL_HTTP_REQUEST_RESPONSE_FINISHED) {
-                niov = evpl_iovec_alloc(evpl, 5, 0, 1, 0, &iov);
-
-                evpl_http_abort_if(niov < 0, "failed to allocate iovec");
-
-                ((char *) iov.data)[0] = '0';
-                ((char *) iov.data)[1] = '\r';
-                ((char *) iov.data)[2] = '\n';
-                ((char *) iov.data)[3] = '\r';
-                ((char *) iov.data)[4] = '\n';
-
-                evpl_sendv(evpl, bind, &iov, 1, 5, EVPL_SEND_FLAG_TAKE_REF);
-
+        if (done) {
+            request->notify_callback(evpl, agent, request,
+                                     EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE,
+                                     request->request_type, request->uri,
+                                     request->notify_data, server->private_data);
 #ifdef __clang_analyzer__
-                /* DL_DELETE asserts head != NULL but NDEBUG strips it
-                 * in Release builds; guide the analyzer explicitly */
-                if (!conn->pending_requests) {
-                    return;
-                }
-#endif /* ifdef __clang_analyzer__ */
-                DL_DELETE(conn->pending_requests, request);
-                evpl_http_request_free(conn->agent, request);
-            } else {
-                request->notify_callback(evpl,
-                                         agent,
-                                         request,
-                                         EVPL_HTTP_NOTIFY_WANT_DATA,
-                                         request->request_type,
-                                         request->uri,
-                                         request->notify_data,
-                                         server->private_data);
-                break;
+            /* DL_DELETE asserts head != NULL but NDEBUG strips it
+             * in Release builds; guide the analyzer explicitly */
+            if (!conn->pending_requests) {
+                return;
             }
+#endif /* ifdef __clang_analyzer__ */
+            DL_DELETE(conn->pending_requests, request);
+            evpl_http_request_free(conn->agent, request);
+        } else {
+            request->notify_callback(evpl, agent, request,
+                                     EVPL_HTTP_NOTIFY_WANT_DATA,
+                                     request->request_type, request->uri,
+                                     request->notify_data, server->private_data);
+            break;
         }
-
     }
 } /* evpl_http_server_flush */
+
+static void
+evpl_http_client_flush(
+    struct evpl           *evpl,
+    struct evpl_http_conn *conn)
+{
+    struct evpl_http_agent   *agent = conn->agent;
+    struct evpl_http_request *request, *tmp;
+    int                       done;
+
+    if (!conn->connected) {
+        return;
+    }
+
+    DL_FOREACH_SAFE(conn->pending_requests, request, tmp)
+    {
+
+        if (request->request_flags & EVPL_HTTP_REQUEST_REQUEST_SENT) {
+            continue;
+        }
+
+        if (!(request->request_flags & EVPL_HTTP_REQUEST_RESPONSE_READY)) {
+            break;
+        }
+
+        if (!(request->request_flags & EVPL_HTTP_REQUEST_RESPONSE_HDR_SENT)) {
+            evpl_http_client_send_headers(evpl, request);
+            request->request_flags |= EVPL_HTTP_REQUEST_RESPONSE_HDR_SENT;
+        }
+
+        done = evpl_http_send_body(evpl, request);
+
+        if (done) {
+            request->request_flags |= EVPL_HTTP_REQUEST_REQUEST_SENT;
+
+            if (request->notify_callback) {
+                request->notify_callback(evpl, agent, request,
+                                         EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE,
+                                         request->request_type, request->uri,
+                                         request->notify_data, conn->private_data);
+            }
+            /* Stays on pending_requests as the await-response FIFO. */
+        } else {
+            if (request->notify_callback) {
+                request->notify_callback(evpl, agent, request,
+                                         EVPL_HTTP_NOTIFY_WANT_DATA,
+                                         request->request_type, request->uri,
+                                         request->notify_data, conn->private_data);
+            }
+            break;
+        }
+    }
+} /* evpl_http_client_flush */
+
+void
+evpl_http_flush(
+    struct evpl *evpl,
+    void        *arg)
+{
+    struct evpl_http_conn *conn = arg;
+
+#ifdef HAVE_NGHTTP2
+    if (conn->proto == EVPL_HTTP_PROTO_H2) {
+        evpl_http2_flush(evpl, conn);
+        return;
+    }
+#endif /* ifdef HAVE_NGHTTP2 */
+
+    if (conn->is_server) {
+        evpl_http_server_flush(evpl, conn);
+    } else {
+        evpl_http_client_flush(evpl, conn);
+    }
+} /* evpl_http_flush */
 
 static void
 evpl_http_accept(
@@ -913,13 +1107,15 @@ evpl_http_accept(
     http_conn            = evpl_zalloc(sizeof(*http_conn));
     http_conn->server    = server;
     http_conn->is_server = 1;
+    http_conn->proto     = EVPL_HTTP_PROTO_UNKNOWN;
+    http_conn->connected = 1;
     http_conn->agent     = server->agent;
     http_conn->bind      = bind;
     *notify_callback     = evpl_http_event;
     *segment_callback    = NULL;
     *conn_private_data   = http_conn;
 
-    evpl_deferral_init(&http_conn->flush, evpl_http_server_flush, http_conn);
+    evpl_deferral_init(&http_conn->flush, evpl_http_flush, http_conn);
 
 
 } /* evpl_http_accept */
@@ -932,6 +1128,13 @@ evpl_http_attach(
     void                         *private_data)
 {
     struct evpl_http_server *server;
+
+#ifdef HAVE_NGHTTP2
+    /* Advertise ALPN so a TLS listener can negotiate "h2"; harmless for a
+     * plain-TCP listener (no TLS context is created). */
+    static const char *const protos[] = { "h2", "http/1.1" };
+    evpl_tls_set_alpn_protocols(protos, 2);
+#endif /* ifdef HAVE_NGHTTP2 */
 
     server = evpl_zalloc(sizeof(*server));
 
@@ -953,6 +1156,119 @@ evpl_http_server_destroy(
     evpl_listener_detach(agent->evpl, server->binding);
     evpl_free(server);
 } /* evpl_http_server_destroy */
+
+SYMBOL_EXPORT struct evpl_http_conn *
+evpl_http_client_connect(
+    struct evpl_http_agent *agent,
+    enum evpl_protocol_id   protocol_id,
+    struct evpl_endpoint   *endpoint,
+    enum evpl_http_version  version,
+    void                   *private_data)
+{
+    struct evpl_http_conn *conn;
+
+#ifdef HAVE_NGHTTP2
+    /* Advertise ALPN so an h2-over-TLS connection can be negotiated. */
+    if (protocol_id == EVPL_STREAM_SOCKET_TLS) {
+        if (version == EVPL_HTTP_VERSION_HTTP2) {
+            static const char *const protos[] = { "h2" };
+            evpl_tls_set_alpn_protocols(protos, 1);
+        } else if (version == EVPL_HTTP_VERSION_AUTO) {
+            static const char *const protos[] = { "h2", "http/1.1" };
+            evpl_tls_set_alpn_protocols(protos, 2);
+        }
+    }
+#endif /* ifdef HAVE_NGHTTP2 */
+
+    conn               = evpl_zalloc(sizeof(*conn));
+    conn->is_server    = 0;
+    conn->proto        = EVPL_HTTP_PROTO_UNKNOWN;
+    conn->version      = version;
+    conn->connected    = 0;
+    conn->agent        = agent;
+    conn->private_data = private_data;
+
+    evpl_deferral_init(&conn->flush, evpl_http_flush, conn);
+
+    conn->bind = evpl_connect(agent->evpl, protocol_id, NULL, endpoint,
+                              evpl_http_event, NULL, conn);
+
+    return conn;
+} /* evpl_http_client_connect */
+
+SYMBOL_EXPORT void
+evpl_http_client_close(
+    struct evpl_http_agent *agent,
+    struct evpl_http_conn  *conn)
+{
+    evpl_close(agent->evpl, conn->bind);
+} /* evpl_http_client_close */
+
+SYMBOL_EXPORT struct evpl_http_request *
+evpl_http_request_create(
+    struct evpl_http_conn      *conn,
+    enum evpl_http_request_type method,
+    const char                 *url)
+{
+    struct evpl_http_request *request;
+
+    request               = evpl_http_request_alloc(conn->agent);
+    request->conn         = conn;
+    request->request_type = method;
+    request->uri_len      = evpl_copy_string(request->uri, url, sizeof(request->uri));
+
+    return request;
+} /* evpl_http_request_create */
+
+SYMBOL_EXPORT void
+evpl_http_client_set_request_length(
+    struct evpl_http_request *request,
+    uint64_t                  content_length)
+{
+    request->response_length = content_length;
+    request->response_left   = content_length;
+} /* evpl_http_client_set_request_length */
+
+SYMBOL_EXPORT void
+evpl_http_client_set_request_chunked(struct evpl_http_request *request)
+{
+    request->response_transfer_encoding = EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED;
+} /* evpl_http_client_set_request_chunked */
+
+SYMBOL_EXPORT void
+evpl_http_request_dispatch(
+    struct evpl_http_request   *request,
+    evpl_http_notify_callback_t notify_callback,
+    void                       *notify_data)
+{
+    struct evpl_http_conn *conn = request->conn;
+    struct evpl           *evpl = conn->agent->evpl;
+
+    request->notify_callback = notify_callback;
+    request->notify_data     = notify_data;
+    request->request_flags  |= EVPL_HTTP_REQUEST_RESPONSE_READY;
+
+#ifdef HAVE_NGHTTP2
+    if (conn->proto == EVPL_HTTP_PROTO_H2) {
+        evpl_http2_dispatch(request);
+        return;
+    }
+#endif /* ifdef HAVE_NGHTTP2 */
+
+    /* Queue in request order; flushed now if connected, otherwise once the
+     * connection completes (or the h2c/h1 protocol is decided). */
+    DL_APPEND(conn->pending_requests, request);
+
+    if (conn->connected) {
+        evpl_defer(evpl, &conn->flush);
+    }
+} /* evpl_http_request_dispatch */
+
+SYMBOL_EXPORT int
+evpl_http_request_status(struct evpl_http_request *request)
+{
+    return request->status;
+} /* evpl_http_request_status */
 
 SYMBOL_EXPORT enum evpl_http_request_type
 evpl_http_request_type(struct evpl_http_request *request)
@@ -995,12 +1311,26 @@ evpl_http_request_add_datav(
 
     if (niov == 0) {
         request->request_flags |= EVPL_HTTP_REQUEST_RESPONSE_FINISHED;
+
+#ifdef HAVE_NGHTTP2
+        if (request->conn->proto == EVPL_HTTP_PROTO_H2) {
+            request->h2.eof = 1;
+            evpl_http2_submit(request);
+        }
+#endif /* ifdef HAVE_NGHTTP2 */
         return;
     }
 
     for (i = 0; i < niov; i++) {
         evpl_iovec_ring_add(&request->send_ring, &iov[i]);
     }
+
+#ifdef HAVE_NGHTTP2
+    if (request->conn->proto == EVPL_HTTP_PROTO_H2) {
+        evpl_http2_submit(request);
+        return;
+    }
+#endif /* ifdef HAVE_NGHTTP2 */
 
     if (request->request_flags & EVPL_HTTP_REQUEST_RESPONSE_READY) {
         evpl_defer(request->conn->agent->evpl, &request->conn->flush);
@@ -1037,6 +1367,15 @@ evpl_http_server_dispatch_default(
 
     request->status         = status;
     request->request_flags |= EVPL_HTTP_REQUEST_RESPONSE_READY;
+
+#ifdef HAVE_NGHTTP2
+    if (conn->proto == EVPL_HTTP_PROTO_H2) {
+        /* HTTP/2 carries no hop-by-hop Connection header and frames its own
+         * body, so the response is submitted directly to the session. */
+        evpl_http2_dispatch(request);
+        return;
+    }
+#endif /* ifdef HAVE_NGHTTP2 */
 
     evpl_http_request_add_header(request, "Connection", "keep-alive");
 
@@ -1104,6 +1443,37 @@ evpl_http_request_header_iterate(
         callback(header->name, header->value, private_data);
     }
 } /* evpl_http_request_header_iterate */
+
+SYMBOL_EXPORT const char *
+evpl_http_response_header(
+    struct evpl_http_request *request,
+    const char               *name)
+{
+    struct evpl_http_request_header *header;
+
+    DL_FOREACH(request->response_headers, header)
+    {
+        if (strncasecmp(header->name, name, sizeof(header->name) - 1) == 0) {
+            return header->value;
+        }
+    }
+
+    return NULL;
+} /* evpl_http_response_header */
+
+SYMBOL_EXPORT void
+evpl_http_response_header_iterate(
+    struct evpl_http_request     *request,
+    evpl_http_request_header_cb_t callback,
+    void                         *private_data)
+{
+    struct evpl_http_request_header *header;
+
+    DL_FOREACH(request->response_headers, header)
+    {
+        callback(header->name, header->value, private_data);
+    }
+} /* evpl_http_response_header_iterate */
 
 SYMBOL_EXPORT uint64_t
 evpl_http_request_get_data_avail(struct evpl_http_request *request)

--- a/src/http/http2.c
+++ b/src/http/http2.c
@@ -1,0 +1,779 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * HTTP/2 codec for libevpl, built on nghttp2.
+ *
+ * The framing, HPACK and flow control live in nghttp2; this file glues its
+ * callback model onto libevpl's asynchronous bind I/O and zero-copy iovec
+ * buffering.  Each HTTP/2 stream maps onto one struct evpl_http_request so the
+ * same dispatch/notify lifecycle and request object are used as for HTTP/1.x.
+ *
+ * Buffering: nghttp2's internal allocations are routed to evpl_malloc/free via
+ * nghttp2_mem.  Inbound DATA is copied once into evpl iovecs (nghttp2 owns the
+ * framing buffer); outbound DATA is sent straight from the request send_ring by
+ * reference (NGHTTP2_DATA_FLAG_NO_COPY + send_data callback), i.e. zero-copy.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <nghttp2/nghttp2.h>
+
+#include "http_internal.h"
+
+struct evpl_http2_conn {
+    struct evpl_http_conn    *conn;
+    nghttp2_session          *session;
+    struct evpl_http_request *streams; /* live streams, DL list via prev/next */
+};
+
+/* ----- nghttp2 memory hooks -> libevpl allocator ----- */
+
+static void *
+evpl_http2_malloc(
+    size_t size,
+    void  *user)
+{
+    return evpl_malloc(size);
+} /* evpl_http2_malloc */
+
+static void
+evpl_http2_free(
+    void *ptr,
+    void *user)
+{
+    if (ptr) {
+        evpl_free(ptr);
+    }
+} /* evpl_http2_free */
+
+static void *
+evpl_http2_calloc(
+    size_t nmemb,
+    size_t size,
+    void  *user)
+{
+    return evpl_calloc(nmemb, size);
+} /* evpl_http2_calloc */
+
+static void *
+evpl_http2_realloc(
+    void  *ptr,
+    size_t size,
+    void  *user)
+{
+    return evpl_realloc(ptr, size);
+} /* evpl_http2_realloc */
+
+static nghttp2_mem evpl_http2_mem = {
+    NULL,
+    evpl_http2_malloc,
+    evpl_http2_free,
+    evpl_http2_calloc,
+    evpl_http2_realloc,
+};
+
+/* ----- helpers ----- */
+
+static inline void
+evpl_http2_lower(char *s)
+{
+    for (; *s; s++) {
+        if (*s >= 'A' && *s <= 'Z') {
+            *s += 'a' - 'A';
+        }
+    }
+} /* evpl_http2_lower */
+
+/* Connection-specific (hop-by-hop) header fields that are illegal in HTTP/2
+ * (RFC 7540 8.1.2.2); names are compared lowercased. */
+static inline int
+evpl_http2_hop_by_hop(const char *name)
+{
+    return strcmp(name, "connection") == 0 ||
+           strcmp(name, "keep-alive") == 0 ||
+           strcmp(name, "proxy-connection") == 0 ||
+           strcmp(name, "transfer-encoding") == 0 ||
+           strcmp(name, "upgrade") == 0;
+} /* evpl_http2_hop_by_hop */
+
+static inline void
+evpl_http2_notify(
+    struct evpl_http_request  *request,
+    enum evpl_http_notify_type type)
+{
+    struct evpl_http_conn *conn = request->conn;
+
+    if (request->notify_callback) {
+        request->notify_callback(conn->agent->evpl, conn->agent, request, type,
+                                 request->request_type, request->uri,
+                                 request->notify_data, evpl_http_priv(conn));
+    }
+} /* evpl_http2_notify */
+
+/* ----- outbound DATA: zero-copy from request->send_ring ----- */
+
+static ssize_t
+evpl_http2_data_read(
+    nghttp2_session     *session,
+    int32_t              stream_id,
+    uint8_t             *buf,
+    size_t               length,
+    uint32_t            *data_flags,
+    nghttp2_data_source *source,
+    void                *user)
+{
+    struct evpl_http_request *request = source->ptr;
+    uint64_t                  avail   = evpl_iovec_ring_bytes(&request->send_ring);
+    int                       chunked = request->response_transfer_encoding ==
+        EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED;
+    size_t                    n;
+
+    if (avail == 0) {
+        if (request->h2.eof || (!chunked && request->response_left == 0)) {
+            *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+            return 0;
+        }
+
+        /* No body staged yet: hold the DATA frame and request more from the
+         * application.  The WANT_DATA notification (and the application's
+         * resulting nghttp2_session_resume_data) must run AFTER this send
+         * completes -- resuming while still inside the read callback races with
+         * nghttp2 marking the stream deferred and the resume would be lost. */
+        request->h2.deferred  = 1;
+        request->h2.want_data = 1;
+        return NGHTTP2_ERR_DEFERRED;
+    }
+
+    n = avail < length ? avail : length;
+
+    *data_flags |= NGHTTP2_DATA_FLAG_NO_COPY;
+
+    if ((chunked && request->h2.eof && n == avail) ||
+        (!chunked && n == request->response_left)) {
+        *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+    }
+
+    return (ssize_t) n;
+} /* evpl_http2_data_read */
+
+static int
+evpl_http2_send_data(
+    nghttp2_session     *session,
+    nghttp2_frame       *frame,
+    const uint8_t       *framehd,
+    size_t               length,
+    nghttp2_data_source *source,
+    void                *user)
+{
+    struct evpl_http_conn    *conn    = user;
+    struct evpl_http_request *request = source->ptr;
+    struct evpl              *evpl    = conn->agent->evpl;
+    struct evpl_bind         *bind    = conn->bind;
+    struct evpl_iovec         hd;
+    struct evpl_iovec        *iovp;
+    struct evpl_iovec         part;
+    uint64_t                  left = length;
+
+    /* 9-byte DATA frame header (we never emit padding). */
+    evpl_iovec_alloc(evpl, 9, 0, 1, 0, &hd);
+    memcpy(hd.data, framehd, 9);
+    hd.length = 9;
+    evpl_sendv(evpl, bind, &hd, 1, 9, EVPL_SEND_FLAG_TAKE_REF);
+
+    while (left > 0) {
+        iovp = evpl_iovec_ring_tail(&request->send_ring);
+
+        if (!iovp) {
+            break;
+        }
+
+        if (iovp->length <= left) {
+            evpl_sendv(evpl, bind, iovp, 1, iovp->length, EVPL_SEND_FLAG_TAKE_REF);
+            left -= iovp->length;
+            evpl_iovec_ring_remove(&request->send_ring);
+        } else {
+            evpl_iovec_clone_segment(&part, iovp, 0, left);
+            evpl_sendv(evpl, bind, &part, 1, left, EVPL_SEND_FLAG_TAKE_REF);
+            iovp->data                += left;
+            iovp->length              -= left;
+            request->send_ring.length -= left;
+            left                       = 0;
+        }
+    }
+
+    if (request->response_transfer_encoding ==
+        EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT) {
+        request->response_left -= length;
+    }
+
+    return 0;
+} /* evpl_http2_send_data */
+
+/* ----- control / HEADERS frame output ----- */
+
+static ssize_t
+evpl_http2_send(
+    nghttp2_session *session,
+    const uint8_t   *data,
+    size_t           length,
+    int              flags,
+    void            *user)
+{
+    struct evpl_http_conn *conn = user;
+    struct evpl           *evpl = conn->agent->evpl;
+    struct evpl_iovec      iov;
+
+    evpl_iovec_alloc(evpl, length, 0, 1, 0, &iov);
+    memcpy(iov.data, data, length);
+    iov.length = length;
+
+    evpl_sendv(evpl, conn->bind, &iov, 1, length, EVPL_SEND_FLAG_TAKE_REF);
+
+    return (ssize_t) length;
+} /* evpl_http2_send */
+
+/* ----- inbound frame callbacks ----- */
+
+static int
+evpl_http2_on_begin_headers(
+    nghttp2_session     *session,
+    const nghttp2_frame *frame,
+    void                *user)
+{
+    struct evpl_http_conn    *conn = user;
+    struct evpl_http_request *request;
+
+    if (frame->hd.type != NGHTTP2_HEADERS) {
+        return 0;
+    }
+
+    /* The server allocates a request per inbound stream; on the client the
+     * request already exists (created by the application and passed as
+     * stream_user_data to nghttp2_submit_request). */
+    if (conn->is_server && frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
+        request               = evpl_http_request_alloc(conn->agent);
+        request->conn         = conn;
+        request->h2.stream_id = frame->hd.stream_id;
+
+        DL_APPEND(conn->h2->streams, request);
+
+        nghttp2_session_set_stream_user_data(session, frame->hd.stream_id, request);
+    }
+
+    return 0;
+} /* evpl_http2_on_begin_headers */
+
+static int
+evpl_http2_on_header(
+    nghttp2_session     *session,
+    const nghttp2_frame *frame,
+    const uint8_t       *name,
+    size_t               namelen,
+    const uint8_t       *value,
+    size_t               valuelen,
+    uint8_t              flags,
+    void                *user)
+{
+    struct evpl_http_conn           *conn = user;
+    struct evpl_http_request        *request;
+    struct evpl_http_request_header *header;
+    int                              n;
+
+    request = nghttp2_session_get_stream_user_data(session, frame->hd.stream_id);
+
+    if (!request) {
+        return 0;
+    }
+
+    if (namelen > 0 && name[0] == ':') {
+        char tmp[256];
+
+        n = valuelen < sizeof(tmp) - 1 ? (int) valuelen : (int) sizeof(tmp) - 1;
+
+        memcpy(tmp, value, n);
+        tmp[n] = '\0';
+
+        if (conn->is_server) {
+            if (namelen == 7 && memcmp(name, ":method", 7) == 0) {
+                request->request_type = evpl_http_method_from_string(tmp);
+            } else if (namelen == 5 && memcmp(name, ":path", 5) == 0) {
+                request->uri_len = evpl_copy_string(request->uri, tmp, sizeof(request->uri));
+            } else if (namelen == 10 && memcmp(name, ":authority", 10) == 0) {
+                header = evpl_http_request_header_alloc(conn->agent);
+                strncpy(header->name, "Host", sizeof(header->name) - 1);
+                strncpy(header->value, tmp, sizeof(header->value) - 1);
+                DL_APPEND(request->request_headers, header);
+            }
+        } else {
+            if (namelen == 7 && memcmp(name, ":status", 7) == 0) {
+                request->status = atoi(tmp);
+            }
+        }
+
+        return 0;
+    }
+
+    header = evpl_http_request_header_alloc(conn->agent);
+
+    n = namelen < sizeof(header->name) - 1 ? namelen : sizeof(header->name) - 1;
+    memcpy(header->name, name, n);
+    header->name[n] = '\0';
+
+    n = valuelen < sizeof(header->value) - 1 ? valuelen : sizeof(header->value) - 1;
+    memcpy(header->value, value, n);
+    header->value[n] = '\0';
+
+    if (conn->is_server) {
+        DL_APPEND(request->request_headers, header);
+    } else {
+        DL_APPEND(request->response_headers, header);
+    }
+
+    /* Inbound body length (request body on the server, response body on the
+    * client) is tracked via request_left for the END_STREAM bookkeeping. */
+    if (strncasecmp(header->name, "content-length", 14) == 0) {
+        request->request_length = strtoull(header->value, NULL, 10);
+        request->request_left   = request->request_length;
+    }
+
+    return 0;
+} /* evpl_http2_on_header */
+
+static int
+evpl_http2_on_frame_recv(
+    nghttp2_session     *session,
+    const nghttp2_frame *frame,
+    void                *user)
+{
+    struct evpl_http_conn    *conn = user;
+    struct evpl_http_request *request;
+
+    request = nghttp2_session_get_stream_user_data(session, frame->hd.stream_id);
+
+    if (!request) {
+        return 0;
+    }
+
+    if (frame->hd.type == NGHTTP2_HEADERS &&
+        (frame->hd.flags & NGHTTP2_FLAG_END_HEADERS)) {
+
+        if (conn->is_server) {
+            if (frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
+                conn->server->dispatch_callback(conn->agent->evpl, conn->agent,
+                                                request, &request->notify_callback,
+                                                &request->notify_data,
+                                                conn->server->private_data);
+            }
+        } else {
+            evpl_http2_notify(request, EVPL_HTTP_NOTIFY_RESPONSE_HEADERS);
+        }
+    }
+
+    if ((frame->hd.type == NGHTTP2_HEADERS || frame->hd.type == NGHTTP2_DATA) &&
+        (frame->hd.flags & NGHTTP2_FLAG_END_STREAM)) {
+        request->request_state = EVPL_HTTP_REQUEST_STATE_COMPLETE;
+        evpl_http2_notify(request, EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE);
+    }
+
+    return 0;
+} /* evpl_http2_on_frame_recv */
+
+static int
+evpl_http2_on_data_chunk(
+    nghttp2_session *session,
+    uint8_t          flags,
+    int32_t          stream_id,
+    const uint8_t   *data,
+    size_t           len,
+    void            *user)
+{
+    struct evpl_http_conn    *conn = user;
+    struct evpl_http_request *request;
+    struct evpl_iovec         iov;
+
+    request = nghttp2_session_get_stream_user_data(session, stream_id);
+
+    if (!request || len == 0) {
+        return 0;
+    }
+
+    evpl_iovec_alloc(conn->agent->evpl, len, 0, 1, 0, &iov);
+    memcpy(iov.data, data, len);
+    iov.length = len;
+
+    evpl_iovec_ring_add(&request->recv_ring, &iov);
+
+    if (request->request_left >= len) {
+        request->request_left -= len;
+    }
+
+    evpl_http2_notify(request, EVPL_HTTP_NOTIFY_RECEIVE_DATA);
+
+    return 0;
+} /* evpl_http2_on_data_chunk */
+
+static int
+evpl_http2_on_frame_send(
+    nghttp2_session     *session,
+    const nghttp2_frame *frame,
+    void                *user)
+{
+    struct evpl_http_request *request;
+
+    if ((frame->hd.type != NGHTTP2_HEADERS && frame->hd.type != NGHTTP2_DATA) ||
+        !(frame->hd.flags & NGHTTP2_FLAG_END_STREAM)) {
+        return 0;
+    }
+
+    request = nghttp2_session_get_stream_user_data(session, frame->hd.stream_id);
+
+    if (request) {
+        /* The local message (response on the server, request on the client) has
+         * been fully transmitted. */
+        evpl_http2_notify(request, EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE);
+    }
+
+    return 0;
+} /* evpl_http2_on_frame_send */
+
+static int
+evpl_http2_on_stream_close(
+    nghttp2_session *session,
+    int32_t          stream_id,
+    uint32_t         error_code,
+    void            *user)
+{
+    struct evpl_http_conn    *conn = user;
+    struct evpl_http_request *request;
+
+    request = nghttp2_session_get_stream_user_data(session, stream_id);
+
+    if (!request) {
+        return 0;
+    }
+
+    nghttp2_session_set_stream_user_data(session, stream_id, NULL);
+
+    DL_DELETE(conn->h2->streams, request);
+
+    evpl_http_request_free(conn->agent, request);
+
+    return 0;
+} /* evpl_http2_on_stream_close */
+
+/* ----- session lifecycle ----- */
+
+void
+evpl_http2_conn_init(struct evpl_http_conn *conn)
+{
+    struct evpl_http2_conn    *h2;
+    nghttp2_session_callbacks *callbacks;
+    nghttp2_settings_entry     iv[1];
+
+    h2       = evpl_zalloc(sizeof(*h2));
+    h2->conn = conn;
+    conn->h2 = h2;
+
+    nghttp2_session_callbacks_new(&callbacks);
+
+    nghttp2_session_callbacks_set_send_callback(callbacks, evpl_http2_send);
+    nghttp2_session_callbacks_set_send_data_callback(callbacks, evpl_http2_send_data);
+    nghttp2_session_callbacks_set_on_begin_headers_callback(callbacks, evpl_http2_on_begin_headers);
+    nghttp2_session_callbacks_set_on_header_callback(callbacks, evpl_http2_on_header);
+    nghttp2_session_callbacks_set_on_frame_recv_callback(callbacks, evpl_http2_on_frame_recv);
+    nghttp2_session_callbacks_set_on_data_chunk_recv_callback(callbacks, evpl_http2_on_data_chunk);
+    nghttp2_session_callbacks_set_on_frame_send_callback(callbacks, evpl_http2_on_frame_send);
+    nghttp2_session_callbacks_set_on_stream_close_callback(callbacks, evpl_http2_on_stream_close);
+
+    if (conn->is_server) {
+        nghttp2_session_server_new3(&h2->session, callbacks, conn, NULL, &evpl_http2_mem);
+    } else {
+        nghttp2_session_client_new3(&h2->session, callbacks, conn, NULL, &evpl_http2_mem);
+    }
+
+    nghttp2_session_callbacks_del(callbacks);
+
+    iv[0].settings_id = NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS;
+    iv[0].value       = 100;
+
+    nghttp2_submit_settings(h2->session, NGHTTP2_FLAG_NONE, iv, 1);
+} /* evpl_http2_conn_init */
+
+void
+evpl_http2_conn_destroy(struct evpl_http_conn *conn)
+{
+    struct evpl_http2_conn   *h2 = conn->h2;
+    struct evpl_http_request *request;
+
+    if (!h2) {
+        return;
+    }
+
+    while (h2->streams) {
+        request = h2->streams;
+        DL_DELETE(h2->streams, request);
+        evpl_http_request_free(conn->agent, request);
+    }
+
+    nghttp2_session_del(h2->session);
+
+    evpl_free(h2);
+    conn->h2 = NULL;
+} /* evpl_http2_conn_destroy */
+
+void
+evpl_http2_recv(struct evpl_http_conn *conn)
+{
+    struct evpl      *evpl = conn->agent->evpl;
+    struct evpl_bind *bind = conn->bind;
+    struct evpl_iovec iov[8];
+    int               niov, i, length;
+    ssize_t           rc;
+
+    while (1) {
+        niov = evpl_recvv(evpl, bind, iov, 8, 256 * 1024, &length);
+
+        if (niov <= 0) {
+            break;
+        }
+
+        for (i = 0; i < niov; i++) {
+            rc = nghttp2_session_mem_recv(conn->h2->session, iov[i].data, iov[i].length);
+
+            evpl_iovec_release(evpl, &iov[i]);
+
+            if (rc < 0) {
+                evpl_http_error("nghttp2 recv error: %s", nghttp2_strerror((int) rc));
+                evpl_close(evpl, bind);
+                return;
+            }
+        }
+    }
+
+    evpl_http2_flush(evpl, conn);
+} /* evpl_http2_recv */
+
+void
+evpl_http2_flush(
+    struct evpl *evpl,
+    void        *arg)
+{
+    struct evpl_http_conn    *conn = arg;
+    struct evpl_http_request *request, *tmp;
+    int                       rc;
+
+    if (!conn->connected || !conn->h2) {
+        return;
+    }
+
+    rc = nghttp2_session_send(conn->h2->session);
+
+    if (rc != 0) {
+        evpl_http_error("nghttp2 send error: %s", nghttp2_strerror(rc));
+        evpl_close(evpl, conn->bind);
+        return;
+    }
+
+    /* Now that the send pass has completed, ask the application to supply more
+     * body for any stream whose data provider ran dry.  Doing this here (rather
+     * than inside the provider callback) means the resulting
+     * nghttp2_session_resume_data runs outside nghttp2_session_send. */
+    DL_FOREACH_SAFE(conn->h2->streams, request, tmp)
+    {
+        if (request->h2.want_data) {
+            request->h2.want_data = 0;
+            evpl_http2_notify(request, EVPL_HTTP_NOTIFY_WANT_DATA);
+        }
+    }
+} /* evpl_http2_flush */
+
+/* ----- request/response submission ----- */
+
+static void
+evpl_http2_submit_response(struct evpl_http_request *request)
+{
+    struct evpl_http_conn           *conn = request->conn;
+    struct evpl_http_request_header *header;
+    nghttp2_nv                       nva[64];
+    nghttp2_data_provider            prd;
+    nghttp2_data_provider           *pprd;
+    size_t                           nvlen = 0;
+    char                             status_str[8];
+    int                              has_body;
+
+    snprintf(status_str, sizeof(status_str), "%d", request->status);
+
+    nva[nvlen].name     = (uint8_t *) ":status";
+    nva[nvlen].namelen  = 7;
+    nva[nvlen].value    = (uint8_t *) status_str;
+    nva[nvlen].valuelen = strlen(status_str);
+    nva[nvlen].flags    = NGHTTP2_NV_FLAG_NONE;
+    nvlen++;
+
+    DL_FOREACH(request->response_headers, header)
+    {
+        evpl_http2_lower(header->name);
+
+        if (evpl_http2_hop_by_hop(header->name) ||
+            strcmp(header->name, "content-length") == 0) {
+            continue;
+        }
+
+        if (nvlen >= 64) {
+            break;
+        }
+
+        nva[nvlen].name     = (uint8_t *) header->name;
+        nva[nvlen].namelen  = strlen(header->name);
+        nva[nvlen].value    = (uint8_t *) header->value;
+        nva[nvlen].valuelen = strlen(header->value);
+        nva[nvlen].flags    = NGHTTP2_NV_FLAG_NONE;
+        nvlen++;
+    }
+
+    has_body = (request->response_transfer_encoding ==
+                EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED) ||
+        request->response_left > 0;
+
+    if (has_body) {
+        prd.source.ptr    = request;
+        prd.read_callback = evpl_http2_data_read;
+        pprd              = &prd;
+    } else {
+        pprd = NULL;
+    }
+
+    nghttp2_submit_response(conn->h2->session, request->h2.stream_id,
+                            nva, nvlen, pprd);
+} /* evpl_http2_submit_response */
+
+static void
+evpl_http2_submit_request(struct evpl_http_request *request)
+{
+    struct evpl_http_conn           *conn = request->conn;
+    struct evpl_http_request_header *header;
+    nghttp2_nv                       nva[64];
+    nghttp2_data_provider            prd;
+    nghttp2_data_provider           *pprd;
+    size_t                           nvlen = 0;
+    const char                      *scheme;
+    const char                      *authority = NULL;
+    int                              has_body;
+    int32_t                          stream_id;
+
+    scheme = (evpl_bind_get_protocol(conn->bind) == EVPL_STREAM_SOCKET_TLS) ?
+        "https" : "http";
+
+    nva[nvlen].name     = (uint8_t *) ":method";
+    nva[nvlen].namelen  = 7;
+    nva[nvlen].value    = (uint8_t *) evpl_http_method_to_wire(request->request_type);
+    nva[nvlen].valuelen = strlen((char *) nva[nvlen].value);
+    nva[nvlen].flags    = NGHTTP2_NV_FLAG_NONE;
+    nvlen++;
+
+    nva[nvlen].name     = (uint8_t *) ":scheme";
+    nva[nvlen].namelen  = 7;
+    nva[nvlen].value    = (uint8_t *) scheme;
+    nva[nvlen].valuelen = strlen(scheme);
+    nva[nvlen].flags    = NGHTTP2_NV_FLAG_NONE;
+    nvlen++;
+
+    nva[nvlen].name     = (uint8_t *) ":path";
+    nva[nvlen].namelen  = 5;
+    nva[nvlen].value    = (uint8_t *) request->uri;
+    nva[nvlen].valuelen = strlen(request->uri);
+    nva[nvlen].flags    = NGHTTP2_NV_FLAG_NONE;
+    nvlen++;
+
+    DL_FOREACH(request->request_headers, header)
+    {
+        evpl_http2_lower(header->name);
+
+        if (strcmp(header->name, "host") == 0) {
+            authority = header->value;
+            continue;
+        }
+
+        if (evpl_http2_hop_by_hop(header->name) ||
+            strcmp(header->name, "content-length") == 0) {
+            continue;
+        }
+
+        if (nvlen >= 64) {
+            break;
+        }
+
+        nva[nvlen].name     = (uint8_t *) header->name;
+        nva[nvlen].namelen  = strlen(header->name);
+        nva[nvlen].value    = (uint8_t *) header->value;
+        nva[nvlen].valuelen = strlen(header->value);
+        nva[nvlen].flags    = NGHTTP2_NV_FLAG_NONE;
+        nvlen++;
+    }
+
+    if (authority) {
+        nva[nvlen].name     = (uint8_t *) ":authority";
+        nva[nvlen].namelen  = 10;
+        nva[nvlen].value    = (uint8_t *) authority;
+        nva[nvlen].valuelen = strlen(authority);
+        nva[nvlen].flags    = NGHTTP2_NV_FLAG_NONE;
+        nvlen++;
+    }
+
+    has_body = (request->response_transfer_encoding ==
+                EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED) ||
+        request->response_left > 0;
+
+    if (has_body) {
+        prd.source.ptr    = request;
+        prd.read_callback = evpl_http2_data_read;
+        pprd              = &prd;
+    } else {
+        pprd = NULL;
+    }
+
+    stream_id = nghttp2_submit_request(conn->h2->session, NULL, nva, nvlen,
+                                       pprd, request);
+
+    if (stream_id < 0) {
+        evpl_http_error("nghttp2 submit_request error: %s",
+                        nghttp2_strerror(stream_id));
+        return;
+    }
+
+    request->h2.stream_id = stream_id;
+} /* evpl_http2_submit_request */
+
+void
+evpl_http2_dispatch(struct evpl_http_request *request)
+{
+    struct evpl_http_conn *conn = request->conn;
+
+    if (conn->is_server) {
+        evpl_http2_submit_response(request);
+    } else {
+        DL_APPEND(conn->h2->streams, request);
+        evpl_http2_submit_request(request);
+    }
+
+    request->h2.headers_submitted = 1;
+
+    evpl_defer(conn->agent->evpl, &conn->flush);
+} /* evpl_http2_dispatch */
+
+void
+evpl_http2_submit(struct evpl_http_request *request)
+{
+    struct evpl_http_conn *conn = request->conn;
+
+    if (request->h2.headers_submitted && request->h2.deferred) {
+        request->h2.deferred = 0;
+        nghttp2_session_resume_data(conn->h2->session, request->h2.stream_id);
+    }
+
+    evpl_defer(conn->agent->evpl, &conn->flush);
+} /* evpl_http2_submit */

--- a/src/http/http_internal.h
+++ b/src/http/http_internal.h
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <string.h>
+#include <utlist.h>
+
+#include "core/evpl.h"
+#include "evpl/evpl.h"
+#include "core/iovec_ring.h"
+#include "evpl/evpl_http.h"
+
+#define evpl_http_debug(...) evpl_debug("http", __FILE__, __LINE__, __VA_ARGS__)
+#define evpl_http_info(...)  evpl_info("http", __FILE__, __LINE__, __VA_ARGS__)
+#define evpl_http_error(...) evpl_error("http", __FILE__, __LINE__, __VA_ARGS__)
+#define evpl_http_fatal(...) evpl_fatal("http", __FILE__, __LINE__, __VA_ARGS__)
+#define evpl_http_abort(...) evpl_abort("http", __FILE__, __LINE__, __VA_ARGS__)
+
+#define evpl_http_fatal_if(cond, ...) \
+        evpl_fatal_if(cond, "http", __FILE__, __LINE__, __VA_ARGS__)
+
+#define evpl_http_abort_if(cond, ...) \
+        evpl_abort_if(cond, "http", __FILE__, __LINE__, __VA_ARGS__)
+
+enum evpl_http_request_state {
+    EVPL_HTTP_REQUEST_STATE_INIT,
+    EVPL_HTTP_REQUEST_STATE_HEADERS,
+    EVPL_HTTP_REQUEST_STATE_BODY,
+    EVPL_HTTP_REQUEST_STATE_COMPLETE,
+};
+
+enum evpl_http_request_http_version {
+    EVPL_HTTP_REQUEST_HTTP_VERSION_1_0,
+    EVPL_HTTP_REQUEST_HTTP_VERSION_1_1,
+};
+
+enum evpl_http_request_transfer_encoding {
+    EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT,
+    EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED,
+};
+
+/* Protocol spoken on a connection.  UNKNOWN until decided (by ALPN on TLS or
+ * the h2c client preface / requested version on TCP). */
+enum evpl_http_proto {
+    EVPL_HTTP_PROTO_UNKNOWN = 0,
+    EVPL_HTTP_PROTO_H1,
+    EVPL_HTTP_PROTO_H2,
+};
+
+struct evpl_http_request_header {
+    struct evpl_http_request_header *prev;
+    struct evpl_http_request_header *next;
+    char                             name[256];
+    char                             value[16384];
+};
+
+#define EVPL_HTTP_REQUEST_WANTS_CONTINUE    0x01
+#define EVPL_HTTP_REQUEST_EXPECT_CHUNK_NL   0x02
+#define EVPL_HTTP_REQUEST_RESPONSE_READY    0x04
+#define EVPL_HTTP_REQUEST_RESPONSE_HDR_SENT 0x08
+#define EVPL_HTTP_REQUEST_RESPONSE_FINISHED 0x10
+/* Client: the request (headers + body) has been fully written to the wire and
+ * is now awaiting its response. */
+#define EVPL_HTTP_REQUEST_REQUEST_SENT      0x20
+
+/* Per-stream HTTP/2 bookkeeping, embedded in every request.  Only meaningful
+ * when request->conn->proto == EVPL_HTTP_PROTO_H2. */
+struct evpl_http2_stream {
+    int32_t stream_id;
+    int     headers_submitted;  /* nghttp2_submit_response/request already done */
+    int     deferred;           /* data provider returned NGHTTP2_ERR_DEFERRED  */
+    int     want_data;          /* provider needs more body; fire WANT_DATA      */
+    int     eof;                /* outgoing body finished (add_datav(NULL,0))    */
+};
+
+struct evpl_http_request {
+    enum evpl_http_request_type              request_type;
+    enum evpl_http_request_state             request_state;
+    enum evpl_http_request_http_version      http_version;
+    enum evpl_http_request_transfer_encoding request_transfer_encoding;
+    enum evpl_http_request_transfer_encoding response_transfer_encoding;
+    evpl_http_notify_callback_t              notify_callback;
+    void                                    *notify_data;
+    uint64_t                                 request_length;
+    uint64_t                                 request_left;
+    uint64_t                                 request_chunk_left;
+    uint64_t                                 response_length;
+    uint64_t                                 response_left;
+    uint64_t                                 request_flags;
+    int                                      status;
+    int                                      uri_len;
+    struct evpl_http_conn                   *conn;
+    struct evpl_iovec_ring                   send_ring;
+    struct evpl_iovec_ring                   recv_ring;
+    struct evpl_http_request_header         *request_headers;
+    struct evpl_http_request_header         *response_headers;
+    struct evpl_http2_stream                 h2;
+    struct evpl_http_request                *prev;
+    struct evpl_http_request                *next;
+    char                                     uri[16384];
+};
+
+struct evpl_http_conn {
+    int                       is_server;
+    enum evpl_http_proto proto;
+    enum evpl_http_version version;        /* requested version (client) */
+    int                       connected;   /* bind handshake/connect done */
+    struct evpl_http_server  *server;
+    struct evpl_http_agent   *agent;
+    struct evpl_bind         *bind;
+    struct evpl_deferral      flush;
+    struct evpl_http_request *current_request;
+    struct evpl_http_request *pending_requests;
+    struct evpl_http2_conn   *h2;          /* NULL unless proto == H2 */
+    void                     *private_data;
+};
+
+struct evpl_http_server {
+    struct evpl_http_agent       *agent;
+    struct evpl_listener         *listener;
+    struct evpl_listener_binding *binding;
+    void                         *private_data;
+    evpl_http_dispatch_callback_t dispatch_callback;
+};
+
+struct evpl_http_agent {
+    struct evpl_http_request        *free_requests;
+    struct evpl_http_request_header *free_headers;
+    struct evpl                     *evpl;
+};
+
+static inline struct evpl_http_request_header *
+evpl_http_request_header_alloc(struct evpl_http_agent *agent)
+{
+    struct evpl_http_request_header *header;
+
+    header = agent->free_headers;
+
+    if (header) {
+        agent->free_headers = header->next;
+    } else {
+        header = evpl_zalloc(sizeof(*header));
+    }
+
+    return header;
+} /* evpl_http_request_header_alloc */
+
+static inline void
+evpl_http_request_header_free(
+    struct evpl_http_agent          *agent,
+    struct evpl_http_request_header *header)
+{
+    LL_PREPEND(agent->free_headers, header);
+} /* evpl_http_request_header_free */
+
+static inline struct evpl_http_request *
+evpl_http_request_alloc(struct evpl_http_agent *agent)
+{
+    struct evpl_http_request *request;
+
+    request = agent->free_requests;
+
+    if (request) {
+        agent->free_requests = request->next;
+    } else {
+        request = evpl_zalloc(sizeof(*request));
+        evpl_iovec_ring_alloc(&request->send_ring, 1024, 4096);
+        evpl_iovec_ring_alloc(&request->recv_ring, 1024, 4096);
+    }
+
+    request->request_type               = EVPL_HTTP_REQUEST_TYPE_UNKNOWN;
+    request->request_state              = EVPL_HTTP_REQUEST_STATE_INIT;
+    request->http_version               = EVPL_HTTP_REQUEST_HTTP_VERSION_1_1;
+    request->request_transfer_encoding  = EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT;
+    request->response_transfer_encoding = EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT;
+    request->request_length             = 0;
+    request->request_left               = 0;
+    request->request_chunk_left         = 0;
+    request->response_length            = 0;
+    request->response_left              = 0;
+    request->request_flags              = 0;
+    request->status                     = 0;
+    request->uri_len                    = 0;
+    request->notify_callback            = NULL;
+    request->notify_data                = NULL;
+    request->request_headers            = NULL;
+    request->response_headers           = NULL;
+    memset(&request->h2, 0, sizeof(request->h2));
+    return request;
+} /* evpl_http_request_alloc */
+
+static inline void
+evpl_http_request_free(
+    struct evpl_http_agent   *agent,
+    struct evpl_http_request *request)
+{
+    struct evpl_http_request_header *header;
+
+    while (request->request_headers) {
+        header = request->request_headers;
+        DL_DELETE(request->request_headers, header);
+        evpl_http_request_header_free(agent, header);
+    }
+
+    while (request->response_headers) {
+        header = request->response_headers;
+        DL_DELETE(request->response_headers, header);
+        evpl_http_request_header_free(agent, header);
+    }
+
+    evpl_iovec_ring_clear(agent->evpl, &request->recv_ring);
+    evpl_iovec_ring_clear(agent->evpl, &request->send_ring);
+
+    LL_PREPEND(agent->free_requests, request);
+} /* evpl_http_request_free */
+
+static inline int
+evpl_copy_string(
+    char       *dst,
+    const char *src,
+    int         maxlen)
+{
+    const char *sp = src;
+    char       *dp = dst;
+
+    while (*sp) {
+
+        if (unlikely(dp - dst >= maxlen - 1)) {
+            return -1;
+        }
+
+        *dp++ = *sp++;
+    }
+
+    *dp = '\0';
+
+    return dp - dst;
+} /* evpl_copy_string */
+
+static inline enum evpl_http_request_type
+evpl_http_method_from_string(const char *token)
+{
+    if (strcmp(token, "GET") == 0) {
+        return EVPL_HTTP_REQUEST_TYPE_GET;
+    } else if (strcmp(token, "HEAD") == 0) {
+        return EVPL_HTTP_REQUEST_TYPE_HEAD;
+    } else if (strcmp(token, "POST") == 0) {
+        return EVPL_HTTP_REQUEST_TYPE_POST;
+    } else if (strcmp(token, "PUT") == 0) {
+        return EVPL_HTTP_REQUEST_TYPE_PUT;
+    } else if (strcmp(token, "DELETE") == 0) {
+        return EVPL_HTTP_REQUEST_TYPE_DELETE;
+    } else {
+        return EVPL_HTTP_REQUEST_TYPE_UNKNOWN;
+    }
+} /* evpl_http_method_from_string */
+
+static inline const char *
+evpl_http_method_to_wire(enum evpl_http_request_type type)
+{
+    switch (type) {
+        case EVPL_HTTP_REQUEST_TYPE_GET:
+            return "GET";
+        case EVPL_HTTP_REQUEST_TYPE_HEAD:
+            return "HEAD";
+        case EVPL_HTTP_REQUEST_TYPE_POST:
+            return "POST";
+        case EVPL_HTTP_REQUEST_TYPE_PUT:
+            return "PUT";
+        case EVPL_HTTP_REQUEST_TYPE_DELETE:
+            return "DELETE";
+        default:
+            return "GET";
+    } /* switch */
+} /* evpl_http_method_to_wire */
+
+/* Private data passed to notify/dispatch callbacks: the server's private data
+ * for accepted connections, the connection's private data for clients. */
+static inline void *
+evpl_http_priv(struct evpl_http_conn *conn)
+{
+    return conn->is_server ? conn->server->private_data : conn->private_data;
+} /* evpl_http_priv */
+
+/* The single flush deferral entry point; dispatches by protocol/direction. */
+void
+evpl_http_flush(
+    struct evpl *evpl,
+    void        *arg);
+
+#ifdef HAVE_NGHTTP2
+
+/* HTTP/2 codec entry points (src/http/http2.c). */
+
+void
+evpl_http2_conn_init(
+    struct evpl_http_conn *conn);
+
+void
+evpl_http2_conn_destroy(
+    struct evpl_http_conn *conn);
+
+void
+evpl_http2_recv(
+    struct evpl_http_conn *conn);
+
+void
+evpl_http2_flush(
+    struct evpl *evpl,
+    void        *arg);
+
+/* Submit a request (client) or response (server) to the nghttp2 session and
+ * pump.  Called when the application dispatches a request/response on an
+ * already-established h2 connection. */
+void
+evpl_http2_dispatch(
+    struct evpl_http_request *request);
+
+/* Resume a deferred body / pump the session after the application appended more
+ * body data via evpl_http_request_add_datav on an h2 connection. */
+void
+evpl_http2_submit(
+    struct evpl_http_request *request);
+
+#endif /* HAVE_NGHTTP2 */

--- a/src/http/tests/CMakeLists.txt
+++ b/src/http/tests/CMakeLists.txt
@@ -7,3 +7,23 @@ unit_test(http chunked http_chunked.c)
 
 target_link_libraries(http_basic evpl_http curl)
 target_link_libraries(http_chunked evpl_http curl)
+
+# evpl HTTP/1.1 client <-> evpl server (no nghttp2 required)
+unit_test(http client http1_client.c)
+target_link_libraries(http_client evpl_http)
+
+if (HAVE_NGHTTP2)
+    # evpl HTTP/2 client <-> evpl server (h2c prior-knowledge, and h2 over TLS)
+    unit_test(http h2_client http2_client.c)
+    target_link_libraries(http_h2_client evpl_http)
+
+    unit_test(http h2_client_tls http2_client_tls.c)
+    target_link_libraries(http_h2_client_tls evpl_http)
+
+    # libevpl HTTP/2 server driven by libcurl (reference client)
+    unit_test(http h2_basic http2_basic.c)
+    target_link_libraries(http_h2_basic evpl_http curl)
+
+    unit_test(http h2_tls http2_tls.c)
+    target_link_libraries(http_h2_tls evpl_http curl)
+endif()

--- a/src/http/tests/http1_client.c
+++ b/src/http/tests/http1_client.c
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Exercises the libevpl HTTP client against the libevpl HTTP server over plain
+ * HTTP/1.1: GET (no body), POST (fixed Content-Length), and a chunked request
+ * answered with a chunked response.  The server runs in its own thread/event
+ * loop; the client drives its own event loop in the main thread.
+ *
+ * The same harness backs http2_client (which selects HTTP/2 via the version
+ * argument), so this also validates the unified, transport-agnostic API.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+
+#ifndef TEST_PROTOCOL
+#define TEST_PROTOCOL EVPL_STREAM_SOCKET_TCP
+#endif /* ifndef TEST_PROTOCOL */
+
+#ifndef TEST_VERSION
+#define TEST_VERSION  EVPL_HTTP_VERSION_HTTP1
+#endif /* ifndef TEST_VERSION */
+
+#define TEST_PORT     8080
+
+static const char response_body[] = "hello world";
+
+/* ------------------------------------------------------------------ server */
+
+struct test_server {
+    pthread_t            thread;
+    volatile int         run;
+    struct evpl_doorbell doorbell;
+};
+
+static void
+server_wake(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+} /* server_wake */
+
+static void
+server_notify(
+    struct evpl                *evpl,
+    struct evpl_http_agent     *agent,
+    struct evpl_http_request   *request,
+    enum evpl_http_notify_type  notify_type,
+    enum evpl_http_request_type request_type,
+    const char                 *uri,
+    void                       *notify_data,
+    void                       *private_data)
+{
+    struct evpl_iovec iov;
+    int               chunked;
+
+    switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
+            chunked = (strcmp(uri, "/chunked") == 0);
+
+            evpl_http_request_add_header(request, "MyHeader", "MyValue");
+
+            if (chunked) {
+                evpl_http_server_set_response_chunked(request);
+                evpl_http_server_dispatch_default(request, 200);
+            } else {
+                evpl_iovec_alloc(evpl, sizeof(response_body) - 1, 0, 1, 0, &iov);
+                memcpy(iov.data, response_body, sizeof(response_body) - 1);
+                iov.length = sizeof(response_body) - 1;
+                evpl_http_server_set_response_length(request, sizeof(response_body) - 1);
+                evpl_http_request_add_datav(request, &iov, 1);
+                evpl_http_server_dispatch_default(request, 200);
+            }
+            break;
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+            /* chunked response: stream the body then finish */
+            evpl_iovec_alloc(evpl, sizeof(response_body) - 1, 0, 1, 0, &iov);
+            memcpy(iov.data, response_body, sizeof(response_body) - 1);
+            iov.length = sizeof(response_body) - 1;
+            evpl_http_request_add_datav(request, &iov, 1);
+            evpl_http_request_add_datav(request, NULL, 0);
+            break;
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+        case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
+            break;
+    } /* switch */
+} /* server_notify */
+
+static void
+server_dispatch(
+    struct evpl                 *evpl,
+    struct evpl_http_agent      *agent,
+    struct evpl_http_request    *request,
+    evpl_http_notify_callback_t *notify_callback,
+    void                       **notify_data,
+    void                        *private_data)
+{
+    *notify_callback = server_notify;
+    *notify_data     = NULL;
+} /* server_dispatch */
+
+static void *
+server_function(void *ptr)
+{
+    struct test_server      *server_ctx = ptr;
+    struct evpl_http_server *server;
+    struct evpl             *evpl;
+    struct evpl_endpoint    *endpoint;
+    struct evpl_listener    *listener;
+    struct evpl_http_agent  *agent;
+
+    evpl = evpl_create(NULL);
+
+    evpl_add_doorbell(evpl, &server_ctx->doorbell, server_wake);
+
+    agent = evpl_http_init(evpl);
+
+    endpoint = evpl_endpoint_create("0.0.0.0", TEST_PORT);
+
+    listener = evpl_listener_create();
+
+    server = evpl_http_attach(agent, listener, server_dispatch, NULL);
+
+    evpl_listen(listener, TEST_PROTOCOL, endpoint);
+
+    __sync_synchronize();
+
+    server_ctx->run = 1;
+
+    while (server_ctx->run) {
+        evpl_continue(evpl);
+    }
+
+    evpl_http_server_destroy(agent, server);
+    evpl_http_destroy(agent);
+
+    evpl_listener_destroy(listener);
+    evpl_destroy(evpl);
+
+    return NULL;
+} /* server_function */
+
+/* ------------------------------------------------------------------ client */
+
+struct req_ctx {
+    int  done;
+    int  status;
+    int  body_len;
+    char body[256];
+};
+
+static void
+client_drain(
+    struct evpl              *evpl,
+    struct evpl_http_request *request,
+    struct req_ctx           *rc)
+{
+    struct evpl_iovec iov[8];
+    uint64_t          avail;
+    int               niov, i;
+
+    avail = evpl_http_request_get_data_avail(request);
+
+    while (avail > 0) {
+        niov = evpl_http_request_get_datav(evpl, request, iov, (int) avail);
+
+        for (i = 0; i < niov; i++) {
+            memcpy(rc->body + rc->body_len, iov[i].data, iov[i].length);
+            rc->body_len += iov[i].length;
+            evpl_iovec_release(evpl, &iov[i]);
+        }
+
+        avail = evpl_http_request_get_data_avail(request);
+    }
+} /* client_drain */
+
+static void
+client_notify(
+    struct evpl                *evpl,
+    struct evpl_http_agent     *agent,
+    struct evpl_http_request   *request,
+    enum evpl_http_notify_type  notify_type,
+    enum evpl_http_request_type request_type,
+    const char                 *uri,
+    void                       *notify_data,
+    void                       *private_data)
+{
+    struct req_ctx *rc = notify_data;
+
+    switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+            rc->status = evpl_http_request_status(request);
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+            client_drain(evpl, request, rc);
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
+            client_drain(evpl, request, rc);
+            rc->done = 1;
+            break;
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+        case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
+            break;
+    } /* switch */
+} /* client_notify */
+
+static const char *
+evpl_http_method_type_name(
+    enum evpl_http_request_type t);
+
+static int
+do_request(
+    struct evpl                *evpl,
+    struct evpl_http_conn      *conn,
+    enum evpl_http_request_type method,
+    const char                 *url,
+    const char                 *body,
+    int                         chunked)
+{
+    struct evpl_http_request *request;
+    struct req_ctx            rc;
+    struct evpl_iovec         iov;
+    size_t                    body_len = body ? strlen(body) : 0;
+
+    memset(&rc, 0, sizeof(rc));
+
+    request = evpl_http_request_create(conn, method, url);
+
+    evpl_http_request_add_header(request, "Host", "localhost");
+
+    if (chunked) {
+        evpl_http_client_set_request_chunked(request);
+        if (body_len) {
+            evpl_iovec_alloc(evpl, body_len, 0, 1, 0, &iov);
+            memcpy(iov.data, body, body_len);
+            iov.length = body_len;
+            evpl_http_request_add_datav(request, &iov, 1);
+        }
+        evpl_http_request_add_datav(request, NULL, 0);
+    } else {
+        evpl_http_client_set_request_length(request, body_len);
+        if (body_len) {
+            evpl_iovec_alloc(evpl, body_len, 0, 1, 0, &iov);
+            memcpy(iov.data, body, body_len);
+            iov.length = body_len;
+            evpl_http_request_add_datav(request, &iov, 1);
+        }
+    }
+
+    evpl_http_request_dispatch(request, client_notify, &rc);
+
+    while (!rc.done) {
+        evpl_continue(evpl);
+    }
+
+    if (rc.status != 200) {
+        fprintf(stderr, "%s %s: bad status %d\n",
+                evpl_http_method_type_name(method), url, rc.status);
+        return 1;
+    }
+
+    if (rc.body_len != (int) (sizeof(response_body) - 1) ||
+        memcmp(rc.body, response_body, rc.body_len) != 0) {
+        fprintf(stderr, "%s %s: bad body '%.*s' (%d bytes)\n",
+                evpl_http_method_type_name(method), url,
+                rc.body_len, rc.body, rc.body_len);
+        return 1;
+    }
+
+    fprintf(stderr, "%s %s: ok (status %d, %d bytes)\n",
+            evpl_http_method_type_name(method), url, rc.status, rc.body_len);
+
+    return 0;
+} /* do_request */
+
+/* method name for diagnostics only */
+static const char *
+evpl_http_method_type_name(enum evpl_http_request_type t)
+{
+    switch (t) {
+        case EVPL_HTTP_REQUEST_TYPE_GET:
+            return "GET";
+        case EVPL_HTTP_REQUEST_TYPE_POST:
+            return "POST";
+        default:
+            return "?";
+    } /* switch */
+} /* evpl_http_method_type_name */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct test_server         server;
+    struct evpl               *evpl;
+    struct evpl_http_agent    *agent;
+    struct evpl_endpoint      *endpoint;
+    struct evpl_http_conn     *conn;
+    struct evpl_global_config *config;
+    int                        rc = 0;
+
+    /* TLS variants use a self-signed server cert; skip peer verification. */
+    config = evpl_global_config_init();
+    evpl_global_config_set_tls_verify_peer(config, 0);
+    evpl_init(config);
+
+    server.run = 0;
+
+    pthread_create(&server.thread, NULL, server_function, &server);
+
+    while (!server.run) {
+        __sync_synchronize();
+    }
+
+    evpl = evpl_create(NULL);
+
+    agent = evpl_http_init(evpl);
+
+    endpoint = evpl_endpoint_create("127.0.0.1", TEST_PORT);
+
+    conn = evpl_http_client_connect(agent, TEST_PROTOCOL, endpoint,
+                                    TEST_VERSION, NULL);
+
+    rc |= do_request(evpl, conn, EVPL_HTTP_REQUEST_TYPE_GET, "/", NULL, 0);
+    rc |= do_request(evpl, conn, EVPL_HTTP_REQUEST_TYPE_POST, "/", "ping pong", 0);
+    rc |= do_request(evpl, conn, EVPL_HTTP_REQUEST_TYPE_POST, "/chunked", "streamed", 1);
+
+    evpl_http_client_close(agent, conn);
+
+    evpl_http_destroy(agent);
+    evpl_destroy(evpl);
+
+    server.run = 0;
+    __sync_synchronize();
+    evpl_ring_doorbell(&server.doorbell);
+    pthread_join(server.thread, NULL);
+
+    if (rc == 0) {
+        fprintf(stderr, "all requests ok\n");
+    }
+
+    return rc;
+} /* main */

--- a/src/http/tests/http2_basic.c
+++ b/src/http/tests/http2_basic.c
@@ -2,9 +2,15 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+/*
+ * Drives the libevpl HTTP/2 server with libcurl using h2c prior-knowledge
+ * (cleartext HTTP/2, no Upgrade).  The server code is identical to the HTTP/1.x
+ * server tests -- proof of the transparent, unified API.
+ */
+
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-#include <sys/eventfd.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <curl/curl.h>
@@ -12,9 +18,11 @@
 #include "evpl/evpl.h"
 #include "evpl/evpl_http.h"
 
+#define TEST_PORT 8081
+
 struct test_server {
     pthread_t            thread;
-    int                  run;
+    volatile int         run;
     struct evpl_doorbell doorbell;
 };
 
@@ -23,7 +31,6 @@ server_wake(
     struct evpl          *evpl,
     struct evpl_doorbell *doorbell)
 {
-    /* do nothing */
 } /* server_wake */
 
 static void
@@ -40,30 +47,19 @@ server_notify(
     struct evpl_iovec iov;
 
     switch (notify_type) {
-        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
-            break;
-        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
-            fprintf(stderr, "notify request\n");
-            break;
         case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
-            fprintf(stderr, "notify request complete\n");
             evpl_http_request_add_header(request, "MyHeader", "MyValue");
-            evpl_http_server_set_response_chunked(request);
-            evpl_http_server_dispatch_default(request, 200);
-            break;
-        case EVPL_HTTP_NOTIFY_WANT_DATA:
-            fprintf(stderr, "notify want data\n");
-
             evpl_iovec_alloc(evpl, 11, 0, 1, 0, &iov);
             memcpy(iov.data, "hello world", 11);
             iov.length = 11;
-
+            evpl_http_server_set_response_length(request, 11);
             evpl_http_request_add_datav(request, &iov, 1);
-            evpl_http_request_add_datav(request, NULL, 0);
-
+            evpl_http_server_dispatch_default(request, 200);
             break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
         case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
-            fprintf(stderr, "notify response complete\n");
             break;
     } /* switch */
 } /* server_notify */
@@ -77,15 +73,14 @@ server_dispatch(
     void                       **notify_data,
     void                        *private_data)
 {
-    fprintf(stderr, "dispatch request\n");
     *notify_callback = server_notify;
     *notify_data     = NULL;
 } /* server_dispatch */
 
-void *
+static void *
 server_function(void *ptr)
 {
-    struct test_server      *server_ctx = (struct test_server *) ptr;
+    struct test_server      *server_ctx = ptr;
     struct evpl_http_server *server;
     struct evpl             *evpl;
     struct evpl_endpoint    *endpoint;
@@ -93,21 +88,15 @@ server_function(void *ptr)
     struct evpl_http_agent  *agent;
 
     evpl = evpl_create(NULL);
-
     evpl_add_doorbell(evpl, &server_ctx->doorbell, server_wake);
-
-    agent = evpl_http_init(evpl);
-
-    endpoint = evpl_endpoint_create("0.0.0.0", 80);
-
+    agent    = evpl_http_init(evpl);
+    endpoint = evpl_endpoint_create("0.0.0.0", TEST_PORT);
     listener = evpl_listener_create();
-
-    server = evpl_http_attach(agent, listener, server_dispatch, NULL);
+    server   = evpl_http_attach(agent, listener, server_dispatch, NULL);
 
     evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint);
 
     __sync_synchronize();
-
     server_ctx->run = 1;
 
     while (server_ctx->run) {
@@ -116,26 +105,11 @@ server_function(void *ptr)
 
     evpl_http_server_destroy(agent, server);
     evpl_http_destroy(agent);
-
     evpl_listener_destroy(listener);
-
     evpl_destroy(evpl);
 
     return NULL;
-} /* server */
-
-static size_t
-header_callback(
-    char  *buffer,
-    size_t size,
-    size_t nitems,
-    void  *userdata)
-{
-    size_t total_size = size * nitems;
-
-    fprintf(stderr, "Received header: %.*s", (int) total_size, buffer);
-    return total_size;
-} /* header_callback */
+} /* server_function */
 
 static size_t
 write_callback(
@@ -144,53 +118,22 @@ write_callback(
     size_t nmemb,
     void  *userdata)
 {
-    size_t total_size = size * nmemb;
-
-    fprintf(stderr, "Response body: %.*s\n", (int) total_size, ptr);
-    return total_size;
+    return size * nmemb;
 } /* write_callback */
-
-static size_t      total_sent = 0;
-static const char *chunks[]   = {
-    "This is the first chunk of data",
-    "Here comes the second chunk",
-    "And finally, the third chunk"
-};
-static size_t      num_chunks = 3;
-
-static size_t
-read_callback(
-    char  *buffer,
-    size_t size,
-    size_t nitems,
-    void  *userdata)
-{
-    size_t chunk_index = total_sent;
-
-    if (chunk_index >= num_chunks) {
-        return 0;  // Signal end of data
-    }
-
-    size_t to_copy = strlen(chunks[chunk_index]);
-    memcpy(buffer, chunks[chunk_index], to_copy);
-    total_sent++;
-
-    return to_copy;
-} /* read_callback */
 
 int
 main(
     int   argc,
     char *argv[])
-
 {
     struct test_server server;
     CURL              *curl;
     CURLcode           res;
-    long               http_code = 0;
+    long               http_code    = 0;
+    long               http_version = 0;
+    char               url[64];
 
     server.run = 0;
-
     pthread_create(&server.thread, NULL, server_function, &server);
 
     while (!server.run) {
@@ -198,42 +141,36 @@ main(
     }
 
     curl = curl_easy_init();
-
     if (!curl) {
         fprintf(stderr, "Failed to initialize curl\n");
         return 1;
     }
 
-    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:80");
+    snprintf(url, sizeof(url), "http://localhost:%d", TEST_PORT);
+
+    curl_easy_setopt(curl, CURLOPT_URL, url);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
-    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-
-    // Set up chunked transfer
-    curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
-    curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, -1L);  // Required for chunked transfer
-    curl_easy_setopt(curl, CURLOPT_POST, 1L);
-
-    total_sent = 0;  // Reset counter before sending
+    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION,
+                     (long) CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE);
 
     res = curl_easy_perform(curl);
 
     if (res == CURLE_OK) {
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-        fprintf(stderr, "http_code %ld\n", http_code);
-
-
+        curl_easy_getinfo(curl, CURLINFO_HTTP_VERSION, &http_version);
+        fprintf(stderr, "http_code %ld http_version %ld\n", http_code, http_version);
+    } else {
+        fprintf(stderr, "curl failed: %s\n", curl_easy_strerror(res));
     }
 
     curl_easy_cleanup(curl);
 
     server.run = 0;
     __sync_synchronize();
-
     evpl_ring_doorbell(&server.doorbell);
-
     pthread_join(server.thread, NULL);
 
-    return (res == CURLE_OK && http_code == 200) ? 0 : 1;
+    return (res == CURLE_OK && http_code == 200 &&
+            http_version == CURL_HTTP_VERSION_2_0) ? 0 : 1;
 } /* main */

--- a/src/http/tests/http2_client.c
+++ b/src/http/tests/http2_client.c
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Same evpl-client <-> evpl-server harness as http1_client, but selecting
+ * HTTP/2 (h2c prior-knowledge over plain TCP).  Proves the unified client/server
+ * code drives HTTP/2 with no API changes.
+ */
+
+#define TEST_VERSION EVPL_HTTP_VERSION_HTTP2
+
+#include "http1_client.c"

--- a/src/http/tests/http2_client_tls.c
+++ b/src/http/tests/http2_client_tls.c
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Same evpl-client <-> evpl-server harness as http1_client, but over TLS with
+ * HTTP/2 negotiated via ALPN ("h2").
+ */
+
+#define TEST_PROTOCOL EVPL_STREAM_SOCKET_TLS
+#define TEST_VERSION  EVPL_HTTP_VERSION_HTTP2
+
+#include "http1_client.c"

--- a/src/http/tests/http2_tls.c
+++ b/src/http/tests/http2_tls.c
@@ -2,9 +2,15 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+/*
+ * Drives the libevpl HTTP/2 server with libcurl over TLS, with HTTP/2 selected
+ * via ALPN ("h2").  The server uses an auto-generated self-signed certificate
+ * (peer verification disabled on both ends).
+ */
+
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-#include <sys/eventfd.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <curl/curl.h>
@@ -12,9 +18,11 @@
 #include "evpl/evpl.h"
 #include "evpl/evpl_http.h"
 
+#define TEST_PORT 8082
+
 struct test_server {
     pthread_t            thread;
-    int                  run;
+    volatile int         run;
     struct evpl_doorbell doorbell;
 };
 
@@ -23,7 +31,6 @@ server_wake(
     struct evpl          *evpl,
     struct evpl_doorbell *doorbell)
 {
-    /* do nothing */
 } /* server_wake */
 
 static void
@@ -40,30 +47,19 @@ server_notify(
     struct evpl_iovec iov;
 
     switch (notify_type) {
-        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
-            break;
-        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
-            fprintf(stderr, "notify request\n");
-            break;
         case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
-            fprintf(stderr, "notify request complete\n");
             evpl_http_request_add_header(request, "MyHeader", "MyValue");
-            evpl_http_server_set_response_chunked(request);
-            evpl_http_server_dispatch_default(request, 200);
-            break;
-        case EVPL_HTTP_NOTIFY_WANT_DATA:
-            fprintf(stderr, "notify want data\n");
-
             evpl_iovec_alloc(evpl, 11, 0, 1, 0, &iov);
             memcpy(iov.data, "hello world", 11);
             iov.length = 11;
-
+            evpl_http_server_set_response_length(request, 11);
             evpl_http_request_add_datav(request, &iov, 1);
-            evpl_http_request_add_datav(request, NULL, 0);
-
+            evpl_http_server_dispatch_default(request, 200);
             break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
         case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
-            fprintf(stderr, "notify response complete\n");
             break;
     } /* switch */
 } /* server_notify */
@@ -77,15 +73,14 @@ server_dispatch(
     void                       **notify_data,
     void                        *private_data)
 {
-    fprintf(stderr, "dispatch request\n");
     *notify_callback = server_notify;
     *notify_data     = NULL;
 } /* server_dispatch */
 
-void *
+static void *
 server_function(void *ptr)
 {
-    struct test_server      *server_ctx = (struct test_server *) ptr;
+    struct test_server      *server_ctx = ptr;
     struct evpl_http_server *server;
     struct evpl             *evpl;
     struct evpl_endpoint    *endpoint;
@@ -93,21 +88,15 @@ server_function(void *ptr)
     struct evpl_http_agent  *agent;
 
     evpl = evpl_create(NULL);
-
     evpl_add_doorbell(evpl, &server_ctx->doorbell, server_wake);
-
-    agent = evpl_http_init(evpl);
-
-    endpoint = evpl_endpoint_create("0.0.0.0", 80);
-
+    agent    = evpl_http_init(evpl);
+    endpoint = evpl_endpoint_create("0.0.0.0", TEST_PORT);
     listener = evpl_listener_create();
+    server   = evpl_http_attach(agent, listener, server_dispatch, NULL);
 
-    server = evpl_http_attach(agent, listener, server_dispatch, NULL);
-
-    evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint);
+    evpl_listen(listener, EVPL_STREAM_SOCKET_TLS, endpoint);
 
     __sync_synchronize();
-
     server_ctx->run = 1;
 
     while (server_ctx->run) {
@@ -116,26 +105,11 @@ server_function(void *ptr)
 
     evpl_http_server_destroy(agent, server);
     evpl_http_destroy(agent);
-
     evpl_listener_destroy(listener);
-
     evpl_destroy(evpl);
 
     return NULL;
-} /* server */
-
-static size_t
-header_callback(
-    char  *buffer,
-    size_t size,
-    size_t nitems,
-    void  *userdata)
-{
-    size_t total_size = size * nitems;
-
-    fprintf(stderr, "Received header: %.*s", (int) total_size, buffer);
-    return total_size;
-} /* header_callback */
+} /* server_function */
 
 static size_t
 write_callback(
@@ -144,53 +118,28 @@ write_callback(
     size_t nmemb,
     void  *userdata)
 {
-    size_t total_size = size * nmemb;
-
-    fprintf(stderr, "Response body: %.*s\n", (int) total_size, ptr);
-    return total_size;
+    return size * nmemb;
 } /* write_callback */
-
-static size_t      total_sent = 0;
-static const char *chunks[]   = {
-    "This is the first chunk of data",
-    "Here comes the second chunk",
-    "And finally, the third chunk"
-};
-static size_t      num_chunks = 3;
-
-static size_t
-read_callback(
-    char  *buffer,
-    size_t size,
-    size_t nitems,
-    void  *userdata)
-{
-    size_t chunk_index = total_sent;
-
-    if (chunk_index >= num_chunks) {
-        return 0;  // Signal end of data
-    }
-
-    size_t to_copy = strlen(chunks[chunk_index]);
-    memcpy(buffer, chunks[chunk_index], to_copy);
-    total_sent++;
-
-    return to_copy;
-} /* read_callback */
 
 int
 main(
     int   argc,
     char *argv[])
-
 {
-    struct test_server server;
-    CURL              *curl;
-    CURLcode           res;
-    long               http_code = 0;
+    struct test_server         server;
+    struct evpl_global_config *config;
+    CURL                      *curl;
+    CURLcode                   res;
+    long                       http_code    = 0;
+    long                       http_version = 0;
+    char                       url[64];
+
+    /* Self-signed server cert; don't require a client cert. */
+    config = evpl_global_config_init();
+    evpl_global_config_set_tls_verify_peer(config, 0);
+    evpl_init(config);
 
     server.run = 0;
-
     pthread_create(&server.thread, NULL, server_function, &server);
 
     while (!server.run) {
@@ -198,42 +147,38 @@ main(
     }
 
     curl = curl_easy_init();
-
     if (!curl) {
         fprintf(stderr, "Failed to initialize curl\n");
         return 1;
     }
 
-    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:80");
+    snprintf(url, sizeof(url), "https://localhost:%d", TEST_PORT);
+
+    curl_easy_setopt(curl, CURLOPT_URL, url);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
-    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-
-    // Set up chunked transfer
-    curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
-    curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, -1L);  // Required for chunked transfer
-    curl_easy_setopt(curl, CURLOPT_POST, 1L);
-
-    total_sent = 0;  // Reset counter before sending
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION,
+                     (long) CURL_HTTP_VERSION_2TLS);
 
     res = curl_easy_perform(curl);
 
     if (res == CURLE_OK) {
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-        fprintf(stderr, "http_code %ld\n", http_code);
-
-
+        curl_easy_getinfo(curl, CURLINFO_HTTP_VERSION, &http_version);
+        fprintf(stderr, "http_code %ld http_version %ld\n", http_code, http_version);
+    } else {
+        fprintf(stderr, "curl failed: %s\n", curl_easy_strerror(res));
     }
 
     curl_easy_cleanup(curl);
 
     server.run = 0;
     __sync_synchronize();
-
     evpl_ring_doorbell(&server.doorbell);
-
     pthread_join(server.thread, NULL);
 
-    return (res == CURLE_OK && http_code == 200) ? 0 : 1;
+    return (res == CURLE_OK && http_code == 200 &&
+            http_version == CURL_HTTP_VERSION_2_0) ? 0 : 1;
 } /* main */

--- a/src/http/tests/http_basic.c
+++ b/src/http/tests/http_basic.c
@@ -54,6 +54,8 @@ server_notify(
     int               header_count;
 
     switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+            break;
         case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
             fprintf(stderr, "notify request\n");
             break;


### PR DESCRIPTION
## Summary

Adds HTTP/2 support (client **and** server) to libevpl's HTTP layer using [nghttp2](https://nghttp2.org/), alongside a new **HTTP/1.1 client** — the layer was previously server-only (the client receive path was an `abort()`).

The application-facing API is **unified and transport-agnostic**: the same `evpl_http` dispatch/notify callbacks and `struct evpl_http_request` drive both HTTP/1.x and HTTP/2. Each HTTP/2 stream maps to one request, and the protocol version is chosen automatically — by ALPN over TLS, or the client preface / requested version in cleartext. Existing HTTP/1.x server code is unchanged in behavior.

## Details

- **nghttp2** is detected via `find_library` and gated behind `-DHAVE_NGHTTP2`. Without it the library builds HTTP/1.x-only and simply never advertises `h2`.
- **Transports:** `h2c` prior-knowledge (cleartext) and `h2` over TLS via **ALPN**.
- **ALPN** is new in the TLS framework (`evpl_tls_set_alpn_protocols` / `evpl_tls_get_alpn`): server selection callback, client offered-protocol list, and post-handshake readback.
- **Buffering stays on libevpl iovecs:** nghttp2's internal allocations route through `evpl_malloc`/`evpl_free` (new `evpl_realloc`); outbound DATA is sent **zero-copy** straight from the request `send_ring` via `NGHTTP2_DATA_FLAG_NO_COPY` + a send-data callback; inbound DATA is copied once into evpl iovecs.
- Shared structs/helpers move to `src/http/http_internal.h`; the nghttp2 codec lives in `src/http/http2.c`.

## New public API

`evpl_http_client_connect` / `evpl_http_client_close`, `evpl_http_request_create`, `evpl_http_client_set_request_length` / `_chunked`, `evpl_http_request_dispatch`, `evpl_http_request_status`, `evpl_http_response_header` / `_iterate`, and a client-only `EVPL_HTTP_NOTIFY_RESPONSE_HEADERS` notification.

## Tests

`src/http/tests/`: an evpl client↔server harness over HTTP/1.1 and HTTP/2 (`h2c` and `h2`-over-TLS) exercising GET/POST/chunked, plus libcurl driving the HTTP/2 server with both prior-knowledge and ALPN. Full ctest suite passes on Debug (ASan) and Release.