### PR TITLE
rpc2: drop the message on a truncated RPC header instead of negative skip

### DIFF
--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -2089,6 +2089,22 @@ evpl_rpc2_recv_msg(
 
     rc = unmarshall_rpc_msg(&rpc_msg, hdr_iov, hdr_niov, NULL, &msg->dbuf);
 
+    if (rc < 0) {
+        /* Truncated / undecodable RPC header (RFC 5531 §8): the call header
+         * could not be fully decoded.  Reusing the negative return as a byte
+         * offset below drives a negative-offset, over-length iovec clone, so
+         * release every reference acquired so far and drop the connection
+         * instead. */
+        evpl_iovecs_release_internal(evpl, hdr_iov, hdr_niov);
+        evpl_iovecs_release_internal(evpl, iovec, niov);
+        if (!rdma && offset == 0) {
+            evpl_free(iovec);
+        }
+        evpl_rpc2_msg_free(thread, msg);
+        evpl_close(evpl, bind);
+        return;
+    }
+
     /* Clone recv iovecs to msg - this keeps the buffer data alive */
     msg->recv_iov = xdr_dbuf_alloc_space(sizeof(*msg->recv_iov) * niov, &msg->dbuf);
 


### PR DESCRIPTION
`evpl_rpc2_recv_msg` never checked the return value of `unmarshall_rpc_msg`. On a truncated / undecodable call header (e.g. a CALL whose cred is cut short) the generated unmarshaller returns `-1`, which was then reused as the byte offset into `evpl_rpc2_iovec_skip(..., rc)` and in `request_length = length - (rc + offset)`. A `-1` offset drives `evpl_iovec_clone_segment` with a negative, over-length range — an out-of-bounds / garbage iovec clone triggered by a single malformed, pre-auth packet. RFC 5531 §8 requires the call header to be fully and validly decoded before dispatch; an undecodable header is a protocol error, not a valid negative-length header.

Fix: check `rc < 0` immediately after the decode and, on failure, release every reference acquired so far (`hdr_iov` and the delivered/accumulator iovecs), free the msg, and close the connection — mirroring the existing reassembly-cap bail a few lines above.

Validated: libevpl builds clean and all 7 `rpc2` ctests pass (incl. `multifrag`, which exercises the header/reassembly path). Root-cause fix for chimera-nas/chimera#1055; lands in chimera via a libevpl submodule bump.