### PR TITLE
http: retire live connections before freeing the agent

### DIFF
--- a/src/http/http.c
+++ b/src/http/http.c
@@ -122,6 +122,23 @@ evpl_http_destroy(struct evpl_http_agent *agent)
 {
     struct evpl_http_request        *request;
     struct evpl_http_request_header *header;
+    struct evpl_http_conn           *conn;
+
+    /* Close and retire every live connection before freeing the agent.  Conn
+     * binds hold notify callbacks that dereference the agent (the h2 receive
+     * path reads conn->agent->evpl on every data event), so an agent freed
+     * while a bind still has buffered input is a use-after-free as soon as
+     * evpl_destroy's close pump delivers that data.  Pump the loop until the
+     * disconnect notifications retire each conn (evpl_close is idempotent on
+     * a bind already pending close).  Must run on the agent's evpl thread,
+     * which every existing caller already does. */
+    while (agent->conns) {
+        DL_FOREACH(agent->conns, conn)
+        {
+            evpl_close(agent->evpl, conn->bind);
+        }
+        evpl_continue(agent->evpl);
+    }
 
     while (agent->free_headers) {
         header = agent->free_headers;
@@ -765,6 +782,7 @@ evpl_http_event(
                 request = next;
             }
 
+            DL_DELETE(http_conn->agent->conns, http_conn);
             evpl_free(http_conn);
         }
         break;
@@ -1116,6 +1134,7 @@ evpl_http_accept(
 
     evpl_deferral_init(&http_conn->flush, evpl_http_flush, http_conn);
 
+    DL_APPEND(server->agent->conns, http_conn);
 
 } /* evpl_http_accept */
 
@@ -1188,6 +1207,8 @@ evpl_http_client_connect(
     conn->private_data = private_data;
 
     evpl_deferral_init(&conn->flush, evpl_http_flush, conn);
+
+    DL_APPEND(agent->conns, conn);
 
     conn->bind = evpl_connect(agent->evpl, protocol_id, NULL, endpoint,
                               evpl_http_event, NULL, conn);

--- a/src/http/http_internal.h
+++ b/src/http/http_internal.h
@@ -115,6 +115,11 @@ struct evpl_http_conn {
     struct evpl_http_request *pending_requests;
     struct evpl_http2_conn   *h2;          /* NULL unless proto == H2 */
     void                     *private_data;
+    /* Agent-wide live-connection list (agent->conns): every conn's bind holds
+     * notify callbacks that dereference the agent, so evpl_http_destroy must
+     * be able to find and retire them before the agent is freed. */
+    struct evpl_http_conn    *prev;
+    struct evpl_http_conn    *next;
 };
 
 struct evpl_http_server {
@@ -128,6 +133,7 @@ struct evpl_http_server {
 struct evpl_http_agent {
     struct evpl_http_request        *free_requests;
     struct evpl_http_request_header *free_headers;
+    struct evpl_http_conn           *conns; /* live connections; see conn */
     struct evpl                     *evpl;
 };
 


### PR DESCRIPTION
Fixes the flaky `libevpl/http/h2_tls` CI failure (ASan heap-use-after-free, seen once on a loaded rocky10 Debug runner — but it's a race any user of the teardown sequence can hit).

`evpl_http_destroy` freed the agent while connection binds still existed. Every conn's bind holds notify callbacks that dereference the agent — the h2 receive path reads `conn->agent->evpl` on every data event — so an agent freed while a bind still has buffered input is a use-after-free as soon as `evpl_destroy`'s close pump delivers that data:

```
heap-use-after-free in evpl_http2_recv http2.c:531
  evpl_http_event ← evpl_tls_read_ktls ← evpl_destroy_close_bind ← evpl_destroy
freed by evpl_http_destroy http.c:140 (server_function teardown)
```

The window is the client's final TLS bytes landing between the server's `evpl_http_destroy` and bind teardown.

Fix: track live connections on the agent (accept/connect append, the disconnect path removes), and have `evpl_http_destroy` close every remaining bind and pump the loop until the disconnect notifications retire each conn before the agent is freed. `evpl_close` is idempotent on a bind already pending close, and conns leave the list strictly before their bind reaches the closed state, so the drain never touches a dead bind. Must run on the agent's evpl thread, which every existing caller already does.

All 7 http tests green; the h2 suites looped 30× under ASan.