### PR TITLE
rpc2: harden inbound CALL dispatch (proc bound + rpcvers validation)

### DIFF
--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -2336,7 +2336,6 @@ evpl_rpc2_recv_msg(
                     program->version == rpc_msg.body.cbody.vers) {
 
                     request->program = program;
-                    request->metric  = server_binding ? server_binding->metrics[i][request->proc] : NULL;
                     break;
                 }
             }
@@ -2350,6 +2349,25 @@ evpl_rpc2_recv_msg(
                 evpl_rpc2_send_reply_error(evpl, request, PROG_MISMATCH);
                 return;
             }
+
+            /* The proc number is unauthenticated input from the wire.  Range
+             * check it against the program's maxproc BEFORE using it to index
+             * the per-program metrics array (sized maxproc + 1).  An
+             * out-of-range proc is answered with PROC_UNAVAIL per RFC 5531
+             * rather than indexing the array with a wild value. */
+            if (unlikely(request->proc > program->maxproc)) {
+                evpl_rpc2_debug(
+                    "rpc2 received call for out-of-range proc %u (prog %u vers %u maxproc %u)",
+                    request->proc,
+                    rpc_msg.body.cbody.prog,
+                    rpc_msg.body.cbody.vers,
+                    program->maxproc);
+
+                evpl_rpc2_send_reply_error(evpl, request, PROC_UNAVAIL);
+                return;
+            }
+
+            request->metric = server_binding ? server_binding->metrics[i][request->proc] : NULL;
 
             if (request->pending_reads == 0) {
                 evpl_rpc2_server_handle_request(request, req_iov, req_niov, request_length, authsys, flavor);

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -686,8 +686,14 @@ evpl_rpc2_send_reply(
                 length   = wrapped_len;
             }
         }
+    } else if (error_stat == RPC_MISMATCH) {
+        /* MSG_DENIED / RPC_MISMATCH: the call's RPC version is not 2.  Report
+         * the range of RPC versions we support (low = high = 2) per RFC 5531. */
+        rpc_reply.body.rbody.rreply.stat      = RPC_MISMATCH;
+        rpc_reply.body.rbody.rreply.info.low  = 2;
+        rpc_reply.body.rbody.rreply.info.high = 2;
     } else {
-        /* MSG_DENIED - currently only AUTH_ERROR is supported */
+        /* MSG_DENIED / AUTH_ERROR: error_stat carries the auth_stat. */
         rpc_reply.body.rbody.rreply.stat = AUTH_ERROR;
         rpc_reply.body.rbody.rreply.auth = error_stat;
     }
@@ -928,6 +934,26 @@ evpl_rpc2_send_reply_denied(
     return evpl_rpc2_send_reply(evpl, request, NULL, &msg_iov, msg_niov, 4096, 4096,
                                 MSG_DENIED, auth_error);
 } /* evpl_rpc2_send_reply_denied */
+
+/*
+ * Reject a CALL whose RPC version is not 2 (MSG_DENIED, RPC_MISMATCH).
+ *
+ * The supported RPC version range (low = high = 2) is filled in by
+ * evpl_rpc2_send_reply's RPC_MISMATCH branch.
+ */
+static inline int
+evpl_rpc2_send_reply_mismatch(
+    struct evpl              *evpl,
+    struct evpl_rpc2_request *request)
+{
+    struct evpl_iovec msg_iov;
+    int               msg_niov = 1;
+
+    msg_niov = evpl_iovec_alloc(evpl, 4096, 0, 1, 0, &msg_iov);
+
+    return evpl_rpc2_send_reply(evpl, request, NULL, &msg_iov, msg_niov, 4096, 4096,
+                                MSG_DENIED, RPC_MISMATCH);
+} /* evpl_rpc2_send_reply_mismatch */
 
 
 static inline int
@@ -2157,6 +2183,18 @@ evpl_rpc2_recv_msg(
             request->encoding.xid = request->xid;
             request->proc         = rpc_msg.body.cbody.proc;
             prometheus_stopwatch_start(&request->timestamp);
+
+            /* RFC 5531: rpcvers MUST equal 2.  A call claiming a different RPC
+             * version is rejected with MSG_DENIED / RPC_MISMATCH (advertising
+             * the supported version range) rather than being dispatched as if
+             * it were version 2. */
+            if (unlikely(rpc_msg.body.cbody.rpcvers != 2)) {
+                evpl_rpc2_debug("rpc2 received call with unsupported rpcvers %u",
+                                rpc_msg.body.cbody.rpcvers);
+
+                evpl_rpc2_send_reply_mismatch(evpl, request);
+                return;
+            }
 
             /* Parse credentials - authsys data is in msg->dbuf which persists */
             flavor = rpc_msg.body.cbody.cred.flavor;


### PR DESCRIPTION
Two robustness fixes to the rpc2 inbound CALL path. These are the root fixes for chimera-nas/chimera#1054 and chimera-nas/chimera#1186; they will land in chimera via a libevpl submodule bump.

## 1. Range-check the wire proc before indexing the metrics array (chimera-nas/chimera#1054, high)

The procedure number taken verbatim from the wire (`request->proc`) was used to index the per-program metrics array — sized `(maxproc + 1)` — before any range check. A CALL for a valid prog/vers with a proc beyond `maxproc` (e.g. `proc = 0xFFFFFFFF`) loaded a wild pointer that was later dereferenced in `prometheus_time_histogram_sample`: a pre-auth out-of-bounds read / crash reachable over AUTH_NONE, affecting every rpc2-served program.

Fix: validate `proc` is within `[0, maxproc]` before indexing the metrics array, and answer an out-of-range proc with `PROC_UNAVAIL` per RFC 5531 — matching how the generated dispatcher already rejects unknown procedures.

## 2. Reject rpcvers != 2 with RPC_MISMATCH (chimera-nas/chimera#1186, low)

The CALL path never validated `call_body.rpcvers` against the mandatory value 2. A call claiming a different RPC version was dispatched as if it were version 2 instead of being rejected with `MSG_DENIED` / `RPC_MISMATCH`.

Fix: gate the CALL path early on `rpcvers == 2`; on a mismatch emit `MSG_DENIED` / `RPC_MISMATCH` advertising the supported version range (low = high = 2) per RFC 5531. The `send_reply` MSG_DENIED branch now emits either RPC_MISMATCH or AUTH_ERROR.

## Testing

`ctest -R rpc2` (all 7 pass, including `multifrag` which exercises the CALL path).