### PR TITLE
core: fix evpl_iovec_profile_dump redefinition when profiler is off

### DIFF
--- a/include/evpl/evpl_memory.h
+++ b/include/evpl/evpl_memory.h
@@ -202,7 +202,11 @@ static inline void evpl_iovec_profile_release(struct evpl_iovec *iovec) { (void)
 static inline void evpl_iovec_profile_move(
     struct evpl_iovec *dst,
     struct evpl_iovec *src) { (void) dst; (void) src; }
-static inline void evpl_iovec_profile_dump(const char *reason) { (void) reason; }
+/* dump is defined (as an exported no-op) in iovec_profile.c for this branch,
+ * so it is only declared here -- defining it static inline as well would
+ * collide with that definition inside the iovec_profile.c translation unit. */
+void evpl_iovec_profile_dump(
+    const char *reason);
 #endif /* EVPL_IOVEC_PROFILE */
 
 int evpl_iovec_alloc(


### PR DESCRIPTION
## Summary

With `EVPL_IOVEC_PROFILE` **not** defined (the default), `evpl_memory.h`'s `#else` branch defined `evpl_iovec_profile_dump()` as a `static inline` no-op, while `iovec_profile.c`'s matching `#else` branch defines and exports the same function as a real no-op. `iovec_profile.c` includes `evpl/evpl.h` → `evpl_memory.h`, so both definitions land in that translation unit:

```
error: redefinition of 'evpl_iovec_profile_dump'
```

Because the profiler is off by default, any consumer that builds libevpl (e.g. chimera) fails to compile once this file is present.

## Fix

Declare `dump` in the `#else` branch instead of defining it `static inline` — matching the `#ifdef` branch, where it is a plain prototype defined in `iovec_profile.c`. The exported no-op in `iovec_profile.c` becomes the single definition. `assign`/`release`/`move` stay header-only inline no-ops, since `iovec_profile.c` does not export those.

Verified by building chimera (which pins libevpl as a submodule) against this change with the profiler off: full Release build links cleanly.