### PR TITLE
build: clang source-based code coverage (make coverage)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,12 +9,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock
 
+# clang, llvm and libclang-rt-dev are all installed unversioned so they resolve
+# to the same LLVM release from the base image.  They have to match: clang looks
+# for its compiler-rt profile/sanitizer runtimes under a resource directory
+# named for its own major version, so pinning one of them to a different
+# release leaves the runtimes missing and any -fprofile-instr-generate or
+# -fsanitize build fails to link.  (This previously pinned libclang-rt-18-dev
+# while clang tracked the default, which broke `make coverage` once the base
+# image moved past 18.)
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
     apt-get -y --no-install-recommends install unminimize apt-utils && \
     yes | unminimize && \
     apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build git lldb gdb less psmisc uncrustify reuse \
-    net-tools tshark tcpdump uuid-dev iproute2 man-db manpages-dev ca-certificates ssh libjansson-dev libclang-rt-18-dev llvm \
+    net-tools tshark tcpdump uuid-dev iproute2 man-db manpages-dev ca-certificates ssh libjansson-dev libclang-rt-dev llvm \
     libxxhash-dev librdmacm-dev liburing-dev libaio-dev libunwind-dev flex bison libcurl4-openssl-dev build-essential ruby-full npm \
     libssl-dev openssl clangd uthash-dev libnuma-dev && \
     gem install jekyll bundler && \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,23 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_definitions(-O3)
 endif()
 
+# Coverage build: clang source-based code coverage, instrumenting every TU.
+# The matching merge/report step lives in etc/coverage-report.sh, driven by the
+# Makefile's test_coverage target.  Kept deliberately parallel to the same
+# build type in the parent chimera project so a report can be read the same way
+# from either side; running it here narrows the picture to libevpl alone, with
+# its own test suite as the workload.
+if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
+    if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
+        message(FATAL_ERROR
+            "Coverage build requires clang for source-based coverage "
+            "(re-run with -DCMAKE_C_COMPILER=clang; the Makefile does this for you).")
+    endif()
+    message(STATUS "Enabling clang source-based code coverage")
+    add_definitions(-O0 -fprofile-instr-generate -fcoverage-mapping -DEVPL_COVERAGE=1)
+    add_link_options(-fprofile-instr-generate -fcoverage-mapping)
+endif()
+
 if(EVPL_IOVEC_PROFILE)
     message(STATUS "Enabling retained-iovec stack profiling")
     add_definitions(-DEVPL_IOVEC_PROFILE=1)

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,27 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
-CMAKE_ARGS := -G Ninja -DCMAKE_C_COMPILER=gcc
-CMAKE_ARGS_RELEASE := -DCMAKE_BUILD_TYPE=Release
-CMAKE_ARGS_DEBUG := -DCMAKE_BUILD_TYPE=Debug
+CMAKE_ARGS := -G Ninja
+CMAKE_ARGS_RELEASE := -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc
+CMAKE_ARGS_DEBUG := -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc
+# Coverage uses clang's source-based coverage, so force the clang toolchain
+# (the compiler pin moved out of CMAKE_ARGS so this build type can differ).
+CMAKE_ARGS_COVERAGE := -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_C_COMPILER=clang
 CTEST_ARGS := --output-on-failure --timeout 10
+# The Coverage build is -O0 with instrumentation on every TU, so tests run
+# appreciably slower than the Release/Debug builds the 10s timeout was chosen
+# for.  Give them room rather than collecting timeouts as coverage gaps.
+CTEST_ARGS_COVERAGE := --output-on-failure --timeout 60
+
+# Restrict the coverage run to a subset of the suite:
+#
+#   make coverage COVERAGE_TESTS=conformance
+#
+# The value is a ctest -R regex.  Empty (the default) runs everything.  Useful
+# for asking what one test actually reaches -- the report then reflects only
+# the filtered run, since the profile directory is cleared each time.
+COVERAGE_TESTS ?=
+CTEST_FILTER := $(if ${COVERAGE_TESTS},-R ${COVERAGE_TESTS},)
 
 # Use LIBEVPL_BUILD_DIR if set (for devcontainer), otherwise use build subdirectory
 BUILD_DIR ?= $(if $(LIBEVPL_BUILD_DIR),$(LIBEVPL_BUILD_DIR),build)
@@ -34,11 +51,34 @@ test_debug: build_debug
 test_release: build_release
 	cd ${BUILD_DIR}/Release && ctest ${CTEST_ARGS}
 
+.PHONY: build_coverage
+build_coverage:
+	@mkdir -p ${BUILD_DIR}/Coverage
+	@cmake ${CMAKE_ARGS} ${CMAKE_ARGS_COVERAGE} -S . -B ${BUILD_DIR}/Coverage
+	@ninja -C ${BUILD_DIR}/Coverage
+
+# Run the suite against the instrumented build, then merge the raw profiles and
+# print a coverage report. Each test writes its own profile via the %m/%p
+# patterns; the path is absolute so it survives the cwd changes and netns hops
+# the tests make. The report runs even when tests fail, since partial coverage
+# from a failing run is still worth reading.
+COVERAGE_DIR := $(abspath ${BUILD_DIR}/Coverage)/coverage
+.PHONY: test_coverage
+test_coverage: build_coverage
+	@rm -rf ${COVERAGE_DIR}
+	@mkdir -p ${COVERAGE_DIR}/profraw
+	-cd ${BUILD_DIR}/Coverage && \
+		LLVM_PROFILE_FILE=${COVERAGE_DIR}/profraw/%m-%p.profraw ctest ${CTEST_ARGS_COVERAGE} ${CTEST_FILTER}
+	@bash etc/coverage-report.sh ${BUILD_DIR}/Coverage
+
 .PHONY: debug
 debug: build_debug test_debug
 
 .PHONY: release
 release: build_release test_release
+
+.PHONY: coverage
+coverage: build_coverage test_coverage
 
 clean:
 	@rm -rf ${BUILD_DIR}

--- a/etc/coverage-report.sh
+++ b/etc/coverage-report.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Ben Jarvis
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# coverage-report.sh - Merge clang source-based coverage data and print a report
+#
+# Usage: coverage-report.sh BUILD_DIR
+#
+# Expects the test suite to have already run with the binaries instrumented by a
+# Coverage build (-fprofile-instr-generate -fcoverage-mapping) and with
+# LLVM_PROFILE_FILE pointing into BUILD_DIR/coverage/profraw (see the Makefile's
+# test_coverage target). This merges every *.profraw into a single profdata file
+# and prints a per-file llvm-cov report covering the libevpl source tree.
+#
+# Set COVERAGE_HTML=1 to additionally emit a browsable HTML report under
+# BUILD_DIR/coverage/html.
+
+set -euo pipefail
+
+BUILD_DIR="${1:?usage: coverage-report.sh BUILD_DIR}"
+COV_DIR="${BUILD_DIR}/coverage"
+PROFRAW_DIR="${COV_DIR}/profraw"
+PROFDATA="${COV_DIR}/coverage.profdata"
+
+PROFDATA_TOOL="${LLVM_PROFDATA:-llvm-profdata}"
+COV_TOOL="${LLVM_COV:-llvm-cov}"
+
+# Drop everything that isn't first-party libevpl source from the report.  The
+# submodules (xdrzcc, prometheus-c, oteltracing-c) live under ext/ and the
+# vendored headers under 3rdparty/, so libevpl's own code is what remains.
+#
+# These are anchored to libevpl's own source root rather than written as bare
+# /ext/ and /3rdparty/: libevpl is itself commonly checked out *inside* another
+# project's ext/ directory (chimera keeps it at ext/libevpl), and an unanchored
+# pattern would then match every path in this tree and empty the whole report.
+SRC_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+esc_src=$(printf '%s' "${SRC_DIR}" | sed 's/[.[\*^$()+?{|/]/\\&/g')
+IGNORE_REGEX="(${esc_src}/ext/|${esc_src}/3rdparty/|/usr/|/CMakeFiles/)"
+
+# By default, also exclude generated code so it doesn't distort the totals.
+# Generated sources (the xdrzcc XDR marshallers for rpc2, etc.) are emitted into
+# the build tree, whereas hand-written sources live under the source tree -- so
+# "compiled from under BUILD_DIR" is a reliable, generator-agnostic way to spot
+# generated code. Set COVERAGE_INCLUDE_GENERATED=1 to fold it back into the
+# report, which is what you want when the question is how well the generated
+# marshallers themselves are exercised.
+INCLUDE_GENERATED="${COVERAGE_INCLUDE_GENERATED:-0}"
+if [[ "${INCLUDE_GENERATED}" == "1" ]]; then
+    echo "coverage: including generated code (COVERAGE_INCLUDE_GENERATED=1)"
+else
+    abs_build=$(readlink -f "${BUILD_DIR}")
+    # Escape regex metacharacters so the path is matched literally.
+    esc_build=$(printf '%s' "${abs_build}" | sed 's/[.[\*^$()+?{|/]/\\&/g')
+    IGNORE_REGEX="(${esc_build}/|${esc_src}/ext/|${esc_src}/3rdparty/|/usr/|/CMakeFiles/)"
+    echo "coverage: excluding generated code under ${abs_build} (set COVERAGE_INCLUDE_GENERATED=1 to include)"
+fi
+
+# A full suite run produces one .profraw per test process (and per daemon a test
+# spawns), which can overflow ARG_MAX if globbed onto the command line. Build a
+# newline-separated list file and hand it to llvm-profdata via --input-files
+# instead.
+raw_list="${COV_DIR}/profraw.list"
+find "${PROFRAW_DIR}" -type f -name '*.profraw' > "${raw_list}"
+raw_count=$(wc -l < "${raw_list}")
+if [[ "${raw_count}" -eq 0 ]]; then
+    echo "coverage: no .profraw files found under ${PROFRAW_DIR}" >&2
+    echo "coverage: did the tests run against a Coverage build with LLVM_PROFILE_FILE set?" >&2
+    exit 1
+fi
+
+echo "coverage: merging ${raw_count} raw profile(s) ..."
+"${PROFDATA_TOOL}" merge -sparse --input-files="${raw_list}" -o "${PROFDATA}"
+
+# Collect the instrumented binaries: any executable or shared object in the
+# build tree that carries an __llvm_covmap section. llvm-cov fails outright if
+# handed an object with no coverage mapping, so we must filter rather than glob.
+# NB: the section list is captured into a variable rather than piped into
+# grep.  Under `set -o pipefail`, `readelf ... | grep -q` reports failure
+# whenever grep finds its match early, exits, and leaves readelf to die of
+# SIGPIPE -- so a matching binary is racily reported as NOT instrumented and
+# silently dropped from the report.
+objs=()
+while IFS= read -r f; do
+    sections=$(readelf -SW "$f" 2>/dev/null || true)
+    if [[ "${sections}" == *__llvm_covmap* ]]; then
+        objs+=("$f")
+    fi
+done < <(find "${BUILD_DIR}" -type f \
+            \( -perm -u+x -o -name '*.so' -o -name '*.so.*' \) \
+            ! -path '*/CMakeFiles/*')
+
+if [[ ${#objs[@]} -eq 0 ]]; then
+    echo "coverage: no instrumented binaries found under ${BUILD_DIR}" >&2
+    exit 1
+fi
+
+# llvm-cov takes the first object positionally and the rest via -object.
+object_args=()
+for o in "${objs[@]:1}"; do
+    object_args+=(-object "$o")
+done
+
+echo "coverage: reporting over ${#objs[@]} instrumented binaries"
+echo
+"${COV_TOOL}" report "${objs[0]}" "${object_args[@]}" \
+    -instr-profile="${PROFDATA}" \
+    -ignore-filename-regex="${IGNORE_REGEX}" \
+    -show-region-summary=false
+
+if [[ "${COVERAGE_HTML:-0}" == "1" ]]; then
+    HTML_DIR="${COV_DIR}/html"
+    echo
+    echo "coverage: writing HTML report to ${HTML_DIR} ..."
+    "${COV_TOOL}" show "${objs[0]}" "${object_args[@]}" \
+        -instr-profile="${PROFDATA}" \
+        -ignore-filename-regex="${IGNORE_REGEX}" \
+        -format=html -output-dir="${HTML_DIR}" \
+        -show-line-counts-or-regions
+    echo "coverage: open ${HTML_DIR}/index.html"
+fi


### PR DESCRIPTION
Adds `make coverage` to libevpl so coverage can be measured here rather than only through a parent project.

- `CMakeLists.txt`: `Coverage` build type; requires clang, instruments every TU at `-O0` with `-fprofile-instr-generate -fcoverage-mapping`.
- `Makefile`: `build_coverage` / `test_coverage` / `coverage`. The compiler pin moves out of `CMAKE_ARGS` into the per-build-type variables so Release and Debug keep gcc and only Coverage selects clang. Coverage gets its own ctest timeout, since an `-O0` instrumented build is slow enough that the existing 10s would collect timeouts as coverage gaps.
- `COVERAGE_TESTS=<ctest regex>` restricts the run to a subset of the suite.
- `etc/coverage-report.sh`: merges the per-process `.profraw` files and prints a per-file `llvm-cov` report over libevpl's own sources, excluding `ext/`, `3rdparty/` and (by default) generated code. The exclusions are anchored to the source root, since libevpl is commonly checked out inside another project's `ext/`.
- `.devcontainer/Dockerfile`: install `libclang-rt-dev` unversioned instead of pinning `libclang-rt-18-dev`, so clang, llvm and the compiler-rt runtimes all track the same release. With the pin stale, `libclang_rt.profile.a` is missing and instrumented objects fail to link.

Not build-tested as a container image (no docker available); package resolution verified with `apt-get --dry-run`.