### PR TITLE
core: never ignore pthread_create failure; retry transient EAGAIN

### DIFF
--- a/src/core/allocator.c
+++ b/src/core/allocator.c
@@ -17,6 +17,7 @@
 #include "core/allocator.h"
 #include "core/protocol.h"
 #include "core/macros.h"
+#include "core/pthread_util.h"
 
 /* Encodes the log2 of a specific hugetlb page size into the mmap flags so a
  * non-default pool (e.g. 1 GiB) can be selected; see mmap(2) MAP_HUGE_*. */
@@ -82,8 +83,15 @@ evpl_allocator_create()
         allocator->prealloc_threads = evpl_zalloc(threads * sizeof(pthread_t));
 
         for (i = 0; i < (int) threads; i++) {
-            pthread_create(&allocator->prealloc_threads[i], NULL,
-                           evpl_allocator_prealloc_thread, allocator);
+            int rc = evpl_pthread_create(&allocator->prealloc_threads[i], NULL,
+                                         evpl_allocator_prealloc_thread,
+                                         allocator);
+
+            /* A missing producer would leave outstanding_slabs credits that
+            * nothing services and destroy() joining a garbage pthread_t. */
+            evpl_core_abort_if(rc,
+                               "evpl_allocator_create: pthread_create failed: %s",
+                               strerror(rc));
         }
 
         /* Seed initial fill so target is reached before first consumer.

--- a/src/core/logging.c
+++ b/src/core/logging.c
@@ -134,7 +134,9 @@ evpl_fatal(
     EvplLog(level_string[EVPL_LOG_FATAL], mod, srcfile, lineno, fmt, argp);
     va_end(argp);
 
-    EvplFlush();
+    if (EvplFlush) {
+        EvplFlush();
+    }
 
     exit(1);
 } /* evpl_fatal */
@@ -153,7 +155,9 @@ evpl_abort(
     EvplLog(level_string[EVPL_LOG_FATAL], mod, srcfile, lineno, fmt, argp);
     va_end(argp);
 
-    EvplFlush();
+    if (EvplFlush) {
+        EvplFlush();
+    }
 
     abort();
 } /* evpl_abort */

--- a/src/core/pthread_util.h
+++ b/src/core/pthread_util.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <errno.h>
+#include <pthread.h>
+#include <unistd.h>
+
+/*
+ * pthread_create with bounded retry on EAGAIN.
+ *
+ * EAGAIN from pthread_create is almost always transient resource pressure
+ * (RLIMIT_NPROC, cgroup pids/memory limits, kernel threads-max) during load
+ * spikes.  Retry briefly to ride out the spike, then hand the error back so
+ * the caller can fail loudly; callers must never ignore the result, since a
+ * missing thread typically turns into a silent hang on a ready-flag or
+ * work queue that nothing will ever service.
+ *
+ * Returns 0 on success or the final pthread_create error code.
+ */
+static inline int
+evpl_pthread_create(
+    pthread_t            *thread,
+    const pthread_attr_t *attr,
+    void *(*start_routine )(void *),
+    void                 *arg)
+{
+    useconds_t delay = 1000;
+    int        attempt;
+    int        rc;
+
+    for (attempt = 0; ; attempt++) {
+        rc = pthread_create(thread, attr, start_routine, arg);
+
+        if (rc != EAGAIN || attempt >= 100) {
+            return rc;
+        }
+
+        usleep(delay);
+
+        if (delay < 100000) {
+            delay *= 2;
+        }
+    }
+} /* evpl_pthread_create */

--- a/src/core/thread/thread.c
+++ b/src/core/thread/thread.c
@@ -13,6 +13,7 @@
 #include "core/evpl_shared.h"
 #include "core/event_fn.h"
 #include "core/macros.h"
+#include "core/pthread_util.h"
 
 extern struct evpl_shared *evpl_shared;
 
@@ -135,6 +136,7 @@ evpl_thread_create(
     void                           *private_data)
 {
     struct evpl_thread *evpl_thread;
+    int                 rc;
 
     __evpl_init();
 
@@ -152,8 +154,13 @@ evpl_thread_create(
     pthread_mutex_init(&evpl_thread->lock, NULL);
     pthread_cond_init(&evpl_thread->cond, NULL);
 
-    pthread_create(&evpl_thread->thread, NULL,
-                   evpl_thread_function, evpl_thread);
+    /* If the thread is never created, the ready-wait below would block
+     * forever, so a creation failure must abort rather than fall through. */
+    rc = evpl_pthread_create(&evpl_thread->thread, NULL,
+                             evpl_thread_function, evpl_thread);
+
+    evpl_thread_abort_if(rc, "evpl_thread_create: pthread_create failed: %s",
+                         strerror(rc));
 
     pthread_mutex_lock(&evpl_thread->lock);
 


### PR DESCRIPTION
## Summary

`evpl_thread_create` ignored the `pthread_create` return value and fell straight into its ready-flag `pthread_cond_wait`, so a creation failure — `EAGAIN` under thread/pid/memory pressure — left the caller blocked **forever, silently**.

This is the root cause of a rare chimera CI hang (`chimera/posix/lockf_linux` 300s timeout, passing on rerun): under full-suite `-j` ASan load, a forked test child stalled with zero output at:

```
#3  pthread_cond_wait
#4  evpl_thread_create               thread.c (while (!ready) cond_wait)
#5  chimera_vfs_spawn_delegation_pool (count=64)
#6  chimera_vfs_init
#7  chimera_client_init
#9  chimera_posix_init_json
```

Reproduced deterministically with an LD_PRELOAD shim failing the first `pthread_create` issued from `evpl_thread_create` in the forked child: exact CI signature (child alive and mute, parent waiting, timeout).

## Changes

- **`src/core/pthread_util.h` (new)**: `evpl_pthread_create()` — retries `EAGAIN` with bounded exponential backoff (~10s worst case) to ride out transient load spikes, returns the final error otherwise.
- **`src/core/thread/thread.c`**: use it in `evpl_thread_create` and abort loudly on failure instead of waiting forever on a thread that doesn't exist.
- **`src/core/allocator.c`**: same for the prealloc producer loop — a missing producer left `outstanding_slabs` credits nothing services, and `evpl_allocator_destroy` would `pthread_join` a garbage `pthread_t`.
- **`src/core/logging.c`**: guard `EvplFlush` in `evpl_fatal`/`evpl_abort` — the default flush hook is `NULL`, so any fatal in a process that never called `evpl_set_log_fn` crashed at pc 0 instead of reporting the error (found while testing the abort path of this fix).

## Validation

- Shim failing one `pthread_create` with `EAGAIN` (transient): previously hung 300s; now retries and the test **passes**.
- Shim failing persistently: previously hung; now aborts in ~10s with `evpl_thread_create: pthread_create failed: Resource temporarily unavailable` (and no NULL-call SEGV in the abort path).
- libevpl thread/core ctest suites pass; full chimera Debug build green.