### PR TITLE
core: add evpl_bind_is_closing() accessor

### DIFF
--- a/include/evpl/evpl_bind.h
+++ b/include/evpl/evpl_bind.h
@@ -209,3 +209,13 @@ enum evpl_protocol_id evpl_bind_get_protocol(
 
 int evpl_bind_is_rdma(
     struct evpl_bind *bind);
+
+/* True once the peer's close has been observed on this bind (read-side FIN seen,
+ * half-close requested, or destroy in progress) but possibly before
+ * EVPL_NOTIFY_DISCONNECTED has been dispatched for it.  A genuinely live,
+ * fully-connected bind returns 0.  Lets a caller distinguish a peer that is on
+ * its way out (its reservations will be released once the disconnect lands) from
+ * one that is still connected, even in the window before the disconnect callback
+ * runs. */
+int evpl_bind_is_closing(
+    struct evpl_bind *bind);

--- a/src/core/bind.c
+++ b/src/core/bind.c
@@ -277,6 +277,22 @@ evpl_bind_is_rdma(struct evpl_bind *bind)
     return bind->protocol->rdma;
 } /* evpl_bind_is_rdma */
 
+SYMBOL_EXPORT int
+evpl_bind_is_closing(struct evpl_bind *bind)
+{
+    /* True once the peer's close has been observed on this bind but before the
+     * deferred destroy dispatches EVPL_NOTIFY_DISCONNECTED: a read-side FIN
+     * (recv returns 0) calls evpl_close, which sets EVPL_BIND_PENDING_CLOSED
+     * synchronously and defers the destroy; a half-close (evpl_finish) sets
+     * EVPL_BIND_FINISH; the destroy itself sets EVPL_BIND_CLOSED.  A genuinely
+     * live bind has none of these set.  Lets a caller distinguish a peer that is
+     * on its way out (its reservations will be released once the disconnect
+     * callback lands) from one that is still fully connected. */
+    return (bind->flags & (EVPL_BIND_PENDING_CLOSED |
+                           EVPL_BIND_CLOSED |
+                           EVPL_BIND_FINISH)) != 0;
+} /* evpl_bind_is_closing */
+
 SYMBOL_EXPORT void
 evpl_bind_request_send_notifications(
     struct evpl      *evpl,


### PR DESCRIPTION
Expose whether a bind has observed its peer's close (read-side FIN seen, half-close requested, or destroy in progress) before `EVPL_NOTIFY_DISCONNECTED` has been dispatched for it.  A genuinely live, fully-connected bind returns 0.

When a TCP peer FINs, the socket read path (`recv` returns 0) calls `evpl_close`, which synchronously sets `EVPL_BIND_PENDING_CLOSED` and defers the destroy that later dispatches `EVPL_NOTIFY_DISCONNECTED`.  This leaves a window where a peer is provably on its way out but no disconnect callback has run yet.  `evpl_bind_is_closing()` reports that window by testing the `EVPL_BIND_PENDING_CLOSED | EVPL_BIND_CLOSED | EVPL_BIND_FINISH` flags.

This lets a consumer (chimera SMB durable-handle arbitration) distinguish a peer whose reservations will be released once its disconnect lands from one that is still fully connected, in the pre-notify window.

Prototype is exported via the public `evpl/evpl_bind.h` (pulled in by `evpl/evpl.h`); flags live in the internal `core/bind.h` already included by `bind.c`.  All 69 existing tests pass.