### PR TITLE
http: don't free the client's in-flight request twice on disconnect

### DIFF
--- a/src/http/http.c
+++ b/src/http/http.c
@@ -764,12 +764,21 @@ evpl_http_event(
              * partially-parsed request (current_request, e.g. one allocated on
              * a final read that returned EOF) and any received requests whose
              * response has not yet completed (pending_requests). Otherwise
-             * tearing down the connection leaks them. */
-            if (http_conn->current_request) {
+             * tearing down the connection leaks them.
+             *
+             * On a client connection the two overlap: current_request is set
+             * to the head of pending_requests while a response is being parsed
+             * and only leaves that list once the response completes, so
+             * freeing it here as well would put the same request on the
+             * agent's free list twice.  On a server connection they are always
+             * disjoint (a request moves to pending_requests exactly when
+             * current_request is cleared). */
+            if (http_conn->current_request &&
+                http_conn->current_request != http_conn->pending_requests) {
                 evpl_http_request_free(http_conn->agent,
                                        http_conn->current_request);
-                http_conn->current_request = NULL;
             }
+            http_conn->current_request = NULL;
 
             /* Walk and free the whole list directly rather than DL_DELETE per
              * element: there is no need to keep the list consistent while


### PR DESCRIPTION
On a client connection `current_request` aliases the head of `pending_requests`.
`evpl_http_client_handle_data` sets it there when a response starts arriving and
only takes the request off the list once the response completes:

```c
    if (!conn->current_request) {
        if (!conn->pending_requests) { ... }
        /* HTTP/1.x responses arrive in request order: the head of the queue. */
        conn->current_request = conn->pending_requests;
    }
```

The `EVPL_NOTIFY_DISCONNECTED` handler frees `current_request` and then walks
`pending_requests` freeing every entry, so if the connection drops while a
response is being parsed the same request goes through `evpl_http_request_free`
twice. It ends up on the agent's `free_requests` list twice, and from there the
pool can hand the same object out to two live requests, or double-free it when
`evpl_http_destroy` drains the list.

You don't need malformed input for this. A server closing the connection
mid-response is enough.

The handler was written in #74, before there was an HTTP/1.1 client, when the
two were always disjoint. That is still true on a server connection: a request
moves to `pending_requests` exactly when `current_request` is cleared. So the
fix is to skip the separate free when `current_request` is already on the list
and let the `pending_requests` walk own it.

## Reproducer

An evpl HTTP/1.1 client against a raw server that sends a status line, one
header, then closes. Full source in the details block below.

```c
static const char rsp[] = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n";
...
    write(cfd, rsp, sizeof(rsp) - 1);
    close(cfd);                 /* drop the connection mid-response */
```

Built against a Debug (ASan) build and run in a private netns so the fixed port
is free:

```
gcc -g -fsanitize=address -I include repro.c -o repro \
    -Lbuild/Debug/src/core -Lbuild/Debug/src/http \
    -Wl,-rpath,$PWD/build/Debug/src/core -Wl,-rpath,$PWD/build/Debug/src/http \
    -levpl_http -levpl -lpthread

unshare -r -n bash -c 'ip link set lo up; ./repro'
```

On 281409a (stack frames from libasan/libc trimmed):

```
==1857236==ERROR: AddressSanitizer: heap-use-after-free on address 0x7e328c9e02e8
READ of size 8 at 0x7e328c9e02e8 thread T0
    #0 in evpl_http_destroy src/http/http.c:152
    #1 in main repro.c:101

0x7e328c9e02e8 is located 232 bytes inside of 16624-byte region
freed by thread T0 here:
    #1 in evpl_free src/core/memory.c:81
    #2 in evpl_http_destroy src/http/http.c:155
    #3 in main repro.c:101

previously allocated by thread T0 here:
    #1 in evpl_zalloc src/core/memory.c:24
    #2 in evpl_http_request_alloc src/http/http_internal.h:174
    #3 in evpl_http_request_create src/http/http.c:1236
    #4 in main repro.c:92

SUMMARY: AddressSanitizer: heap-use-after-free src/http/http.c:152 in evpl_http_destroy
```

http.c:152 and :155 are the `LL_DELETE` and the `evpl_free` of the same
`free_requests` drain loop, one iteration apart. That is the duplicate entry.

With the patch the same run prints `done` and exits 0.

<details>
<summary>repro.c</summary>

```c
/* evpl HTTP/1.1 client against a raw server that sends a partial response
 * and closes. Build against a Debug (ASan) build of libevpl. */
#include <stdio.h>
#include <string.h>
#include <unistd.h>
#include <pthread.h>
#include <arpa/inet.h>
#include <netinet/in.h>
#include <sys/socket.h>

#include "evpl/evpl.h"
#include "evpl/evpl_http.h"

#define PORT 18082

static const char   rsp[] = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n";
static volatile int listening;

static void *
raw_server(void *ptr)
{
    struct sockaddr_in sin;
    char               buf[4096];
    int                lfd, cfd, one = 1;

    lfd = socket(AF_INET, SOCK_STREAM, 0);
    setsockopt(lfd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));

    memset(&sin, 0, sizeof(sin));
    sin.sin_family      = AF_INET;
    sin.sin_port        = htons(PORT);
    sin.sin_addr.s_addr = htonl(INADDR_ANY);

    bind(lfd, (struct sockaddr *) &sin, sizeof(sin));
    listen(lfd, 4);

    __sync_synchronize();
    listening = 1;

    cfd = accept(lfd, NULL, NULL);
    read(cfd, buf, sizeof(buf));
    write(cfd, rsp, sizeof(rsp) - 1);
    close(cfd);                 /* drop the connection mid-response */
    close(lfd);
    return NULL;
}

static void
client_notify(
    struct evpl                *evpl,
    struct evpl_http_agent     *agent,
    struct evpl_http_request   *request,
    enum evpl_http_notify_type  notify_type,
    enum evpl_http_request_type request_type,
    const char                 *uri,
    void                       *notify_data,
    void                       *private_data)
{
}

int
main(
    int   argc,
    char *argv[])
{
    struct evpl_thread_config *tc;
    struct evpl_http_request  *request;
    struct evpl_http_agent    *agent;
    struct evpl_endpoint      *endpoint;
    struct evpl_http_conn     *conn;
    struct evpl               *evpl;
    pthread_t                  thread;
    int                        i;

    evpl_init(NULL);

    pthread_create(&thread, NULL, raw_server, NULL);
    while (!listening) {
        __sync_synchronize();
    }

    tc = evpl_thread_config_init();
    evpl_thread_config_set_poll_mode(tc, 0);
    evpl_thread_config_set_wait_ms(tc, 20);
    evpl = evpl_create(tc);

    agent    = evpl_http_init(evpl);
    endpoint = evpl_endpoint_create("127.0.0.1", PORT);
    conn     = evpl_http_client_connect(agent, EVPL_STREAM_SOCKET_TCP, endpoint,
                                        EVPL_HTTP_VERSION_HTTP1, NULL);

    request = evpl_http_request_create(conn, EVPL_HTTP_REQUEST_TYPE_GET, "/");
    evpl_http_request_add_header(request, "Host", "localhost");
    evpl_http_client_set_request_length(request, 0);
    evpl_http_request_dispatch(request, client_notify, NULL);

    for (i = 0; i < 50; i++) {
        evpl_continue(evpl);
    }

    evpl_http_destroy(agent);
    evpl_destroy(evpl);
    pthread_join(thread, NULL);

    fprintf(stderr, "done\n");
    return 0;
}
```

</details>

## Testing

Arch Linux, gcc 16.1.1. The whole suite runs under `unshare -r -n` because this
box has no CAP_NET_ADMIN for the netns wrapper and something else already owns
port 8000.

```
cd build/Debug && unshare -r -n bash -c 'ip link set lo up; ctest --timeout 20'
100% tests passed out of 101

cd build/Release && unshare -r -n bash -c 'ip link set lo up; ctest --timeout 20'
100% tests passed out of 101
```

`uncrustify -c etc/uncrustify.cfg --check src/http/http.c` passes.

I did not add a test for this. The existing http tests all drive a well-behaved
peer, so covering it means a new test that speaks raw sockets at the client, and
the failure only shows up under ASan. Happy to add the reproducer above as one
if you want it.

## One more thing, separately

While reproducing this I hit an unrelated leak in the same file. Both
`evpl_http_server_handle_data` and `evpl_http_client_handle_data` allocate a
header before parsing the line, then bail out on `malformed header line` and
`missing header value` without returning it to the pool. A request line followed
by `Bogus\r\n` leaks 16656 bytes per connection on the server side, which a
remote peer controls. I have that fix verified too but left it out to keep this
patch to one thing. Say the word and I will send it.
