### PR TITLE
rpc2: correctness fixes in the reply and framing paths

### DIFF
--- a/include/evpl/evpl_bind.h
+++ b/include/evpl/evpl_bind.h
@@ -45,6 +45,19 @@ typedef void (*evpl_notify_callback_t)(
 
 #define EVPL_SEND_FLAG_TAKE_REF  0x01
 
+/*
+ * Framing callback for a stream transport: inspect what has been buffered so
+ * far (evpl_peek) and report how the next message is delimited.
+ *
+ *   > 0  the length of the next complete message, including whatever framing
+ *        header the protocol uses.  Delivered once that many bytes arrive.
+ *   == 0 no complete message is available yet -- typically the length prefix
+ *        itself has not fully arrived.  The connection is left alone and the
+ *        callback is polled again as more data lands.
+ *   < 0  the framing is unusable and the connection must be closed.  Use this
+ *        for a length that cannot be honoured, not for "need more data": a
+ *        peer can otherwise make the transport buffer on its terms.
+ */
 typedef int (*evpl_segment_callback_t)(
     struct evpl      *evpl,
     struct evpl_bind *bind,

--- a/include/evpl/evpl_rpc2.h
+++ b/include/evpl/evpl_rpc2.h
@@ -131,6 +131,21 @@ evpl_rpc2_thread_destroy(
     struct evpl_rpc2_thread *thread);
 
 /*
+ * Maximum size of a single RPC message, counted across every fragment of a
+ * record.  A record mark claiming more than this is refused at the framing
+ * layer and the connection is closed, so an unauthenticated peer cannot make
+ * the transport buffer on its terms.  Defaults to 4 MiB; pass 0 to restore
+ * the default.  Process-wide, and intended to be set before serving begins.
+ */
+void
+evpl_rpc2_set_max_message_size(
+    uint32_t bytes);
+
+uint32_t
+evpl_rpc2_get_max_message_size(
+    void);
+
+/*
  * Get the client dbuf from a thread for use by client call marshalling.
  */
 void *

--- a/src/core/io_uring/io_uring_tcp.c
+++ b/src/core/io_uring/io_uring_tcp.c
@@ -130,14 +130,20 @@ evpl_io_uring_tcp_recv_callback(
 
                 length = bind->segment_callback(evpl, bind, bind->private_data);
 
-                if (length == 0 ||
-                    evpl_iovec_ring_bytes(&bind->iovec_recv) < length) {
-                    break;
-                }
-
+                /* A negative length is the segment callback's request to drop
+                 * the connection (an unparseable or oversized frame).  This test
+                 * must precede the ring-bytes comparison: that comparison
+                 * promotes the signed length to the unsigned type of
+                 * evpl_iovec_ring_bytes, so a negative value compares as huge and
+                 * would break out of the loop before ever reaching this check. */
                 if (unlikely(length < 0)) {
                     evpl_close(evpl, bind);
                     return;
+                }
+
+                if (length == 0 ||
+                    evpl_iovec_ring_bytes(&bind->iovec_recv) < (uint64_t) length) {
+                    break;
                 }
 
                 niov = evpl_iovec_ring_copyv(evpl, iov, &bind->iovec_recv, length);

--- a/src/core/socket/tcp.c
+++ b/src/core/socket/tcp.c
@@ -118,14 +118,20 @@ evpl_socket_tcp_read(
 
             length = bind->segment_callback(evpl, bind, bind->private_data);
 
-            if (length == 0 ||
-                evpl_iovec_ring_bytes(&bind->iovec_recv) < length) {
-                break;
-            }
-
+            /* A negative length is the segment callback's request to drop
+             * the connection (an unparseable or oversized frame).  This test
+             * must precede the ring-bytes comparison: that comparison
+             * promotes the signed length to the unsigned type of
+             * evpl_iovec_ring_bytes, so a negative value compares as huge and
+             * would break out of the loop before ever reaching this check. */
             if (unlikely(length < 0)) {
                 evpl_close(evpl, bind);
                 goto out;
+            }
+
+            if (length == 0 ||
+                evpl_iovec_ring_bytes(&bind->iovec_recv) < (uint64_t) length) {
+                break;
             }
 
             niov = evpl_iovec_ring_copyv(evpl, iovec, &bind->iovec_recv,

--- a/src/core/tls/tls.c
+++ b/src/core/tls/tls.c
@@ -535,14 +535,20 @@ evpl_tls_read_ktls(
 
             length = bind->segment_callback(evpl, bind, bind->private_data);
 
-            if (length == 0 ||
-                evpl_iovec_ring_bytes(&bind->iovec_recv) < length) {
-                break;
-            }
-
+            /* A negative length is the segment callback's request to drop
+             * the connection (an unparseable or oversized frame).  This test
+             * must precede the ring-bytes comparison: that comparison
+             * promotes the signed length to the unsigned type of
+             * evpl_iovec_ring_bytes, so a negative value compares as huge and
+             * would break out of the loop before ever reaching this check. */
             if (unlikely(length < 0)) {
                 evpl_close(evpl, bind);
                 goto out;
+            }
+
+            if (length == 0 ||
+                evpl_iovec_ring_bytes(&bind->iovec_recv) < (uint64_t) length) {
+                break;
             }
 
             niov = evpl_iovec_ring_copyv(evpl, iovec, &bind->iovec_recv,
@@ -763,13 +769,20 @@ evpl_tls_read(
         while (1) {
             length = bind->segment_callback(evpl, bind, bind->private_data);
 
-            if (length == 0 || evpl_iovec_ring_bytes(&bind->iovec_recv) < length) {
-                break;
-            }
-
+            /* A negative length is the segment callback's request to drop
+             * the connection (an unparseable or oversized frame).  This test
+             * must precede the ring-bytes comparison: that comparison
+             * promotes the signed length to the unsigned type of
+             * evpl_iovec_ring_bytes, so a negative value compares as huge and
+             * would break out of the loop before ever reaching this check. */
             if (unlikely(length < 0)) {
                 evpl_close(evpl, bind);
                 return;
+            }
+
+            if (length == 0 ||
+                evpl_iovec_ring_bytes(&bind->iovec_recv) < (uint64_t) length) {
+                break;
             }
 
             niov = evpl_iovec_ring_copyv(evpl, iovec, &bind->iovec_recv, length);

--- a/src/core/xlio/tcp.c
+++ b/src/core/xlio/tcp.c
@@ -131,14 +131,20 @@ evpl_xlio_tcp_read(
 
             length = bind->segment_callback(evpl, bind, bind->private_data);
 
-            if (length == 0 ||
-                evpl_iovec_ring_bytes(&bind->iovec_recv) < length) {
-                break;
-            }
-
+            /* A negative length is the segment callback's request to drop
+             * the connection (an unparseable or oversized frame).  This test
+             * must precede the ring-bytes comparison: that comparison
+             * promotes the signed length to the unsigned type of
+             * evpl_iovec_ring_bytes, so a negative value compares as huge and
+             * would break out of the loop before ever reaching this check. */
             if (unlikely(length < 0)) {
                 evpl_close(evpl, bind);
                 return;
+            }
+
+            if (length == 0 ||
+                evpl_iovec_ring_bytes(&bind->iovec_recv) < (uint64_t) length) {
+                break;
             }
 
             niov = evpl_iovec_ring_copyv(evpl, iovec, &bind->iovec_recv,

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -117,6 +117,12 @@ struct evpl_rpc2_request {
     void                                 *reply_verf_data;
     uint32_t                              reply_verf_len;
     uint32_t                              reply_verf_flavor;
+
+    /* Supported version range reported with a PROG_MISMATCH reply.  RFC 5531
+     * requires the accepted-reply body for that status to carry the range the
+     * server does export, so a client can retry within it. */
+    uint32_t                              mismatch_low;
+    uint32_t                              mismatch_high;
 };
 
 /*
@@ -667,6 +673,15 @@ evpl_rpc2_send_reply(
             rpc_reply.body.rbody.areply.verf.flavor = AUTH_NONE;
         }
         rpc_reply.body.rbody.areply.reply_data.stat = error_stat;
+
+        /* PROG_MISMATCH is the one accepted-reply status whose body carries
+         * data.  The generated marshaller emits mismatch_info for this arm
+         * unconditionally, so it must be filled in or the reply ships
+         * whatever the stack held. */
+        if (error_stat == PROG_MISMATCH) {
+            rpc_reply.body.rbody.areply.reply_data.info.low  = request->mismatch_low;
+            rpc_reply.body.rbody.areply.reply_data.info.high = request->mismatch_high;
+        }
 
         /* Integrity service (krb5i): reframe the proc results as
          * rpc_gss_integ_data before the RPC header is prepended.  Non-RDMA
@@ -2016,6 +2031,8 @@ evpl_rpc2_recv_msg(
     struct evpl_iovec               *hdr_iov, *req_iov;
     int                              hdr_niov, req_niov;
     int                              i, rc, offset, rdma, request_length;
+    int                              prog_exported;
+    uint32_t                         vers_low, vers_high;
     struct xdr_read_list            *read_list;
     struct xdr_write_list           *write_list;
     struct evpl_iovec               *segment_iov;
@@ -2365,26 +2382,62 @@ evpl_rpc2_recv_msg(
                 }
             }
 
+            /* Look for an exact (program, version) match, and while scanning
+             * note whether the program number is exported at all and over
+             * what version range.  RFC 5531 distinguishes the two failures: a
+             * program we do not export is PROG_UNAVAIL, while a program we do
+             * export at other versions is PROG_MISMATCH carrying the range.
+             * Clients use that difference to decide between downgrading and
+             * giving up. */
             request->program = NULL;
+            prog_exported    = 0;
+            vers_low         = UINT32_MAX;
+            vers_high        = 0;
 
             for (i = 0; i < rpc2_conn->num_server_programs; i++) {
                 program = rpc2_conn->server_programs[i];
 
-                if (program->program == rpc_msg.body.cbody.prog &&
-                    program->version == rpc_msg.body.cbody.vers) {
+                if (program->program != rpc_msg.body.cbody.prog) {
+                    continue;
+                }
 
+                prog_exported = 1;
+
+                if (program->version < vers_low) {
+                    vers_low = program->version;
+                }
+
+                if (program->version > vers_high) {
+                    vers_high = program->version;
+                }
+
+                if (program->version == rpc_msg.body.cbody.vers) {
                     request->program = program;
                     break;
                 }
             }
 
             if (unlikely(!request->program)) {
-                evpl_rpc2_debug(
-                    "rpc2 received call for unknown program %u vers %u",
-                    rpc_msg.body.cbody.prog,
-                    rpc_msg.body.cbody.vers);
+                if (prog_exported) {
+                    evpl_rpc2_debug(
+                        "rpc2 received call for program %u at unsupported vers %u (supported %u-%u)",
+                        rpc_msg.body.cbody.prog,
+                        rpc_msg.body.cbody.vers,
+                        vers_low,
+                        vers_high);
 
-                evpl_rpc2_send_reply_error(evpl, request, PROG_MISMATCH);
+                    request->mismatch_low  = vers_low;
+                    request->mismatch_high = vers_high;
+
+                    evpl_rpc2_send_reply_error(evpl, request, PROG_MISMATCH);
+                } else {
+                    evpl_rpc2_debug(
+                        "rpc2 received call for unexported program %u vers %u",
+                        rpc_msg.body.cbody.prog,
+                        rpc_msg.body.cbody.vers);
+
+                    evpl_rpc2_send_reply_error(evpl, request, PROG_UNAVAIL);
+                }
                 return;
             }
 

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -2031,8 +2031,8 @@ evpl_rpc2_recv_msg(
     struct evpl_iovec               *hdr_iov, *req_iov;
     int                              hdr_niov, req_niov;
     int                              i, rc, offset, rdma, request_length;
-    int                              prog_exported;
-    uint32_t                         vers_low, vers_high;
+    int                              prog_exported, can_deny;
+    uint32_t                         vers_low, vers_high, deny_xid;
     struct xdr_read_list            *read_list;
     struct xdr_write_list           *write_list;
     struct evpl_iovec               *segment_iov;
@@ -2133,16 +2133,58 @@ evpl_rpc2_recv_msg(
     rc = unmarshall_rpc_msg(&rpc_msg, hdr_iov, hdr_niov, NULL, &msg->dbuf);
 
     if (rc < 0) {
-        /* Truncated / undecodable RPC header (RFC 5531 §8): the call header
-         * could not be fully decoded.  Reusing the negative return as a byte
-         * offset below drives a negative-offset, over-length iovec clone, so
-         * release every reference acquired so far and drop the connection
-         * instead. */
+        /* Truncated / undecodable RPC header (RFC 5531 §8).  Reusing the
+         * negative return as a byte offset below would drive a
+         * negative-offset, over-length iovec clone, so nothing further may be
+         * parsed out of this message.
+         *
+         * The xid and mtype are the first two fields of every RPC message and
+         * sit at fixed offsets, ahead of the credential and verifier that are
+         * the usual reason the rest fails to decode.  When they are present
+         * and identify a CALL, the call can still be answered: RFC 5531
+         * rejects a credential the server cannot accept with MSG_DENIED /
+         * AUTH_ERROR, and answering leaves the peer able to tell rejection
+         * from a network fault -- closing the connection does not.  Only when
+         * even that much is unreadable is there nothing to address a reply
+         * to, and the connection is dropped. */
+        deny_xid = 0;
+        can_deny = 0;
+
+        if (hdr_niov > 0 && hdr_iov[0].length >= 2 * sizeof(uint32_t)) {
+            const uint32_t *words = hdr_iov[0].data;
+
+            if (rpc2_ntoh32(words[1]) == CALL) {
+                deny_xid = rpc2_ntoh32(words[0]);
+                can_deny = 1;
+            }
+        }
+
         evpl_iovecs_release_internal(evpl, hdr_iov, hdr_niov);
         evpl_iovecs_release_internal(evpl, iovec, niov);
         if (!rdma && offset == 0) {
             evpl_free(iovec);
         }
+
+        if (can_deny) {
+            evpl_rpc2_debug("rpc2 call xid %u has an undecodable header; "
+                            "rejecting with AUTH_BADCRED", deny_xid);
+
+            request      = evpl_rpc2_request_alloc(thread);
+            request->msg = msg;
+
+            request->m_inflight = thread->m_inflight[EVPL_RPC2_ROLE_SERVER];
+            prometheus_gauge_add(request->m_inflight, 1);
+
+            request->conn         = rpc2_conn;
+            request->bind         = bind;
+            request->xid          = deny_xid;
+            request->encoding.xid = deny_xid;
+            prometheus_stopwatch_start(&request->timestamp);
+
+            evpl_rpc2_send_reply_denied(evpl, request, AUTH_BADCRED);
+            return;
+        }
+
         evpl_rpc2_msg_free(thread, msg);
         evpl_close(evpl, bind);
         return;

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -243,8 +243,8 @@ evpl_rpc2_request_alloc(struct evpl_rpc2_thread *thread)
         request = evpl_zalloc(sizeof(*request));
     }
 
-    request->thread                      = thread;
-    request->m_inflight                  = NULL;
+    request->thread     = thread;
+    request->m_inflight = NULL;
     /* Requests are recycled, and the early error paths -- bad RPC version,
      * unknown program, unknown procedure, rejected credential -- reply before
      * either of these is assigned.  Without a reset they would carry whatever
@@ -337,13 +337,43 @@ rpc2_ntoh32(uint32_t value)
 #endif /* if __BYTE_ORDER == __LITTLE_ENDIAN */
 } /* rpc2_ntoh32 */
 
+/*
+ * Ceiling on one RPC message, counted over every fragment of a record.
+ *
+ * The record mark is unauthenticated input: a peer can claim any length it
+ * likes before sending a byte of it.  Without a ceiling the transport will
+ * keep buffering whatever the claim asks for, so a single connection can be
+ * made to consume memory without bound.  Capping it means an oversized claim
+ * is refused at the framing layer, before anything is allocated for it.
+ *
+ * 4 MiB is comfortably above realistic RPC traffic -- NFS rsize/wsize is
+ * typically 1 MiB and the payload for a large READ/WRITE travels in RDMA
+ * chunks rather than inline -- while staying small enough that the worst case
+ * per connection is bounded.  Adjust with evpl_rpc2_set_max_message_size().
+ */
+#define EVPL_RPC2_DEFAULT_MAX_MSG_SIZE (4u * 1024u * 1024u)
+
+static uint32_t evpl_rpc2_max_msg_size = EVPL_RPC2_DEFAULT_MAX_MSG_SIZE;
+
+SYMBOL_EXPORT void
+evpl_rpc2_set_max_message_size(uint32_t bytes)
+{
+    evpl_rpc2_max_msg_size = bytes ? bytes : EVPL_RPC2_DEFAULT_MAX_MSG_SIZE;
+} /* evpl_rpc2_set_max_message_size */
+
+SYMBOL_EXPORT uint32_t
+evpl_rpc2_get_max_message_size(void)
+{
+    return evpl_rpc2_max_msg_size;
+} /* evpl_rpc2_get_max_message_size */
+
 static int
 rpc2_segment_callback(
     struct evpl      *evpl,
     struct evpl_bind *bind,
     void             *private_data)
 {
-    uint32_t hdr;
+    uint32_t hdr, frag_len;
     int      length;
 
     length = evpl_peek(evpl, bind, &hdr, sizeof(hdr));
@@ -352,16 +382,27 @@ rpc2_segment_callback(
         return 0;
     }
 
-    hdr = rpc2_ntoh32(hdr);
+    hdr      = rpc2_ntoh32(hdr);
+    frag_len = hdr & 0x7FFFFFFF;
+
+    /* Refuse an oversized fragment here, before the transport starts
+     * accumulating bytes for it.  A negative return asks the transport to
+     * close the connection: there is no way to answer a peer whose framing we
+     * do not trust, and continuing would mean buffering on its terms. */
+    if (unlikely(frag_len > evpl_rpc2_max_msg_size)) {
+        evpl_rpc2_error(
+            "rpc2 record mark claims %u bytes, above the %u byte maximum; closing",
+            frag_len, evpl_rpc2_max_msg_size);
+        return -1;
+    }
 
     /* Deliver one TCP record-mark fragment (4-byte mark + payload).
      * Multi-fragment reassembly is performed in evpl_rpc2_recv_msg. */
-    return (hdr & 0x7FFFFFFF) + 4;
+    return (int) frag_len + 4;
 } /* rpc2_segment_callback */
 
-/* Cap on a single reassembled RPC message (DoS guard). Well above
- * realistic NFS COMPOUND sizes (typical rsize/wsize <= 1 MiB). */
-#define EVPL_RPC2_MAX_REASM_LENGTH (16u * 1024u * 1024u)
+/* Cap on a single reassembled RPC message, applied across fragments. */
+#define EVPL_RPC2_MAX_REASM_LENGTH (evpl_rpc2_max_msg_size)
 
 #define EVPL_RPC2_REASM_INIT_CAP   8
 

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -245,6 +245,13 @@ evpl_rpc2_request_alloc(struct evpl_rpc2_thread *thread)
 
     request->thread                      = thread;
     request->m_inflight                  = NULL;
+    /* Requests are recycled, and the early error paths -- bad RPC version,
+     * unknown program, unknown procedure, rejected credential -- reply before
+     * either of these is assigned.  Without a reset they would carry whatever
+     * the previous user of this struct left behind, and the reply path would
+     * charge its latency sample to an unrelated procedure's histogram. */
+    request->program                     = NULL;
+    request->metric                      = NULL;
     request->rdma_credits                = 1;
     request->dbg_reply_sent              = 0;
     request->pending_reads               = 0;


### PR DESCRIPTION
Five independent fixes, one per commit. Found by testing the server against RFC 5531 rather than against its own behaviour.

- **core: make the segment callback's close request reachable.** A negative return means "drop this connection", but the guard testing for it ran after a comparison against `evpl_iovec_ring_bytes()`, which is unsigned 64-bit — so the negative promoted to a huge value, compared greater, and broke out of the loop first. Fixed in all four stream transports; the three-way contract is now documented on `evpl_segment_callback_t`. Note for callers: a callback returning negative to mean "need more data" will now close the connection — return 0 for that.
- **rpc2: distinguish an unexported program, and report a real version range.** `PROG_MISMATCH` replies shipped 8 bytes of uninitialised stack as the supported-version range (`rpc_msg` was never initialised and the marshaller emits `mismatch_info` unconditionally). Separately, an unexported program was answered `PROG_MISMATCH`; RFC 5531 requires `PROG_UNAVAIL`, which was defined in `rpc2.x` and never emitted.
- **rpc2: answer a call whose header will not decode.** A failed `unmarshall_rpc_msg` closed the connection with no reply; the usual cause is an unparseable credential, which RFC 5531 answers with `AUTH_ERROR`. The xid and mtype sit at fixed offsets ahead of the credential, so where they identify a CALL it is now rejected with `AUTH_BADCRED`.
- **rpc2: reset `program` and `metric` on request reuse.** Requests come from a free list and these two fields were not reset. Every early error path replies before they are assigned, so those replies sampled a recycled `metric` and charged their latency to an unrelated procedure's histogram.
- **rpc2: cap the size of a single RPC message.** A record mark is unauthenticated input and the transport buffered whatever it claimed. Now refused in the segment callback before anything is allocated, and the same ceiling bounds reassembly across fragments. Default 4 MiB, adjustable via `evpl_rpc2_set_max_message_size()`. Depends on the first commit.

Each commit builds; branch tip passes the libevpl suite (78/78) in Release and under ASan.