### PR TITLE
http/tls: fix rocky10 h2_tls interop and a scan-build finding

### DIFF
--- a/src/core/tls/tls.c
+++ b/src/core/tls/tls.c
@@ -280,9 +280,17 @@ evpl_tls_create_ctx(int is_server)
         rc = SSL_CTX_set_cipher_list(ctx, config->tls_cipher_list);
         evpl_tls_abort_if(rc <= 0, "Failed to set cipher list: %s", config->tls_cipher_list);
     } else if (config->tls_ktls_enabled) {
-        /* Default cipher list for kTLS */
-        rc = SSL_CTX_set_cipher_list(ctx, "AES128-GCM-SHA256");
-        evpl_tls_abort_if(rc <= 0, "Failed to set cipher list: AES128-GCM-SHA256");
+        /* Default cipher list for kTLS: the kernel offload depends on the
+         * record cipher (AES-128-GCM), not the key exchange, so prefer
+         * ECDHE -- hardened crypto policies (e.g. RHEL DEFAULT) drop the
+         * plain-RSA key exchange entirely, and a server offering only
+         * AES128-GCM-SHA256 fails those clients with "no shared cipher".
+         * Keep the RSA-kex variant as a last-resort fallback. */
+        rc = SSL_CTX_set_cipher_list(ctx,
+                                     "ECDHE-ECDSA-AES128-GCM-SHA256:"
+                                     "ECDHE-RSA-AES128-GCM-SHA256:"
+                                     "AES128-GCM-SHA256");
+        evpl_tls_abort_if(rc <= 0, "Failed to set default kTLS cipher list");
     }
 
     if (is_server && evpl_tls_alpn_wire_len > 0) {

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -667,14 +667,13 @@ evpl_http_conn_connected(struct evpl_http_conn *conn)
 
 #ifdef HAVE_NGHTTP2
     if (conn->proto == EVPL_HTTP_PROTO_H2) {
-        struct evpl_http_request *request, *tmp;
+        struct evpl_http_request *request;
 
         evpl_http2_conn_init(conn);
 
         /* Submit any requests the client queued before the connection
          * completed. */
-        DL_FOREACH_SAFE(conn->pending_requests, request, tmp)
-        {
+        while ((request = conn->pending_requests) != NULL) {
             DL_DELETE(conn->pending_requests, request);
             evpl_http2_dispatch(request);
         }


### PR DESCRIPTION
## Summary

Fixes the two failures chimera's merge queue hit on chimera-nas/chimera#739's submodule bump — the first time the HTTP/2 code (#99) went through chimera's scan-build analyze gate and the rocky10 test matrix. Neither is related to the pthread_create fix in #100; both are pre-existing on libevpl main.

## `libevpl/http/h2_tls` deterministic failure on rocky10

The default kTLS cipher list was the single cipher `AES128-GCM-SHA256` — a **plain-RSA key exchange** suite. Hardened crypto policies (RHEL DEFAULT on rocky10, OpenSSL 3.5) remove RSA key exchange entirely, so a policy-following client like curl has zero overlap with the server and the handshake fails with `no shared cipher`. The evpl↔evpl TLS test passed because both ends override the policy with the same explicit list, which is why this only showed up against curl.

kTLS offload depends on the **record** cipher (AES-128-GCM), not the key exchange, so the default now prefers `ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256` and keeps `AES128-GCM-SHA256` as a last-resort fallback.

Verified in the rocky10 CI image (curl 8.12.1 / OpenSSL 3.5.1 / DEFAULT policy): `h2_tls` went from `curl failed: SSL connect error` to HTTP 200 over h2, and all 7 http tests pass. Local (ubuntu devcontainer) http suite: 7/7.

## scan-build null-deref report in `evpl_http_conn_connected`

chimera's analyze gate (`scan-build --status-bugs`, Release, so utlist's asserts are compiled out) flagged the `DL_FOREACH_SAFE`+`DL_DELETE` drain of `pending_requests`: the analyzer cannot prove the list head is non-NULL at `DL_DELETE`'s tail-fixup branch. Rewrote it as an equivalent head-pop loop (`while ((request = conn->pending_requests)) { DL_DELETE(...); ... }`), which is trivially provable. scan-build on the http target is clean now.