### PR TITLE
Add AF_UNIX stream sockets and path-addressed endpoints

### DIFF
--- a/docs/examples/echo_connected_msg.c
+++ b/docs/examples/echo_connected_msg.c
@@ -120,7 +120,10 @@ server_thread(void *arg)
     binding = evpl_listener_attach(evpl, listener, accept_callback, state);
 
     /* Start listening for incoming connections */
-    evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint);
+    if (evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint)) {
+        fprintf(stderr, "failed to listen\n");
+        exit(1);
+    }
 
     printf("[Server] Listening on port 8000\n");
 

--- a/docs/examples/echo_stream.c
+++ b/docs/examples/echo_stream.c
@@ -103,7 +103,10 @@ server_thread(void *arg)
     binding = evpl_listener_attach(evpl, listener, accept_callback, state);
 
     /* Start listening for incoming connections */
-    evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint);
+    if (evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint)) {
+        fprintf(stderr, "failed to listen\n");
+        exit(1);
+    }
 
     printf("[Server] Listening on port 8000\n");
 

--- a/include/evpl/evpl_bind.h
+++ b/include/evpl/evpl_bind.h
@@ -207,6 +207,11 @@ void evpl_finish(
     struct evpl      *evpl,
     struct evpl_bind *bind);
 
+/* Size a buffer passed to evpl_bind_get_local_address() or
+ * evpl_bind_get_remote_address() to at least this and no representable
+ * address is truncated.  The longest form is an AF_UNIX path. */
+#define EVPL_ADDRESS_STRLEN 128
+
 void evpl_bind_get_local_address(
     struct evpl_bind *bind,
     char             *str,

--- a/include/evpl/evpl_core.h
+++ b/include/evpl/evpl_core.h
@@ -31,7 +31,8 @@ enum evpl_protocol_id {
     EVPL_STREAM_RDMACM_RC    = 6,
     EVPL_STREAM_SOCKET_TLS   = 7,
     EVPL_DATAGRAM_TCP_RDMA   = 8,
-    EVPL_NUM_PROTO           = 9
+    EVPL_STREAM_SOCKET_UNIX  = 9,
+    EVPL_NUM_PROTO           = 10
 };
 
 enum evpl_block_protocol_id {
@@ -108,7 +109,19 @@ int evpl_protocol_lookup(
     enum evpl_protocol_id *id,
     const char            *name);
 
+/* 1 iff the protocol is registered and available in this build/config.  An
+ * unavailable protocol reports 0 from every predicate below, so this is how a
+ * caller distinguishes "not a stream" from "not built". */
+int evpl_protocol_available(
+    enum evpl_protocol_id protocol);
+
 int evpl_protocol_is_stream(
+    enum evpl_protocol_id protocol);
+
+/* 1 iff the protocol names peers by a local socket path rather than by
+ * network address and port, and therefore requires an endpoint created by
+ * evpl_endpoint_create_local(). */
+int evpl_protocol_is_local(
     enum evpl_protocol_id protocol);
 
 struct evpl_config *

--- a/include/evpl/evpl_endpoint.h
+++ b/include/evpl/evpl_endpoint.h
@@ -11,13 +11,46 @@
 struct evpl_endpoint;
 struct evpl_address;
 
+/*
+ * Create an endpoint naming a peer by IP address or DNS name plus a port.
+ * The address is resolved lazily and re-resolved periodically, see
+ * evpl_global_config_set_resolve_timeout_ms().
+ */
 struct evpl_endpoint *
 evpl_endpoint_create(
     const char *address,
     int         port);
 
+/*
+ * Create an endpoint naming a local (AF_UNIX) socket.
+ *
+ * path must be one of:
+ *
+ *   "/absolute/path"  a filesystem socket.  At most 107 bytes; longer paths
+ *                     are rejected rather than truncated, since a shortened
+ *                     path is a different socket.  Relative paths are
+ *                     rejected.
+ *
+ *   "@name"           a Linux abstract-namespace socket.  Not backed by a
+ *                     filesystem entry, so it needs no cleanup and cannot be
+ *                     left stale by a crash.  Scoped to the caller's network
+ *                     namespace.  Linux only.
+ *
+ * Endpoints created here may only be used with protocols for which
+ * evpl_protocol_is_local() is true.
+ *
+ * Returns NULL if the path is malformed or too long.
+ */
+struct evpl_endpoint *
+evpl_endpoint_create_local(
+    const char *path);
+
 void evpl_endpoint_close(
     struct evpl_endpoint *endpoint);
+
+/* 1 iff this endpoint names a local (AF_UNIX) socket. */
+int evpl_endpoint_is_local(
+    const struct evpl_endpoint *ep);
 
 const char *
 evpl_endpoint_address(

--- a/include/evpl/evpl_rpc2.h
+++ b/include/evpl/evpl_rpc2.h
@@ -157,7 +157,9 @@ evpl_rpc2_server_init(
     struct evpl_rpc2_program **programs,
     int                        nprograms);
 
-void
+/* Begin serving on endpoint.  Returns 0, or -1 if the listen could not be
+ * established -- see evpl_listen(). */
+int
 evpl_rpc2_server_start(
     struct evpl_rpc2_server *server,
     int                      protocol,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,61 @@ macro(unit_test_bin module test_name binary_name)
     endif()
 endmacro()
 
+# Directory for test sockets, inside the build tree so a run leaves nothing
+# behind in /tmp and two build trees cannot collide.  Deliberately short:
+# sun_path is only 108 bytes, and the tests append a pid-stamped filename.
+set(EVPL_TEST_SOCKET_DIR ${CMAKE_BINARY_DIR}/tsock)
+file(MAKE_DIRECTORY ${EVPL_TEST_SOCKET_DIR})
+
+# Register a test that needs no network stack -- today that means one
+# addressed purely by AF_UNIX socket name.
+#
+# The netns wrapper exists so that tests hardcoding a loopback port can run
+# concurrently without colliding, and the evpl_net resource lock serializes
+# them where namespaces are unavailable.  A test addressed by socket name
+# needs neither: it takes its name from EVPL_TEST_SOCKET_DIR plus its own pid,
+# so it is already unique, and creating a namespace for it would cost
+# CAP_NET_ADMIN and buy nothing.  These therefore register directly and run
+# fully in parallel, including where namespaces are unavailable.
+#
+# Registered once per event-loop mechanism, like the network variants.
+macro(unit_test_local module test_name)
+
+    set(sources ${ARGN})
+
+    add_executable(${module}_${test_name} ${sources})
+
+    target_link_libraries(${module}_${test_name} evpl pthread)
+
+    list(GET sources 0 first_source)
+
+    foreach(mech ${EVPL_MECHANISMS})
+        set(_test libevpl/${module}/${test_name}_${mech})
+
+        add_test(NAME ${_test} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${module}_${test_name})
+
+        set_tests_properties(${_test} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${first_source};EVPL_TEST_CORE_MECH=${mech};EVPL_TEST_SOCKET_DIR=${EVPL_TEST_SOCKET_DIR}")
+    endforeach()
+
+endmacro()
+
+# As unit_test_local, but for a prebuilt binary from src/tests.
+macro(unit_test_bin_local module test_name binary_name)
+
+    foreach(mech ${EVPL_MECHANISMS})
+        set(_test libevpl/${module}/${test_name}_${mech})
+
+        get_target_property(test_file ${binary_name} TEST_FILE)
+
+        add_test(NAME ${_test} COMMAND ${TEST_BIN}/${binary_name} ${ARGN})
+
+        set_tests_properties(${_test} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file};EVPL_TEST_CORE_MECH=${mech};EVPL_TEST_SOCKET_DIR=${EVPL_TEST_SOCKET_DIR}")
+    endforeach()
+
+endmacro()
+
 macro(unit_test_xdr module test_name xdr_file)
     set(sources ${ARGN})
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 set(BACKEND_LIBDEPS)
 
-set(CORE_SRC ${CORE_SRC} socket/tcp.c socket/tcp.h socket/common.h socket/udp.c socket/udp.h socket/tcp_rdma.c socket/tcp_rdma.h)
+set(CORE_SRC ${CORE_SRC} socket/tcp.c socket/tcp.h socket/common.h socket/udp.c socket/udp.h socket/tcp_rdma.c socket/tcp_rdma.h socket/unix_stream.c socket/unix_stream.h)
 add_subdirectory(socket)
 
 # TLS is available wherever OpenSSL is (HAVE_TLS is set at the top level).  Its

--- a/src/core/address.c
+++ b/src/core/address.c
@@ -26,6 +26,10 @@ evpl_address_init(
 {
     struct evpl_address *ea = evpl_address_alloc();
 
+    evpl_core_abort_if(addrlen > sizeof(ea->sa),
+                       "evpl_address_init: addrlen %u exceeds %zu",
+                       addrlen, sizeof(ea->sa));
+
     ea->addrlen = addrlen;
     memcpy(ea->addr, addr, addrlen);
 

--- a/src/core/address.h
+++ b/src/core/address.h
@@ -6,7 +6,9 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stddef.h>
 #include <arpa/inet.h>
+#include <sys/un.h>
 #include <stdatomic.h>
 
 #include "core/evpl_shared.h"
@@ -57,7 +59,7 @@ evpl_address_set_private(
     address->framework_private[protocol] = private_data;
 } // evpl_address_set_private
 
-static void
+static inline void
 evpl_address_get_address(
     struct evpl_address *address,
     char                *str,
@@ -66,7 +68,9 @@ evpl_address_get_address(
     struct sockaddr     *sa;
     struct sockaddr_in  *sin;
     struct sockaddr_in6 *sin6;
+    struct sockaddr_un  *sun;
     char                 addr_str[INET6_ADDRSTRLEN];
+    int                  pathlen;
 
     if (address == NULL) {
         snprintf(str, len, "(NULL)");
@@ -75,13 +79,50 @@ evpl_address_get_address(
 
     sa = address->addr;
 
-    if (sa->sa_family == AF_INET) {
-        sin = (struct sockaddr_in *) sa;
-        inet_ntop(AF_INET, &sin->sin_addr, addr_str, sizeof(addr_str));
-        snprintf(str, len, "%s:%d", addr_str, ntohs(sin->sin_port));
-    } else if (sa->sa_family == AF_INET6) {
-        sin6 = (struct sockaddr_in6 *) sa;
-        inet_ntop(AF_INET6, &sin6->sin6_addr, addr_str, sizeof(addr_str));
-        snprintf(str, len, "[%s]:%d", addr_str, ntohs(sin6->sin6_port));
-    }
+    switch (sa->sa_family) {
+        case AF_INET:
+            sin = (struct sockaddr_in *) sa;
+            inet_ntop(AF_INET, &sin->sin_addr, addr_str, sizeof(addr_str));
+            snprintf(str, len, "%s:%d", addr_str, ntohs(sin->sin_port));
+            break;
+
+        case AF_INET6:
+            sin6 = (struct sockaddr_in6 *) sa;
+            inet_ntop(AF_INET6, &sin6->sin6_addr, addr_str, sizeof(addr_str));
+            snprintf(str, len, "[%s]:%d", addr_str, ntohs(sin6->sin6_port));
+            break;
+
+        case AF_UNIX:
+            sun     = (struct sockaddr_un *) sa;
+            pathlen = (int) address->addrlen -
+                (int) offsetof(struct sockaddr_un, sun_path);
+
+            if (pathlen <= 0) {
+                /* An unbound peer.  Unix clients are typically not bound to
+                 * any name, so accept() and getsockname() hand back an
+                 * addrlen of exactly sizeof(sa_family_t) with an empty
+                 * sun_path.  This is the ordinary case for the remote end of
+                 * an accepted connection, not an error. */
+                snprintf(str, len, "unix:*");
+            } else if (sun->sun_path[0] == '\0') {
+                /* Abstract namespace.  The name is the remaining pathlen - 1
+                 * bytes and is not NUL terminated, so it needs an explicit
+                 * precision. */
+                snprintf(str, len, "unix:@%.*s", pathlen - 1,
+                         sun->sun_path + 1);
+            } else {
+                /* Pathname socket.  Bound by strnlen rather than trusting an
+                 * addrlen that came from the kernel via a peer. */
+                snprintf(str, len, "unix:%.*s",
+                         (int) strnlen(sun->sun_path, (size_t) pathlen),
+                         sun->sun_path);
+            }
+            break;
+
+        default:
+            /* Never leave the caller's buffer uninitialized -- it is very
+             * likely about to be printed. */
+            snprintf(str, len, "(family %d)", sa->sa_family);
+            break;
+    } /* switch */
 } /* evpl_bind_get_local_address */

--- a/src/core/bind.c
+++ b/src/core/bind.c
@@ -5,8 +5,10 @@
 #include <utlist.h>
 
 #include "core/macros.h"
+#include "core/logging.h"
 #include "core/evpl_shared.h"
 #include "core/bind.h"
+#include "core/endpoint.h"
 #include "core/evpl.h"
 
 SYMBOL_EXPORT struct evpl_bind *
@@ -21,6 +23,7 @@ evpl_connect(
 {
     struct evpl_bind     *bind;
     struct evpl_protocol *protocol = evpl_shared->protocol[protocol_id];
+    struct evpl_address  *local    = NULL, *remote;
 
     if (!protocol) {
         return NULL;
@@ -29,9 +32,48 @@ evpl_connect(
     evpl_core_abort_if(!protocol->connect,
                        "Called evpl_connect with non-connection oriented protocol");
 
-    bind = evpl_bind_prepare(evpl, protocol,
-                             local_endpoint ? evpl_endpoint_resolve(local_endpoint) : NULL,
-                             evpl_endpoint_resolve(remote_endpoint));
+    /* A recoverable error rather than an abort: the address usually comes
+     * from configuration, so a mismatch is bad input, not a bug.  Left
+     * unchecked it surfaces far downstream -- the backend derives the socket
+     * domain from sa_family, so socket() and connect() both succeed and it
+     * dies later on a setsockopt the wrong family does not support. */
+    if (unlikely(evpl_endpoint_check_protocol(remote_endpoint, protocol) < 0)) {
+        evpl_core_error(
+            "evpl_connect: protocol %s cannot be used with %s endpoint '%s'",
+            protocol->name,
+            remote_endpoint->kind == EVPL_ENDPOINT_LOCAL ? "local-path" : "network",
+            remote_endpoint->address);
+        return NULL;
+    }
+
+    remote = evpl_endpoint_resolve(remote_endpoint);
+
+    if (unlikely(!remote)) {
+        evpl_core_error("evpl_connect: failed to resolve '%s'",
+                        remote_endpoint->address);
+        return NULL;
+    }
+
+    if (local_endpoint) {
+        if (unlikely(evpl_endpoint_check_protocol(local_endpoint, protocol) < 0)) {
+            evpl_core_error(
+                "evpl_connect: local endpoint '%s' does not match protocol %s",
+                local_endpoint->address, protocol->name);
+            evpl_address_release(remote);
+            return NULL;
+        }
+
+        local = evpl_endpoint_resolve(local_endpoint);
+
+        if (unlikely(!local)) {
+            evpl_core_error("evpl_connect: failed to resolve local '%s'",
+                            local_endpoint->address);
+            evpl_address_release(remote);
+            return NULL;
+        }
+    }
+
+    bind                   = evpl_bind_prepare(evpl, protocol, local, remote);
     bind->notify_callback  = notify_callback;
     bind->segment_callback = segment_callback;
     bind->private_data     = private_data;
@@ -51,11 +93,32 @@ evpl_bind(
 {
     struct evpl_bind     *bind;
     struct evpl_protocol *protocol = evpl_shared->protocol[protocol_id];
+    struct evpl_address  *local;
+
+    if (!protocol) {
+        return NULL;
+    }
 
     evpl_core_abort_if(!protocol->bind,
                        "Called evpl_bind with connection oriented protocol");
 
-    bind = evpl_bind_prepare(evpl, protocol, evpl_endpoint_resolve(endpoint), NULL);
+    if (unlikely(evpl_endpoint_check_protocol(endpoint, protocol) < 0)) {
+        evpl_core_error(
+            "evpl_bind: protocol %s cannot be used with %s endpoint '%s'",
+            protocol->name,
+            endpoint->kind == EVPL_ENDPOINT_LOCAL ? "local-path" : "network",
+            endpoint->address);
+        return NULL;
+    }
+
+    local = evpl_endpoint_resolve(endpoint);
+
+    if (unlikely(!local)) {
+        evpl_core_error("evpl_bind: failed to resolve '%s'", endpoint->address);
+        return NULL;
+    }
+
+    bind = evpl_bind_prepare(evpl, protocol, local, NULL);
 
     bind->notify_callback  = callback;
     bind->segment_callback = NULL;

--- a/src/core/bind.c
+++ b/src/core/bind.c
@@ -310,6 +310,31 @@ evpl_bind_destroy(
     DL_PREPEND(evpl->free_binds, bind);
 } /* evpl_bind_destroy */
 
+void
+evpl_bind_abort(
+    struct evpl      *evpl,
+    struct evpl_bind *bind)
+{
+    /* Discards a bind that never became live, i.e. one whose protocol failed
+     * to establish it.  Unlike evpl_bind_destroy() there is no connection to
+     * report as disconnected and nothing on the pending-close list, so the
+     * bind just gives up its addresses and returns to the freelist.  The
+     * protocol is responsible for having released its own resources before
+     * reporting failure. */
+    if (bind->local) {
+        evpl_address_release(bind->local);
+        bind->local = NULL;
+    }
+
+    if (bind->remote) {
+        evpl_address_release(bind->remote);
+        bind->remote = NULL;
+    }
+
+    DL_DELETE(evpl->binds, bind);
+    DL_PREPEND(evpl->free_binds, bind);
+} /* evpl_bind_abort */
+
 SYMBOL_EXPORT void
 evpl_bind_get_local_address(
     struct evpl_bind *bind,

--- a/src/core/bind.h
+++ b/src/core/bind.h
@@ -65,6 +65,12 @@ evpl_bind_destroy(
     struct evpl      *evpl,
     struct evpl_bind *bond);
 
+/* Release a bind whose protocol never brought it up.  See bind.c. */
+void
+evpl_bind_abort(
+    struct evpl      *evpl,
+    struct evpl_bind *bind);
+
 
 #define evpl_bind_private(bind) ((void *) ((bind) + 1))
 #define evpl_private2bind(ptr)  (((struct evpl_bind *) (ptr)) - 1)

--- a/src/core/endpoint.c
+++ b/src/core/endpoint.c
@@ -4,18 +4,100 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <stddef.h>
 #include <time.h>
 #include <pthread.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <utlist.h>
 
 #include "core/macros.h"
+#include "core/logging.h"
 #include "core/endpoint.h"
 #include "core/evpl_shared.h"
 #include "core/evpl.h"
+
+#define EVPL_UNIX_PATH_MAX sizeof(((struct sockaddr_un *) 0)->sun_path)
+
+static void
+evpl_endpoint_register(struct evpl_endpoint *ep)
+{
+    pthread_rwlock_init(&ep->lock, NULL);
+
+    pthread_mutex_lock(&evpl_shared->lock);
+    DL_APPEND(evpl_shared->endpoints, ep);
+    pthread_mutex_unlock(&evpl_shared->lock);
+} /* evpl_endpoint_register */
+
+/* Validate a local socket name and build an endpoint for it, or return NULL.
+ * Shared by evpl_endpoint_create_local() and the local branch of
+ * evpl_endpoint_create(). */
+static struct evpl_endpoint *
+evpl_endpoint_alloc_local(const char *path)
+{
+    struct evpl_endpoint *ep;
+    size_t                len;
+
+    if (unlikely(!path)) {
+        evpl_core_error("local endpoint: NULL path");
+        return NULL;
+    }
+
+    len = strlen(path);
+
+    if (unlikely(path[0] != '/' && path[0] != '@')) {
+        evpl_core_error(
+            "local endpoint: '%s' is neither an absolute path "
+            "nor an abstract name ('@name')", path);
+        return NULL;
+    }
+
+    if (unlikely(len < 2)) {
+        evpl_core_error("local endpoint: '%s' is empty", path);
+        return NULL;
+    }
+
+    /* A pathname socket needs a trailing NUL inside sun_path; an abstract
+     * name spends a byte on the leading NUL instead.  Either way the budget
+     * is sizeof(sun_path).  Reject rather than truncate: a silently shortened
+     * path is a different socket. */
+    if (unlikely(len + (path[0] == '@' ? 0 : 1) > EVPL_UNIX_PATH_MAX)) {
+        evpl_core_error(
+            "local endpoint: '%s' is %zu bytes, max is %zu",
+            path, len, EVPL_UNIX_PATH_MAX - (path[0] == '@' ? 0 : 1));
+        return NULL;
+    }
+
+#ifndef __linux__
+    if (unlikely(path[0] == '@')) {
+        evpl_core_error(
+            "local endpoint: abstract sockets ('%s') are "
+            "Linux-only", path);
+        return NULL;
+    }
+#endif /* ifndef __linux__ */
+
+    ep = evpl_zalloc(sizeof(*ep));
+
+    ep->kind = EVPL_ENDPOINT_LOCAL;
+    ep->port = 0;
+    memcpy(ep->address, path, len + 1);
+
+    evpl_endpoint_register(ep);
+
+    return ep;
+} /* evpl_endpoint_alloc_local */
+
+SYMBOL_EXPORT struct evpl_endpoint *
+evpl_endpoint_create_local(const char *path)
+{
+    __evpl_init();
+
+    return evpl_endpoint_alloc_local(path);
+} /* evpl_endpoint_create_local */
 
 SYMBOL_EXPORT struct evpl_endpoint *
 evpl_endpoint_create(
@@ -26,19 +108,31 @@ evpl_endpoint_create(
 
     __evpl_init();
 
+    /* Neither a hostname nor an IP literal can begin with '/' or '@', so a
+     * leading one of those unambiguously names a local socket.  Detecting it
+     * here is what lets a caller that takes an address from configuration
+     * support unix sockets without a separate code path.  The port is not
+     * meaningful for a local endpoint and is ignored. */
+    if (unlikely(address[0] == '/' || address[0] == '@')) {
+        return evpl_endpoint_alloc_local(address);
+    }
+
     ep = evpl_zalloc(sizeof(*ep));
 
+    ep->kind = EVPL_ENDPOINT_INET;
     ep->port = port;
     strncpy(ep->address, address, sizeof(ep->address) - 1);
 
-    pthread_rwlock_init(&ep->lock, NULL);
-
-    pthread_mutex_lock(&evpl_shared->lock);
-    DL_APPEND(evpl_shared->endpoints, ep);
-    pthread_mutex_unlock(&evpl_shared->lock);
+    evpl_endpoint_register(ep);
 
     return ep;
 } /* evpl_endpoint_create */
+
+SYMBOL_EXPORT int
+evpl_endpoint_is_local(const struct evpl_endpoint *ep)
+{
+    return ep->kind == EVPL_ENDPOINT_LOCAL;
+} /* evpl_endpoint_is_local */
 
 SYMBOL_EXPORT void
 evpl_endpoint_close(struct evpl_endpoint *endpoint)
@@ -58,38 +152,66 @@ evpl_endpoint_close(struct evpl_endpoint *endpoint)
     evpl_free(endpoint);
 } /* evpl_endpoint_close */
 
-struct evpl_address *
-evpl_endpoint_resolve(struct evpl_endpoint *endpoint)
+/*
+ * Build the AF_UNIX sockaddr for a local endpoint.  Called with the endpoint
+ * write lock held.  Returns a +1 referenced address, or NULL.
+ */
+static struct evpl_address *
+evpl_endpoint_resolve_local(struct evpl_endpoint *endpoint)
+{
+    struct sockaddr_un sun;
+    socklen_t          addrlen;
+    const char        *path = endpoint->address;
+    size_t             len  = strlen(path);
+
+    memset(&sun, 0, sizeof(sun));
+
+    sun.sun_family = AF_UNIX;
+
+    if (path[0] == '@') {
+        /* Linux abstract namespace: sun_path[0] is a NUL and the name is
+         * exactly the following len-1 bytes.  There is deliberately NO
+         * trailing NUL -- the kernel takes the name to be the whole of
+         * (addrlen - offsetof), so a trailing NUL would become part of the
+         * name and yield a different, unreachable socket.  For the same
+         * reason neither SUN_LEN() (which strlen()s an empty sun_path and
+         * returns the autobind length) nor sizeof(sun) may be used here. */
+        if (unlikely(len < 2 || len > EVPL_UNIX_PATH_MAX)) {
+            evpl_core_error("abstract socket name '%s' is invalid", path);
+            return NULL;
+        }
+
+        memcpy(&sun.sun_path[1], path + 1, len - 1);
+
+        addrlen = offsetof(struct sockaddr_un, sun_path) + len;
+    } else {
+        /* Pathname socket: sun_path holds the path plus a trailing NUL, and
+         * addrlen counts that NUL. */
+        if (unlikely(len == 0 || len + 1 > EVPL_UNIX_PATH_MAX)) {
+            evpl_core_error("unix socket path '%s' is %zu bytes, max is %zu",
+                            path, len, EVPL_UNIX_PATH_MAX - 1);
+            return NULL;
+        }
+
+        memcpy(sun.sun_path, path, len); /* trailing NUL from the memset */
+
+        addrlen = offsetof(struct sockaddr_un, sun_path) + len + 1;
+    }
+
+    return evpl_address_init((struct sockaddr *) &sun, addrlen);
+} /* evpl_endpoint_resolve_local */
+
+/*
+ * Resolve a hostname/IP endpoint via getaddrinfo.  Called with the endpoint
+ * write lock held.  Returns a +1 referenced address, or NULL.
+ */
+static struct evpl_address *
+evpl_endpoint_resolve_inet(struct evpl_endpoint *endpoint)
 {
     char                 port_str[8];
     struct addrinfo      hints, *ai, *p, **pp;
     struct evpl_address *addr;
-    struct timespec      now;
-    uint64_t             age_ms;
     int                  rc, i, n;
-
-    clock_gettime(CLOCK_MONOTONIC, &now);
-
-    pthread_rwlock_rdlock(&endpoint->lock);
-
-    if (likely(endpoint->resolved_addr)) {
-        age_ms = (now.tv_sec - endpoint->last_resolved.tv_sec) * 1000 +
-            (now.tv_nsec - endpoint->last_resolved.tv_nsec) / 1000000;
-
-        if (likely(age_ms <= evpl_shared->config->resolve_timeout_ms)) {
-            addr = endpoint->resolved_addr;
-            evpl_address_incref(addr);
-            pthread_rwlock_unlock(&endpoint->lock);
-            return addr;
-        }
-    }
-
-    pthread_rwlock_unlock(&endpoint->lock);
-    pthread_rwlock_wrlock(&endpoint->lock);
-
-    if (endpoint->resolved_addr) {
-        evpl_address_release(endpoint->resolved_addr);
-    }
 
     snprintf(port_str, sizeof(port_str), "%d", endpoint->port);
 
@@ -98,10 +220,15 @@ evpl_endpoint_resolve(struct evpl_endpoint *endpoint)
     hints.ai_socktype = 0; // SOCK_DGRAM;
     hints.ai_flags    = 0;
 
+    /* getaddrinfo reports failure with a nonzero EAI_* code and leaves *res
+     * untouched, so it must be tested against 0 rather than for a negative
+     * value: the EAI_* constants are negative in glibc but positive on BSD,
+     * where a "< 0" test would walk an uninitialized addrinfo. */
     rc = getaddrinfo(endpoint->address, port_str, &hints, &ai);
 
-    if (unlikely(rc < 0)) {
-        pthread_rwlock_unlock(&endpoint->lock);
+    if (unlikely(rc != 0)) {
+        evpl_core_error("failed to resolve '%s:%d': %s",
+                        endpoint->address, endpoint->port, gai_strerror(rc));
         return NULL;
     }
 
@@ -111,40 +238,127 @@ evpl_endpoint_resolve(struct evpl_endpoint *endpoint)
         n++;
     }
 
-    if (n) {
-        pp = alloca(n * sizeof(struct addrinfo *));
-
-        for (p = ai, i = 0; p != NULL; p = p->ai_next, i++) {
-            pp[i] = p;
-        }
-
-        p = pp[rand() % n];
-
-        addr = evpl_address_init(p->ai_addr, p->ai_addrlen);
-
-        endpoint->resolved_addr = addr;
-        endpoint->last_resolved = now;
-
-        evpl_address_incref(addr);
-
-    } else {
-        addr = NULL;
+    if (unlikely(n == 0)) {
+        freeaddrinfo(ai);
+        return NULL;
     }
 
-    pthread_rwlock_unlock(&endpoint->lock);
+    pp = alloca(n * sizeof(struct addrinfo *));
+
+    for (p = ai, i = 0; p != NULL; p = p->ai_next, i++) {
+        pp[i] = p;
+    }
+
+    p = pp[rand() % n];
+
+    addr = evpl_address_init(p->ai_addr, p->ai_addrlen);
 
     freeaddrinfo(ai);
 
     return addr;
+} /* evpl_endpoint_resolve_inet */
+
+static inline uint64_t
+evpl_endpoint_age_ms(
+    const struct evpl_endpoint *endpoint,
+    const struct timespec      *now)
+{
+    return (now->tv_sec - endpoint->last_resolved.tv_sec) * 1000 +
+           (now->tv_nsec - endpoint->last_resolved.tv_nsec) / 1000000;
+} /* evpl_endpoint_age_ms */
+
+/*
+ * A local endpoint's sockaddr is a pure function of its immutable path, so it
+ * is resolved once and never expires; resolve_timeout_ms exists to pick up DNS
+ * changes and has no analogue for a path.
+ */
+static inline int
+evpl_endpoint_cache_valid(
+    const struct evpl_endpoint *endpoint,
+    const struct timespec      *now)
+{
+    if (!endpoint->resolved_addr) {
+        return 0;
+    }
+
+    if (endpoint->kind == EVPL_ENDPOINT_LOCAL) {
+        return 1;
+    }
+
+    return evpl_endpoint_age_ms(endpoint, now) <=
+           evpl_shared->config->resolve_timeout_ms;
+} /* evpl_endpoint_cache_valid */
+
+struct evpl_address *
+evpl_endpoint_resolve(struct evpl_endpoint *endpoint)
+{
+    struct evpl_address *addr, *old;
+    struct timespec      now;
+
+    clock_gettime(CLOCK_MONOTONIC, &now);
+
+    pthread_rwlock_rdlock(&endpoint->lock);
+
+    if (likely(evpl_endpoint_cache_valid(endpoint, &now))) {
+        addr = endpoint->resolved_addr;
+        evpl_address_incref(addr);
+        pthread_rwlock_unlock(&endpoint->lock);
+        return addr;
+    }
+
+    pthread_rwlock_unlock(&endpoint->lock);
+    pthread_rwlock_wrlock(&endpoint->lock);
+
+    /* Recheck under the write lock: another thread may have resolved while
+     * the lock was dropped, and getaddrinfo is expensive enough to be worth
+     * not doing n times over. */
+    if (evpl_endpoint_cache_valid(endpoint, &now)) {
+        addr = endpoint->resolved_addr;
+        evpl_address_incref(addr);
+        pthread_rwlock_unlock(&endpoint->lock);
+        return addr;
+    }
+
+    if (endpoint->kind == EVPL_ENDPOINT_LOCAL) {
+        addr = evpl_endpoint_resolve_local(endpoint);
+    } else {
+        addr = evpl_endpoint_resolve_inet(endpoint);
+    }
+
+    if (unlikely(!addr)) {
+        /* Leave any previously cached address in place.  Releasing it up
+         * front (as this function used to) both destroyed a working address
+         * on a transient DNS failure and left endpoint->resolved_addr
+         * dangling, which the next call would release a second time. */
+        pthread_rwlock_unlock(&endpoint->lock);
+        return NULL;
+    }
+
+    old = endpoint->resolved_addr;
+
+    endpoint->resolved_addr = addr;
+    endpoint->last_resolved = now;
+
+    evpl_address_incref(addr); /* one ref for the cache, one for the caller */
+
+    pthread_rwlock_unlock(&endpoint->lock);
+
+    /* Released outside the lock: framework release_address callbacks run
+     * here and should not be serialized behind the endpoint rwlock. */
+    if (old) {
+        evpl_address_release(old);
+    }
+
+    return addr;
 } /* evpl_endpoint_resolve */
 
-const char *
+SYMBOL_EXPORT const char *
 evpl_endpoint_address(const struct evpl_endpoint *ep)
 {
     return ep->address;
 }    /* evpl_endpoint_address */
 
-int
+SYMBOL_EXPORT int
 evpl_endpoint_port(const struct evpl_endpoint *ep)
 {
     return ep->port;

--- a/src/core/endpoint.h
+++ b/src/core/endpoint.h
@@ -10,9 +10,27 @@
 #include "core/address.h"
 
 
+enum evpl_endpoint_kind {
+    /* Hostname or IP literal plus port, resolved via getaddrinfo.  Zero so
+     * that a zalloc'd endpoint is an inet endpoint by default. */
+    EVPL_ENDPOINT_INET  = 0,
+    /* AF_UNIX socket, named by a filesystem path, or by an abstract name if
+     * the stored address begins with '@'. */
+    EVPL_ENDPOINT_LOCAL = 1
+};
+
+/*
+ * address holds the hostname or IP literal for an inet endpoint, and the path
+ * or "@name" exactly as supplied for a local one; the sockaddr_un is derived
+ * from it at resolve time.  256 bytes is larger than sun_path (108), so a
+ * valid local address can never be truncated here -- an over-long path is
+ * rejected at create time rather than silently shortened.  port is zero for a
+ * local endpoint.
+ */
 struct evpl_endpoint {
     char                  address[256];
     int                   port;
+    enum evpl_endpoint_kind kind;
     struct timespec       last_resolved;
     struct evpl_address  *resolved_addr;
     pthread_rwlock_t      lock;
@@ -23,3 +41,14 @@ struct evpl_endpoint {
 struct evpl_address *
 evpl_endpoint_resolve(
     struct evpl_endpoint *endpoint);
+
+/* 0 if endpoint may be used with protocol, -1 otherwise.  A local endpoint
+ * requires a local protocol and vice versa. */
+static inline int
+evpl_endpoint_check_protocol(
+    const struct evpl_endpoint *endpoint,
+    const struct evpl_protocol *protocol)
+{
+    return ((endpoint->kind == EVPL_ENDPOINT_LOCAL) == (protocol->local != 0))
+           ? 0 : -1;
+} /* evpl_endpoint_check_protocol */

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -62,6 +62,7 @@
 #include "socket/udp.h"
 #include "socket/tcp.h"
 #include "socket/tcp_rdma.h"
+#include "socket/unix_stream.h"
 
 #ifdef HAVE_TLS
 #include "tls/tls.h"
@@ -182,6 +183,9 @@ evpl_shared_init(struct evpl_global_config *config)
 
     evpl_protocol_init(evpl_shared, EVPL_STREAM_SOCKET_TCP,
                        &evpl_socket_tcp);
+
+    evpl_protocol_init(evpl_shared, EVPL_STREAM_SOCKET_UNIX,
+                       &evpl_socket_unix_stream);
 
 #ifdef HAVE_TLS
     evpl_framework_init(evpl_shared, EVPL_FRAMEWORK_TLS,

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -159,6 +159,10 @@ struct evpl_listen_request {
     pthread_mutex_t             lock;
     pthread_cond_t              cond;
     int                         complete;
+    /* Result of the protocol's listen callback, carried back to the thread
+     * blocked in evpl_listen().  The bind happens on the listener thread, so
+     * this is the only channel a backend failure has. */
+    int                         status;
     struct evpl_address        *address;
     struct evpl_listen_request *prev;
     struct evpl_listen_request *next;

--- a/src/core/io_uring/io_uring_tcp.c
+++ b/src/core/io_uring/io_uring_tcp.c
@@ -505,7 +505,7 @@ evpl_io_uring_tcp_accept_callback(
 
 } /* evpl_accept_tcp */
 
-static void
+static int
 evpl_io_uring_tcp_listen(
     struct evpl      *evpl,
     struct evpl_bind *listen_bind)
@@ -514,29 +514,47 @@ evpl_io_uring_tcp_listen(
     struct evpl_io_uring_context *ctx = evpl_framework_private(evpl, EVPL_FRAMEWORK_IO_URING);
     struct evpl_io_uring_request *req;
     struct io_uring_sqe          *sqe;
+    char                          addr_str[80];
     int                           rc;
     const int                     yes = 1;
 
     s->fd = socket(listen_bind->local->addr->sa_family, SOCK_STREAM, 0);
 
-    evpl_io_uring_abort_if(s->fd < 0, "Failed to create tcp listen socket: %s",
-                           strerror(errno));
+    if (s->fd < 0) {
+        evpl_io_uring_error("Failed to create tcp listen socket: %s",
+                            strerror(errno));
+        return -1;
+    }
 
     rc = setsockopt(s->fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
 
-    evpl_io_uring_abort_if(rc < 0, "Failed to set socket options: %s", strerror(
-                               errno));
+    if (rc < 0) {
+        evpl_io_uring_error("Failed to set socket options: %s",
+                            strerror(errno));
+        goto fail;
+    }
 
     rc = bind(s->fd, listen_bind->local->addr, listen_bind->local->addrlen);
 
-    evpl_io_uring_abort_if(rc < 0, "Failed to bind listen socket: %s", strerror(
-                               errno));
+    if (rc < 0) {
+        evpl_address_get_address(listen_bind->local, addr_str, sizeof(addr_str));
+        evpl_io_uring_error("Failed to bind listen socket to %s: %s",
+                            addr_str, strerror(errno));
+        goto fail;
+    }
 
-    evpl_io_uring_setup_socket(evpl, ctx, s, 1);
-
+    /* Ordered ahead of setup_socket so that every failure above is a plain
+     * close of our own fd.  setup_socket consumes a send group id and tops up
+     * the shared recv ring, which is not worth unwinding. */
     rc = listen(s->fd, evpl_shared->config->max_pending);
 
-    evpl_io_uring_fatal_if(rc, "Failed to listen on listener fd");
+    if (rc < 0) {
+        evpl_io_uring_error("Failed to listen on listener fd: %s",
+                            strerror(errno));
+        goto fail;
+    }
+
+    evpl_io_uring_setup_socket(evpl, ctx, s, 1);
 
     req = evpl_io_uring_request_alloc(ctx, EVPL_IO_URING_REQ_TCP);
 
@@ -552,6 +570,15 @@ evpl_io_uring_tcp_listen(
 
     evpl_defer(evpl, &ctx->flush);
 
+    return 0;
+
+ fail:
+
+    close(s->fd);
+
+    s->fd = -1;
+
+    return -1;
 } /* evpl_io_uring_tcp_listen */
 
 static void

--- a/src/core/listen.c
+++ b/src/core/listen.c
@@ -10,6 +10,8 @@
 
 #include "core/bind.h"
 #include "core/macros.h"
+#include "core/logging.h"
+#include "core/endpoint.h"
 #include "core/evpl_shared.h"
 #include "core/evpl.h"
 
@@ -273,8 +275,27 @@ evpl_listen(
     struct evpl_endpoint *endpoint)
 {
     struct evpl_listen_request *request;
+    struct evpl_protocol       *protocol = evpl_shared->protocol[protocol_id];
+    struct evpl_address        *address;
 
-    if (!evpl_shared->protocol[protocol_id]) {
+    if (!protocol) {
+        return -1;
+    }
+
+    if (unlikely(evpl_endpoint_check_protocol(endpoint, protocol) < 0)) {
+        evpl_core_error(
+            "evpl_listen: protocol %s cannot be used with %s endpoint '%s'",
+            protocol->name,
+            endpoint->kind == EVPL_ENDPOINT_LOCAL ? "local-path" : "network",
+            endpoint->address);
+        return -1;
+    }
+
+    address = evpl_endpoint_resolve(endpoint);
+
+    if (unlikely(!address)) {
+        evpl_core_error("evpl_listen: failed to resolve '%s'",
+                        endpoint->address);
         return -1;
     }
 
@@ -284,7 +305,7 @@ evpl_listen(
     pthread_cond_init(&request->cond, NULL);
 
     request->protocol_id = protocol_id;
-    request->address     = evpl_endpoint_resolve(endpoint);
+    request->address     = address;
 
     pthread_mutex_lock(&EvplListenerLock);
     DL_APPEND(listener->requests, request);

--- a/src/core/listen.c
+++ b/src/core/listen.c
@@ -93,13 +93,26 @@ evpl_listener_callback(
                                  request->address,
                                  NULL);
 
-        evpl_core_abort_if(!bind->protocol->listen,
-                           "evpl_listen called with non-connection oriented protocol");
-
         bind->accept_callback = evpl_listener_accept;
         bind->private_data    = listener;
 
-        bind->protocol->listen(evpl, bind);
+        request->status = bind->protocol->listen(evpl, bind);
+
+        if (unlikely(request->status)) {
+            /* The backend has already released whatever it managed to
+             * acquire, so the bind is inert and never became visible to the
+             * caller; hand it straight back rather than routing it through
+             * the close path, which would report a disconnect for a
+             * connection that never existed. */
+            evpl_bind_abort(evpl, bind);
+
+            pthread_mutex_lock(&request->lock);
+            request->complete = 1;
+            pthread_cond_signal(&request->cond);
+            pthread_mutex_unlock(&request->lock);
+
+            continue;
+        }
 
         if (listener->num_binds >= listener->max_binds) {
             listener->max_binds *= 2;
@@ -277,8 +290,15 @@ evpl_listen(
     struct evpl_listen_request *request;
     struct evpl_protocol       *protocol = evpl_shared->protocol[protocol_id];
     struct evpl_address        *address;
+    int                         status;
 
     if (!protocol) {
+        return -1;
+    }
+
+    if (unlikely(!protocol->listen)) {
+        evpl_core_error("evpl_listen: protocol %s is not connection oriented",
+                        protocol->name);
         return -1;
     }
 
@@ -321,8 +341,10 @@ evpl_listen(
 
     pthread_mutex_unlock(&request->lock);
 
+    status = request->status;
+
     evpl_free(request);
 
-    return 0;
+    return status;
 
 } /* evpl_listen */

--- a/src/core/protocol.c
+++ b/src/core/protocol.c
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include "core/macros.h"
 #include "core/evpl_shared.h"
+#include "core/evpl.h"
 
 void
 evpl_framework_init(
@@ -32,8 +34,40 @@ evpl_block_protocol_init(
     evpl_shared->block_protocol[id] = protocol;
 } /* evpl_block_protocol_init */
 
-int
+/* Protocols may be absent because their backend was compiled out or disabled
+ * by config, so the table slot can legitimately be NULL.  Callers reach these
+ * predicates with ids that came from config strings, so validate rather than
+ * dereference blindly. */
+static inline struct evpl_protocol *
+evpl_protocol_get(enum evpl_protocol_id id)
+{
+    __evpl_init();
+
+    if (unlikely(id >= EVPL_NUM_PROTO)) {
+        return NULL;
+    }
+
+    return evpl_shared->protocol[id];
+} /* evpl_protocol_get */
+
+SYMBOL_EXPORT int
+evpl_protocol_available(enum evpl_protocol_id id)
+{
+    return evpl_protocol_get(id) != NULL;
+} /* evpl_protocol_available */
+
+SYMBOL_EXPORT int
 evpl_protocol_is_stream(enum evpl_protocol_id id)
 {
-    return evpl_shared->protocol[id]->stream;
+    struct evpl_protocol *protocol = evpl_protocol_get(id);
+
+    return protocol ? (int) protocol->stream : 0;
 } /* evpl_protocol_is_stream */
+
+SYMBOL_EXPORT int
+evpl_protocol_is_local(enum evpl_protocol_id id)
+{
+    struct evpl_protocol *protocol = evpl_protocol_get(id);
+
+    return protocol ? (int) protocol->local : 0;
+} /* evpl_protocol_is_local */

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -144,7 +144,15 @@ struct evpl_protocol {
         struct evpl      *evpl,
         struct evpl_bind *bind);
 
-    void                   (*listen)(
+    /* Begin listening for connections.  Returns 0 on success, or -1 if the
+     * listen could not be established -- an address already in use, a
+     * permission problem, a resource limit.  Those are operating conditions
+     * rather than programming errors, so they are reported back through
+     * evpl_listen() rather than being fatal.
+     *
+     * On failure the backend must leave nothing behind: no open descriptor,
+     * no registered event, and no filesystem object it created. */
+    int                    (*listen)(
         struct evpl      *evpl,
         struct evpl_bind *bind);
 

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -97,6 +97,11 @@ struct evpl_protocol {
     /* 1 iff supports RDMA read/write */
     unsigned int           rdma;
 
+    /* 1 iff peers are named by a local socket path or abstract name (AF_UNIX)
+     * rather than by network address and port.  Endpoints and protocols must
+     * agree on this: see evpl_endpoint_check_protocol(). */
+    unsigned int           local;
+
     /* human readable name for protocol, no spaces */
     const char            *name;
 

--- a/src/core/rdmacm/rdmacm.c
+++ b/src/core/rdmacm/rdmacm.c
@@ -1282,13 +1282,14 @@ evpl_rdmacm_attach(
     evpl_free(accepted_id);
 } /* evpl_rdmacm_attach */
 
-void
+int
 evpl_rdmacm_listen(
     struct evpl      *evpl,
     struct evpl_bind *bind)
 {
     struct evpl_rdmacm    *rdmacm;
     struct evpl_rdmacm_id *rdmacm_id = evpl_bind_private(bind);
+    char                   addr_str[80];
     int                    rc;
 
     rdmacm_id->stream         = bind->protocol->stream;
@@ -1303,14 +1304,36 @@ evpl_rdmacm_listen(
 
     rc = rdma_create_id(rdmacm->event_channel, &rdmacm_id->id, rdmacm_id, RDMA_PS_TCP);
 
-    evpl_rdmacm_abort_if(rc, "rdma_create_id listen error %s", strerror(rc));
+    if (rc) {
+        evpl_rdmacm_error("rdma_create_id listen error %s", strerror(rc));
+        return -1;
+    }
 
     rc = rdma_bind_addr(rdmacm_id->id, bind->local->addr);
 
-    evpl_rdmacm_abort_if(rc, "Failed to bind to address: %s", strerror(errno));
+    if (rc) {
+        evpl_address_get_address(bind->local, addr_str, sizeof(addr_str));
+        evpl_rdmacm_error("Failed to bind to address %s: %s",
+                          addr_str, strerror(errno));
+        goto fail;
+    }
 
-    rdma_listen(rdmacm_id->id, 1024);
+    rc = rdma_listen(rdmacm_id->id, 1024);
 
+    if (rc) {
+        evpl_rdmacm_error("Failed to listen on cm id: %s", strerror(errno));
+        goto fail;
+    }
+
+    return 0;
+
+ fail:
+
+    rdma_destroy_id(rdmacm_id->id);
+
+    rdmacm_id->id = NULL;
+
+    return -1;
 } /* evpl_rdmacm_listen */
 
 void

--- a/src/core/socket/tcp.c
+++ b/src/core/socket/tcp.c
@@ -386,44 +386,69 @@ evpl_accept_tcp(
 
 } /* evpl_accept_tcp */
 
-void
+int
 evpl_socket_tcp_listen(
     struct evpl      *evpl,
     struct evpl_bind *listen_bind)
 {
     struct evpl_socket *s = evpl_bind_private(listen_bind);
+    char                addr_str[80];
     int                 rc;
     const int           yes = 1;
 
     s->fd = socket(listen_bind->local->addr->sa_family, SOCK_STREAM, 0);
 
-    evpl_socket_abort_if(s->fd < 0, "Failed to create tcp listen socket: %s",
-                         strerror(errno));
+    if (s->fd < 0) {
+        evpl_socket_error("Failed to create tcp listen socket: %s",
+                          strerror(errno));
+        return -1;
+    }
 
     rc = setsockopt(s->fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
 
-    evpl_socket_abort_if(rc < 0, "Failed to set socket options: %s", strerror(
-                             errno));
+    if (rc < 0) {
+        evpl_socket_error("Failed to set socket options: %s", strerror(errno));
+        goto fail;
+    }
 
     rc = bind(s->fd, listen_bind->local->addr, listen_bind->local->addrlen);
 
-    evpl_socket_abort_if(rc < 0, "Failed to bind listen socket: %s", strerror(
-                             errno));
+    if (rc < 0) {
+        evpl_address_get_address(listen_bind->local, addr_str, sizeof(addr_str));
+        evpl_socket_error("Failed to bind listen socket to %s: %s",
+                          addr_str, strerror(errno));
+        goto fail;
+    }
 
     rc = fcntl(s->fd, F_SETFL, fcntl(s->fd, F_GETFL, 0) | O_NONBLOCK);
 
-    evpl_socket_abort_if(rc < 0, "Failed to set socket flags: %s", strerror(
-                             errno));
+    if (rc < 0) {
+        evpl_socket_error("Failed to set socket flags: %s", strerror(errno));
+        goto fail;
+    }
 
     rc = listen(s->fd, evpl_shared->config->max_pending);
 
-    evpl_socket_fatal_if(rc, "Failed to listen on listener fd");
+    if (rc < 0) {
+        evpl_socket_error("Failed to listen on listener fd: %s",
+                          strerror(errno));
+        goto fail;
+    }
 
     evpl_add_event(evpl, &s->event, s->fd,
                    evpl_accept_tcp, NULL, NULL);
 
     evpl_event_read_interest(evpl, &s->event);
 
+    return 0;
+
+ fail:
+
+    close(s->fd);
+
+    s->fd = -1;
+
+    return -1;
 } /* evpl_socket_tcp_listen */
 
 struct evpl_protocol evpl_socket_tcp = {

--- a/src/core/socket/tcp.h
+++ b/src/core/socket/tcp.h
@@ -11,7 +11,7 @@ struct evpl_protocol;
 
 extern struct evpl_protocol evpl_socket_tcp;
 
-void evpl_socket_tcp_listen(
+int evpl_socket_tcp_listen(
     struct evpl      *evpl,
     struct evpl_bind *listen_bind);
 

--- a/src/core/socket/tcp.h
+++ b/src/core/socket/tcp.h
@@ -6,6 +6,7 @@
 
 struct evpl;
 struct evpl_bind;
+struct evpl_event;
 struct evpl_protocol;
 
 extern struct evpl_protocol evpl_socket_tcp;
@@ -13,3 +14,22 @@ extern struct evpl_protocol evpl_socket_tcp;
 void evpl_socket_tcp_listen(
     struct evpl      *evpl,
     struct evpl_bind *listen_bind);
+
+/* Family-agnostic once a connected fd exists: these operate purely on
+ * evpl_socket::fd and the bind's iovec rings, so AF_UNIX reuses them as-is. */
+
+void evpl_socket_tcp_read(
+    struct evpl       *evpl,
+    struct evpl_event *event);
+
+void evpl_socket_tcp_write(
+    struct evpl       *evpl,
+    struct evpl_event *event);
+
+void evpl_socket_tcp_error(
+    struct evpl       *evpl,
+    struct evpl_event *event);
+
+void evpl_accept_tcp(
+    struct evpl       *evpl,
+    struct evpl_event *event);

--- a/src/core/socket/tests/CMakeLists.txt
+++ b/src/core/socket/tests/CMakeLists.txt
@@ -27,21 +27,24 @@ unit_test_bin_all_mechs(socket rdma_ops_tcp_rdma rdma_ops -r DATAGRAM_TCP_RDMA)
 # datagram tests are omitted because STREAM_SOCKET_UNIX has no .bind op, and
 # rdma_ops needs one-sided RDMA.
 #
-# Each test derives its own socket path from its binary name and pid (see
-# test_address() in src/tests/test_common.h), so they stay collision-free
-# under `ctest -j` without a per-test -a argument.
-unit_test_bin_all_mechs(unix hello_world_stream_unix hello_world_stream -r STREAM_SOCKET_UNIX)
-unit_test_bin_all_mechs(unix hello_world_connected_msg_unix hello_world_connected_msg -r STREAM_SOCKET_UNIX)
+# Registered with unit_test_bin_local: these are addressed by socket name
+# rather than by port, so they need no network namespace and contend with
+# nothing.  Each derives its own name from EVPL_TEST_SOCKET_DIR and its pid
+# (see test_address() in src/tests/test_common.h), so they run fully in
+# parallel and also run where CAP_NET_ADMIN is unavailable.
+unit_test_bin_local(unix hello_world_stream_unix hello_world_stream -r STREAM_SOCKET_UNIX)
+unit_test_bin_local(unix hello_world_connected_msg_unix hello_world_connected_msg -r STREAM_SOCKET_UNIX)
 
-unit_test_bin_all_mechs(unix ping_pong_stream_unix ping_pong_stream -r STREAM_SOCKET_UNIX)
-unit_test_bin_all_mechs(unix ping_pong_msg_unix ping_pong_connected_msg -r STREAM_SOCKET_UNIX)
+unit_test_bin_local(unix ping_pong_stream_unix ping_pong_stream -r STREAM_SOCKET_UNIX)
+unit_test_bin_local(unix ping_pong_msg_unix ping_pong_connected_msg -r STREAM_SOCKET_UNIX)
 
-unit_test_bin_all_mechs(unix bulk_msg_unix bulk_connected_msg -r STREAM_SOCKET_UNIX)
-unit_test_bin_all_mechs(unix bulk_stream_unix bulk_stream -r STREAM_SOCKET_UNIX)
+unit_test_bin_local(unix bulk_msg_unix bulk_connected_msg -r STREAM_SOCKET_UNIX)
+unit_test_bin_local(unix bulk_stream_unix bulk_stream -r STREAM_SOCKET_UNIX)
 
-unit_test_bin_all_mechs(unix rand_full_duplex_stream_unix rand_full_duplex_stream -r STREAM_SOCKET_UNIX)
+unit_test_bin_local(unix rand_full_duplex_stream_unix rand_full_duplex_stream -r STREAM_SOCKET_UNIX)
 
 # Abstract namespace: no filesystem object, so nothing to unlink and nothing a
-# crash can leave stale.
-unit_test_bin_all_mechs(unix hello_world_stream_unix_abstract hello_world_stream -r STREAM_SOCKET_UNIX -a @evpl-test-hws)
-unit_test_bin_all_mechs(unix ping_pong_stream_unix_abstract ping_pong_stream -r STREAM_SOCKET_UNIX -a @evpl-test-pps)
+# crash can leave stale.  "-a @" asks the harness to generate a unique
+# abstract name, which is what keeps these parallel-safe without a namespace.
+unit_test_bin_local(unix hello_world_stream_unix_abstract hello_world_stream -r STREAM_SOCKET_UNIX -a @)
+unit_test_bin_local(unix ping_pong_stream_unix_abstract ping_pong_stream -r STREAM_SOCKET_UNIX -a @)

--- a/src/core/socket/tests/CMakeLists.txt
+++ b/src/core/socket/tests/CMakeLists.txt
@@ -22,3 +22,26 @@ unit_test_bin_all_mechs(socket rand_full_duplex_stream_tcp rand_full_duplex_stre
 
 # TCP_RDMA tests
 unit_test_bin_all_mechs(socket rdma_ops_tcp_rdma rdma_ops -r DATAGRAM_TCP_RDMA)
+
+# AF_UNIX stream tests.  The same stream bodies the TCP battery runs; the
+# datagram tests are omitted because STREAM_SOCKET_UNIX has no .bind op, and
+# rdma_ops needs one-sided RDMA.
+#
+# Each test derives its own socket path from its binary name and pid (see
+# test_address() in src/tests/test_common.h), so they stay collision-free
+# under `ctest -j` without a per-test -a argument.
+unit_test_bin_all_mechs(unix hello_world_stream_unix hello_world_stream -r STREAM_SOCKET_UNIX)
+unit_test_bin_all_mechs(unix hello_world_connected_msg_unix hello_world_connected_msg -r STREAM_SOCKET_UNIX)
+
+unit_test_bin_all_mechs(unix ping_pong_stream_unix ping_pong_stream -r STREAM_SOCKET_UNIX)
+unit_test_bin_all_mechs(unix ping_pong_msg_unix ping_pong_connected_msg -r STREAM_SOCKET_UNIX)
+
+unit_test_bin_all_mechs(unix bulk_msg_unix bulk_connected_msg -r STREAM_SOCKET_UNIX)
+unit_test_bin_all_mechs(unix bulk_stream_unix bulk_stream -r STREAM_SOCKET_UNIX)
+
+unit_test_bin_all_mechs(unix rand_full_duplex_stream_unix rand_full_duplex_stream -r STREAM_SOCKET_UNIX)
+
+# Abstract namespace: no filesystem object, so nothing to unlink and nothing a
+# crash can leave stale.
+unit_test_bin_all_mechs(unix hello_world_stream_unix_abstract hello_world_stream -r STREAM_SOCKET_UNIX -a @evpl-test-hws)
+unit_test_bin_all_mechs(unix ping_pong_stream_unix_abstract ping_pong_stream -r STREAM_SOCKET_UNIX -a @evpl-test-pps)

--- a/src/core/socket/unix_stream.c
+++ b/src/core/socket/unix_stream.c
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "core/allocator.h"
+#include "core/endpoint.h"
+#include "core/address.h"
+#include "core/bind.h"
+#include "core/protocol.h"
+#include "core/event_fn.h"
+#include "core/evpl.h"
+#include "core/socket/common.h"
+#include "core/socket/tcp.h"
+#include "core/socket/unix_stream.h"
+
+/*
+ * AF_UNIX stream sockets.
+ *
+ * Once a connected fd exists the data path is byte for byte the TCP one, so
+ * evpl_socket_tcp_read/write/error and evpl_accept_tcp are reused verbatim and
+ * only connect/listen/attach/pending_close are specialized:
+ *
+ *   - no TCP_NODELAY: IPPROTO_TCP options return ENOPROTOOPT on AF_UNIX, and
+ *     the TCP versions wrap that setsockopt in an abort
+ *   - no SO_REUSEADDR: accepted but meaningless.  An AF_UNIX name is a
+ *     filesystem entry rather than a port, so it does nothing about EADDRINUSE
+ *   - a pathname listener owns a filesystem object, which has to be created
+ *     around a possible stale predecessor and removed at teardown
+ */
+
+#define EVPL_UNIX_PATH_MAX sizeof(((struct sockaddr_un *) 0)->sun_path)
+
+struct evpl_socket_unix {
+    /* Must be first.  evpl_bind_private(), evpl_event_socket() and every
+     * helper in socket/common.h assume the bind's private area begins with a
+     * struct evpl_socket. */
+    struct evpl_socket socket;
+
+    /* Path this bind created and is therefore responsible for removing at
+     * teardown.  Empty for clients, for accepted connections, and for
+     * abstract-namespace listeners, which have no filesystem object.
+     *
+     * Deliberately kept here rather than inferred from bind->accept_callback:
+     * evpl_bind_prepare() recycles binds from a freelist and does not reset
+     * accept_callback, but it does memset the whole private area, so this is
+     * guaranteed clean for every new bind. */
+    char               unlink_path[EVPL_UNIX_PATH_MAX];
+};
+
+/*
+ * Decide what to do about an existing entry at path, called only after bind()
+ * has already failed with EADDRINUSE.
+ *
+ * SO_REUSEADDR does nothing here: bind() fails as long as the name exists,
+ * whether or not anyone is listening behind it.  The only way to tell a live
+ * server from the corpse of a crashed one is to try to connect -- a live
+ * listener accepts immediately, or returns EAGAIN with a full backlog, while a
+ * stale file returns ECONNREFUSED.
+ *
+ * Returns 1 if the entry proved stale and was unlinked, so bind may be
+ * retried; 0 if a live server owns it or it is not ours to remove.
+ */
+static int
+evpl_socket_unix_clear_stale(
+    const struct sockaddr *addr,
+    socklen_t              addrlen,
+    const char            *path)
+{
+    struct stat st;
+    int         fd, rc;
+
+    /* Never unlink something that is not a socket: a typo in an endpoint path
+     * must not delete a user's file. */
+    if (lstat(path, &st) < 0 || !S_ISSOCK(st.st_mode)) {
+        return 0;
+    }
+
+    fd = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
+
+    if (fd < 0) {
+        return 0;
+    }
+
+    /* Probe with the address the resolver already built, rather than
+     * rebuilding one from the path: it carries the exact addrlen, so the
+     * probe is guaranteed to name the same socket bind() just tried. */
+    rc = connect(fd, addr, addrlen);
+
+    /* The probe socket is non-blocking, so a live listener yields 0 -- AF_UNIX
+     * completes connect synchronously -- or EAGAIN when the backlog is full.
+     * Only ECONNREFUSED proves there is no listener behind the file. */
+    if (rc == 0 || errno != ECONNREFUSED) {
+        close(fd);
+        return 0;
+    }
+
+    close(fd);
+
+    return unlink(path) == 0;
+} /* evpl_socket_unix_clear_stale */
+
+static void
+evpl_socket_unix_listen(
+    struct evpl      *evpl,
+    struct evpl_bind *listen_bind)
+{
+    struct evpl_socket_unix *su = evpl_bind_private(listen_bind);
+    struct evpl_socket      *s  = &su->socket;
+    struct sockaddr_un      *sun;
+    size_t                   pathlen;
+    int                      rc;
+
+    sun = (struct sockaddr_un *) listen_bind->local->addr;
+
+    evpl_socket_abort_if(sun->sun_family != AF_UNIX,
+                         "STREAM_SOCKET_UNIX requires a local endpoint, see "
+                         "evpl_endpoint_create_local()");
+
+    s->fd = socket(AF_UNIX, SOCK_STREAM, 0);
+
+    evpl_socket_abort_if(s->fd < 0, "Failed to create unix listen socket: %s",
+                         strerror(errno));
+
+    rc = bind(s->fd, listen_bind->local->addr, listen_bind->local->addrlen);
+
+    /* A crashed predecessor leaves its name in the filesystem and bind() then
+     * fails with EADDRINUSE forever.  Probe lazily and retry only once the
+     * entry has proved stale: the clean case touches nothing, and a running
+     * server can never be silently displaced. */
+    if (rc < 0 && errno == EADDRINUSE && sun->sun_path[0] != '\0' &&
+        evpl_socket_unix_clear_stale(listen_bind->local->addr,
+                                     listen_bind->local->addrlen,
+                                     sun->sun_path)) {
+        rc = bind(s->fd, listen_bind->local->addr, listen_bind->local->addrlen);
+    }
+
+    evpl_socket_abort_if(rc < 0, "Failed to bind unix listen socket '%s': %s",
+                         sun->sun_path, strerror(errno));
+
+    /* Remember the name so pending_close can remove it.  Only a pathname
+     * socket has anything to remove; an abstract name vanishes with the last
+     * reference to the socket. */
+    if (sun->sun_path[0] != '\0') {
+        pathlen = strnlen(sun->sun_path, sizeof(su->unlink_path) - 1);
+
+        memcpy(su->unlink_path, sun->sun_path, pathlen);
+
+        su->unlink_path[pathlen] = '\0';
+    }
+
+    rc = fcntl(s->fd, F_SETFL, fcntl(s->fd, F_GETFL, 0) | O_NONBLOCK);
+
+    evpl_socket_abort_if(rc < 0, "Failed to set socket flags: %s",
+                         strerror(errno));
+
+    rc = listen(s->fd, evpl_shared->config->max_pending);
+
+    evpl_socket_fatal_if(rc, "Failed to listen on listener fd");
+
+    evpl_add_event(evpl, &s->event, s->fd,
+                   evpl_accept_tcp, NULL, NULL);
+
+    evpl_event_read_interest(evpl, &s->event);
+
+} /* evpl_socket_unix_listen */
+
+static void
+evpl_socket_unix_connect(
+    struct evpl      *evpl,
+    struct evpl_bind *bind)
+{
+    struct evpl_socket_unix *su = evpl_bind_private(bind);
+    struct evpl_socket      *s  = &su->socket;
+    struct sockaddr_un      *sun;
+    struct sockaddr_storage  ss;
+    socklen_t                sslen = sizeof(ss);
+    int                      rc;
+
+    sun = (struct sockaddr_un *) bind->remote->addr;
+
+    evpl_socket_abort_if(sun->sun_family != AF_UNIX,
+                         "STREAM_SOCKET_UNIX requires a local endpoint, see "
+                         "evpl_endpoint_create_local()");
+
+    s->fd = socket(AF_UNIX, SOCK_STREAM, 0);
+
+    evpl_socket_abort_if(s->fd < 0, "Failed to create unix socket: %s",
+                         strerror(errno));
+
+    /* Deliberately connects while the fd is still blocking, matching the TCP
+     * backend, which also calls evpl_socket_init() only afterwards.  AF_UNIX
+     * has no EINPROGRESS handshake to wait on, so a non-blocking connect
+     * against a full backlog would return EAGAIN with nothing for epoll to
+     * report -- blocking here is strictly better. */
+    rc = connect(s->fd, bind->remote->addr, bind->remote->addrlen);
+
+    evpl_socket_abort_if(rc < 0 && errno != EINPROGRESS && errno != EAGAIN,
+                         "Failed to connect unix socket '%s': %s",
+                         sun->sun_path, strerror(errno));
+
+    /* The client is unbound, so getsockname reports the unnamed form: an
+     * addrlen of offsetof(struct sockaddr_un, sun_path) and no path.  Recorded
+     * anyway so bind->local is non-NULL and consistent with every other
+     * protocol; evpl_address_alloc zeroes sa, so the short copy is safe. */
+    rc = getsockname(s->fd, (struct sockaddr *) &ss, &sslen);
+
+    evpl_socket_abort_if(rc < 0, "Failed to getsockname on socket: %s",
+                         strerror(errno));
+
+    bind->local          = evpl_address_alloc();
+    bind->local->addrlen = sslen;
+    memcpy(bind->local->addr, &ss, sslen);
+
+    evpl_socket_init(evpl, s, s->fd, 0);
+
+    evpl_add_event(evpl, &s->event, s->fd,
+                   evpl_socket_tcp_read,
+                   evpl_socket_tcp_write,
+                   evpl_socket_tcp_error);
+
+    evpl_event_read_interest(evpl, &s->event);
+    evpl_event_write_interest(evpl, &s->event);
+
+} /* evpl_socket_unix_connect */
+
+static void
+evpl_socket_unix_attach(
+    struct evpl      *evpl,
+    struct evpl_bind *bind,
+    void             *accepted)
+{
+    struct evpl_socket_unix     *su              = evpl_bind_private(bind);
+    struct evpl_socket          *s               = &su->socket;
+    struct evpl_accepted_socket *accepted_socket = accepted;
+    struct evpl_notify           notify;
+    struct sockaddr_storage      ss;
+    socklen_t                    sslen = sizeof(ss);
+    int                          fd    = accepted_socket->fd;
+    int                          rc;
+
+    evpl_free(accepted_socket);
+
+    evpl_socket_init(evpl, s, fd, 1);
+
+    /* An accepted AF_UNIX socket inherits the listener's name, so this yields
+     * the listening path.  su->unlink_path is deliberately left empty: the
+     * listen bind owns the filesystem entry, not this connection. */
+    rc = getsockname(fd, (struct sockaddr *) &ss, &sslen);
+
+    evpl_socket_abort_if(rc < 0, "getsockname failed: %s", strerror(errno));
+
+    bind->local          = evpl_address_alloc();
+    bind->local->addrlen = sslen;
+    memcpy(bind->local->addr, &ss, sslen);
+
+    evpl_add_event(evpl, &s->event, fd,
+                   evpl_socket_tcp_read,
+                   evpl_socket_tcp_write,
+                   evpl_socket_tcp_error);
+
+    evpl_event_read_interest(evpl, &s->event);
+
+    notify.notify_type   = EVPL_NOTIFY_CONNECTED;
+    notify.notify_status = 0;
+    bind->notify_callback(evpl, bind, &notify, bind->private_data);
+
+} /* evpl_socket_unix_attach */
+
+static void
+evpl_socket_unix_pending_close(
+    struct evpl      *evpl,
+    struct evpl_bind *bind)
+{
+    struct evpl_socket_unix *su = evpl_bind_private(bind);
+    struct evpl_socket      *s  = &su->socket;
+
+    /* Remove the name before closing the fd, so a client racing the shutdown
+     * gets ENOENT rather than briefly connecting to a socket that is about to
+     * vanish.  unlink_path is set only by listen(), and only for pathname
+     * sockets, so clients and accepted connections never delete anything. */
+    if (su->unlink_path[0]) {
+        unlink(su->unlink_path);
+        su->unlink_path[0] = '\0';
+    }
+
+    evpl_event_read_disinterest(evpl, &s->event);
+    evpl_event_write_disinterest(evpl, &s->event);
+
+    close(s->fd);
+
+    s->fd = -1;
+} /* evpl_socket_unix_pending_close */
+
+struct evpl_protocol evpl_socket_unix_stream = {
+    .id            = EVPL_STREAM_SOCKET_UNIX,
+    .connected     = 1,
+    .stream        = 1,
+    .local         = 1,
+    .name          = "STREAM_SOCKET_UNIX",
+    .connect       = evpl_socket_unix_connect,
+    .pending_close = evpl_socket_unix_pending_close,
+    .close         = evpl_socket_close,
+    .listen        = evpl_socket_unix_listen,
+    .attach        = evpl_socket_unix_attach,
+    .flush         = evpl_socket_flush,
+};

--- a/src/core/socket/unix_stream.c
+++ b/src/core/socket/unix_stream.c
@@ -111,7 +111,7 @@ evpl_socket_unix_clear_stale(
     return unlink(path) == 0;
 } /* evpl_socket_unix_clear_stale */
 
-static void
+static int
 evpl_socket_unix_listen(
     struct evpl      *evpl,
     struct evpl_bind *listen_bind)
@@ -124,14 +124,19 @@ evpl_socket_unix_listen(
 
     sun = (struct sockaddr_un *) listen_bind->local->addr;
 
+    /* The core rejects an endpoint/protocol mismatch before it reaches a
+     * backend, so this really is a should-never-happen. */
     evpl_socket_abort_if(sun->sun_family != AF_UNIX,
                          "STREAM_SOCKET_UNIX requires a local endpoint, see "
                          "evpl_endpoint_create_local()");
 
     s->fd = socket(AF_UNIX, SOCK_STREAM, 0);
 
-    evpl_socket_abort_if(s->fd < 0, "Failed to create unix listen socket: %s",
-                         strerror(errno));
+    if (s->fd < 0) {
+        evpl_socket_error("Failed to create unix listen socket: %s",
+                          strerror(errno));
+        return -1;
+    }
 
     rc = bind(s->fd, listen_bind->local->addr, listen_bind->local->addrlen);
 
@@ -146,12 +151,18 @@ evpl_socket_unix_listen(
         rc = bind(s->fd, listen_bind->local->addr, listen_bind->local->addrlen);
     }
 
-    evpl_socket_abort_if(rc < 0, "Failed to bind unix listen socket '%s': %s",
-                         sun->sun_path, strerror(errno));
+    if (rc < 0) {
+        evpl_socket_error("Failed to bind unix listen socket '%s': %s",
+                          sun->sun_path[0] ? sun->sun_path : "(abstract)",
+                          strerror(errno));
+        goto fail;
+    }
 
-    /* Remember the name so pending_close can remove it.  Only a pathname
-     * socket has anything to remove; an abstract name vanishes with the last
-     * reference to the socket. */
+    /* Remember the name so teardown can remove it.  Only a pathname socket
+     * has anything to remove; an abstract name vanishes with the last
+     * reference to the socket.  Recorded as soon as bind() succeeds, so that
+     * a later failure below unlinks the entry we just created rather than
+     * leaving it behind to block the next start. */
     if (sun->sun_path[0] != '\0') {
         pathlen = strnlen(sun->sun_path, sizeof(su->unlink_path) - 1);
 
@@ -162,18 +173,38 @@ evpl_socket_unix_listen(
 
     rc = fcntl(s->fd, F_SETFL, fcntl(s->fd, F_GETFL, 0) | O_NONBLOCK);
 
-    evpl_socket_abort_if(rc < 0, "Failed to set socket flags: %s",
-                         strerror(errno));
+    if (rc < 0) {
+        evpl_socket_error("Failed to set socket flags: %s", strerror(errno));
+        goto fail;
+    }
 
     rc = listen(s->fd, evpl_shared->config->max_pending);
 
-    evpl_socket_fatal_if(rc, "Failed to listen on listener fd");
+    if (rc < 0) {
+        evpl_socket_error("Failed to listen on listener fd: %s",
+                          strerror(errno));
+        goto fail;
+    }
 
     evpl_add_event(evpl, &s->event, s->fd,
                    evpl_accept_tcp, NULL, NULL);
 
     evpl_event_read_interest(evpl, &s->event);
 
+    return 0;
+
+ fail:
+
+    if (su->unlink_path[0]) {
+        unlink(su->unlink_path);
+        su->unlink_path[0] = '\0';
+    }
+
+    close(s->fd);
+
+    s->fd = -1;
+
+    return -1;
 } /* evpl_socket_unix_listen */
 
 static void

--- a/src/core/socket/unix_stream.h
+++ b/src/core/socket/unix_stream.h
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+struct evpl;
+struct evpl_bind;
+struct evpl_protocol;
+
+extern struct evpl_protocol evpl_socket_unix_stream;

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -19,3 +19,6 @@ unit_test(core init_with_clean_config init_with_clean_config.c)
 unit_test(core unused_config unused_config.c)
 unit_test(core tls_cipher_config tls_cipher_config.c)
 unit_test_all_mechs(core timer_oneshot timer_oneshot.c)
+
+# Local (AF_UNIX) endpoints.
+unit_test_all_mechs(core endpoint_local endpoint_local.c)

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -20,5 +20,5 @@ unit_test(core unused_config unused_config.c)
 unit_test(core tls_cipher_config tls_cipher_config.c)
 unit_test_all_mechs(core timer_oneshot timer_oneshot.c)
 
-# Local (AF_UNIX) endpoints.
-unit_test_all_mechs(core endpoint_local endpoint_local.c)
+# Local (AF_UNIX) endpoints: addressed by socket name, so no namespace needed.
+unit_test_local(core endpoint_local endpoint_local.c)

--- a/src/core/tests/endpoint_local.c
+++ b/src/core/tests/endpoint_local.c
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include "evpl/evpl.h"
@@ -22,7 +23,7 @@ static int  failures;
 static char server_local[EVPL_ADDRESS_STRLEN];
 static char server_remote[EVPL_ADDRESS_STRLEN];
 static char server_local_trunc[8];
-static int  got_conn;
+static int  conn_count;
 
 #define CHECK(cond, ...) \
         do { \
@@ -52,7 +53,7 @@ server_callback(
     evpl_bind_get_local_address(bind, server_local_trunc,
                                 sizeof(server_local_trunc));
 
-    got_conn = 1;
+    conn_count++;
 } /* server_callback */
 
 static void
@@ -76,6 +77,18 @@ client_callback(
 {
 } /* client_callback */
 
+/* evpl_continue() blocks until something happens -- wait_ms defaults to -1 --
+ * so only ever pump waiting for an event that is genuinely on its way. */
+static void
+wait_for_conns(
+    struct evpl *evpl,
+    int          target)
+{
+    while (conn_count < target) {
+        evpl_continue(evpl);
+    }
+} /* wait_for_conns */
+
 int
 main(
     int   argc,
@@ -88,13 +101,20 @@ main(
     struct evpl_bind             *conn;
     enum evpl_protocol_id         proto;
     char                          path[EVPL_ADDRESS_STRLEN + 32];
-    char                          sockpath[64];
-    int                           rc, i;
+    char                          sockpath[96];
+    const char                   *dir;
+    int                           rc;
 
     evpl_init(NULL);
 
-    snprintf(sockpath, sizeof(sockpath), "/tmp/evpl-endpoint-local-%d.sock",
-             (int) getpid());
+    dir = getenv("EVPL_TEST_SOCKET_DIR");
+
+    if (!dir || dir[0] != '/') {
+        dir = "/tmp";
+    }
+
+    snprintf(sockpath, sizeof(sockpath), "%s/evpl-endpoint-local-%d.sock",
+             dir, (int) getpid());
 
     /* --- rejected forms --- */
     CHECK(evpl_endpoint_create_local("relative/path") == NULL,
@@ -177,11 +197,8 @@ main(
                         client_callback, NULL, NULL);
     CHECK(conn != NULL, "connect(UNIX, local endpoint) succeeds");
 
-    for (i = 0; i < 1000000 && !got_conn; i++) {
-        evpl_continue(evpl);
-    }
-
-    CHECK(got_conn, "server observed the connection");
+    wait_for_conns(evpl, 1);
+    CHECK(conn_count == 1, "server observed the connection");
 
     snprintf(path, sizeof(path), "unix:%s", sockpath);
     CHECK(strcmp(server_local, path) == 0,
@@ -193,7 +210,7 @@ main(
           "unbound peer renders as '%s'", server_remote);
 
     CHECK(strlen(server_local_trunc) == sizeof(server_local_trunc) - 1 &&
-          strncmp(server_local_trunc, "unix:/t", 7) == 0,
+          strncmp(server_local_trunc, path, sizeof(server_local_trunc) - 1) == 0,
           "long path truncates safely to '%s'", server_local_trunc);
 
     /* --- a backend listen failure is reported, not fatal --- */
@@ -204,6 +221,12 @@ main(
     CHECK(evpl_listen(listener, EVPL_STREAM_SOCKET_UNIX, ep) == -1,
           "listen on an address already in use returns -1");
 
+    /* That check went through the stale-socket probe, which establishes a
+     * real connection to prove someone is listening.  The server therefore
+     * sees a connect it did not ask for; drain it so the accepted socket is
+     * attached and freed rather than left in flight at teardown. */
+    wait_for_conns(evpl, 2);
+
     /* A directory nobody may write to: bind() fails with EACCES. */
     ep_denied = evpl_endpoint_create_local("/proc/evpl-denied.sock");
     CHECK(ep_denied != NULL, "endpoint on an unwritable directory created");
@@ -211,16 +234,12 @@ main(
           "listen on an unwritable directory returns -1");
 
     /* Having survived both, the process must still be able to serve. */
-    got_conn = 0;
-    conn     = evpl_connect(evpl, EVPL_STREAM_SOCKET_UNIX, NULL, ep,
-                            client_callback, NULL, NULL);
+    conn = evpl_connect(evpl, EVPL_STREAM_SOCKET_UNIX, NULL, ep,
+                        client_callback, NULL, NULL);
     CHECK(conn != NULL, "still accepting connections after failed listens");
 
-    for (i = 0; i < 1000000 && !got_conn; i++) {
-        evpl_continue(evpl);
-    }
-
-    CHECK(got_conn, "listener still live after failed listens");
+    wait_for_conns(evpl, 3);
+    CHECK(conn_count == 3, "listener still live after failed listens");
 
     evpl_listener_detach(evpl, binding);
     evpl_listener_destroy(listener);

--- a/src/core/tests/endpoint_local.c
+++ b/src/core/tests/endpoint_local.c
@@ -84,7 +84,7 @@ main(
     struct evpl                  *evpl;
     struct evpl_listener         *listener;
     struct evpl_listener_binding *binding;
-    struct evpl_endpoint         *ep, *abstract_ep, *inet_ep;
+    struct evpl_endpoint         *ep, *abstract_ep, *inet_ep, *ep_denied;
     struct evpl_bind             *conn;
     enum evpl_protocol_id         proto;
     char                          path[EVPL_ADDRESS_STRLEN + 32];
@@ -196,6 +196,32 @@ main(
           strncmp(server_local_trunc, "unix:/t", 7) == 0,
           "long path truncates safely to '%s'", server_local_trunc);
 
+    /* --- a backend listen failure is reported, not fatal --- */
+
+    /* The socket is already bound and live above, and the stale-socket probe
+     * will find a listener answering on it, so it must refuse rather than
+     * displace it -- and must say so by returning rather than aborting. */
+    CHECK(evpl_listen(listener, EVPL_STREAM_SOCKET_UNIX, ep) == -1,
+          "listen on an address already in use returns -1");
+
+    /* A directory nobody may write to: bind() fails with EACCES. */
+    ep_denied = evpl_endpoint_create_local("/proc/evpl-denied.sock");
+    CHECK(ep_denied != NULL, "endpoint on an unwritable directory created");
+    CHECK(evpl_listen(listener, EVPL_STREAM_SOCKET_UNIX, ep_denied) == -1,
+          "listen on an unwritable directory returns -1");
+
+    /* Having survived both, the process must still be able to serve. */
+    got_conn = 0;
+    conn     = evpl_connect(evpl, EVPL_STREAM_SOCKET_UNIX, NULL, ep,
+                            client_callback, NULL, NULL);
+    CHECK(conn != NULL, "still accepting connections after failed listens");
+
+    for (i = 0; i < 1000000 && !got_conn; i++) {
+        evpl_continue(evpl);
+    }
+
+    CHECK(got_conn, "listener still live after failed listens");
+
     evpl_listener_detach(evpl, binding);
     evpl_listener_destroy(listener);
     evpl_destroy(evpl);
@@ -203,6 +229,7 @@ main(
     evpl_endpoint_close(ep);
     evpl_endpoint_close(abstract_ep);
     evpl_endpoint_close(inet_ep);
+    evpl_endpoint_close(ep_denied);
 
     printf("\n%s (%d failures)\n", failures ? "FAILED" : "PASSED", failures);
 

--- a/src/core/tests/endpoint_local.c
+++ b/src/core/tests/endpoint_local.c
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Local (AF_UNIX) endpoint construction, protocol pairing, and address
+ * rendering.
+ *
+ * The sockaddr_un length arithmetic is the fiddly part and is what this
+ * mostly guards: a pathname socket carries its trailing NUL inside addrlen
+ * while an abstract name must not, and getting either wrong yields a socket
+ * that binds but is unreachable rather than an outright failure.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "evpl/evpl.h"
+
+static int  failures;
+static char server_local[EVPL_ADDRESS_STRLEN];
+static char server_remote[EVPL_ADDRESS_STRLEN];
+static char server_local_trunc[8];
+static int  got_conn;
+
+#define CHECK(cond, ...) \
+        do { \
+            if (!(cond)) { \
+                printf("FAIL: " __VA_ARGS__); printf("\n"); failures++; \
+            } else { \
+                printf("ok:   " __VA_ARGS__); printf("\n"); \
+            } \
+        } while (0)
+
+static void
+server_callback(
+    struct evpl        *evpl,
+    struct evpl_bind   *bind,
+    struct evpl_notify *notify,
+    void               *private_data)
+{
+    if (notify->notify_type != EVPL_NOTIFY_CONNECTED) {
+        return;
+    }
+
+    evpl_bind_get_local_address(bind, server_local, sizeof(server_local));
+    evpl_bind_get_remote_address(bind, server_remote, sizeof(server_remote));
+
+    /* The listener's path is longer than 8 bytes, so this is a genuine
+     * truncation and must still land NUL terminated. */
+    evpl_bind_get_local_address(bind, server_local_trunc,
+                                sizeof(server_local_trunc));
+
+    got_conn = 1;
+} /* server_callback */
+
+static void
+accept_callback(
+    struct evpl             *evpl,
+    struct evpl_bind        *bind,
+    evpl_notify_callback_t  *notify_callback,
+    evpl_segment_callback_t *segment_callback,
+    void                   **conn_private_data,
+    void                    *private_data)
+{
+    *notify_callback = server_callback;
+} /* accept_callback */
+
+static void
+client_callback(
+    struct evpl        *evpl,
+    struct evpl_bind   *bind,
+    struct evpl_notify *notify,
+    void               *private_data)
+{
+} /* client_callback */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct evpl                  *evpl;
+    struct evpl_listener         *listener;
+    struct evpl_listener_binding *binding;
+    struct evpl_endpoint         *ep, *abstract_ep, *inet_ep;
+    struct evpl_bind             *conn;
+    enum evpl_protocol_id         proto;
+    char                          path[EVPL_ADDRESS_STRLEN + 32];
+    char                          sockpath[64];
+    int                           rc, i;
+
+    evpl_init(NULL);
+
+    snprintf(sockpath, sizeof(sockpath), "/tmp/evpl-endpoint-local-%d.sock",
+             (int) getpid());
+
+    /* --- rejected forms --- */
+    CHECK(evpl_endpoint_create_local("relative/path") == NULL,
+          "relative path rejected");
+    CHECK(evpl_endpoint_create_local("@") == NULL, "bare '@' rejected");
+    CHECK(evpl_endpoint_create_local("nohost") == NULL, "bare name rejected");
+    CHECK(evpl_endpoint_create("/", 0) == NULL, "bare '/' rejected");
+
+    /* sun_path is 108 bytes.  A pathname socket spends one on its trailing
+     * NUL, so 107 is the longest that fits and 108 must be refused rather
+     * than truncated into a different socket. */
+    memset(path, 'x', sizeof(path));
+    path[0]   = '/';
+    path[108] = '\0';
+    CHECK(evpl_endpoint_create_local(path) == NULL,
+          "108-byte path rejected");
+
+    path[107] = '\0';
+    ep        = evpl_endpoint_create_local(path);
+    CHECK(ep != NULL, "107-byte path accepted");
+    if (ep) {
+        evpl_endpoint_close(ep);
+    }
+
+    /* An abstract name spends its byte on the leading NUL instead, so the
+     * whole 108 is usable. */
+    memset(path, 'y', sizeof(path));
+    path[0]   = '@';
+    path[108] = '\0';
+    ep        = evpl_endpoint_create_local(path);
+    CHECK(ep != NULL, "108-byte abstract name accepted");
+    if (ep) {
+        evpl_endpoint_close(ep);
+    }
+
+    /* --- protocol predicates --- */
+    CHECK(evpl_protocol_available(EVPL_STREAM_SOCKET_UNIX) == 1,
+          "STREAM_SOCKET_UNIX available");
+    CHECK(evpl_protocol_is_local(EVPL_STREAM_SOCKET_UNIX) == 1,
+          "STREAM_SOCKET_UNIX is local");
+    CHECK(evpl_protocol_is_local(EVPL_STREAM_SOCKET_TCP) == 0,
+          "STREAM_SOCKET_TCP is not local");
+    CHECK(evpl_protocol_is_stream(EVPL_STREAM_SOCKET_UNIX) == 1,
+          "STREAM_SOCKET_UNIX is a stream");
+
+    rc = evpl_protocol_lookup(&proto, "STREAM_SOCKET_UNIX");
+    CHECK(rc == 0 && proto == EVPL_STREAM_SOCKET_UNIX, "lookup by name");
+
+    /* --- evpl_endpoint_create recognizes a local socket name --- */
+    ep = evpl_endpoint_create(sockpath, 0);
+    CHECK(ep && evpl_endpoint_is_local(ep), "create('/path') detects local");
+
+    abstract_ep = evpl_endpoint_create("@evpl-endpoint-local", 0);
+    CHECK(abstract_ep && evpl_endpoint_is_local(abstract_ep),
+          "create('@name') detects local");
+
+    inet_ep = evpl_endpoint_create("127.0.0.1", 8299);
+    CHECK(inet_ep && !evpl_endpoint_is_local(inet_ep),
+          "create('127.0.0.1') stays inet");
+
+    evpl     = evpl_create(NULL);
+    listener = evpl_listener_create();
+
+    /* --- a protocol/endpoint mismatch is an error, not an abort --- */
+    CHECK(evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, ep) == -1,
+          "listen(TCP, local endpoint) refused");
+    CHECK(evpl_listen(listener, EVPL_STREAM_SOCKET_UNIX, inet_ep) == -1,
+          "listen(UNIX, inet endpoint) refused");
+    CHECK(evpl_connect(evpl, EVPL_STREAM_SOCKET_TCP, NULL, ep,
+                       client_callback, NULL, NULL) == NULL,
+          "connect(TCP, local endpoint) refused");
+
+    /* --- a real connection, and how its addresses render --- */
+    binding = evpl_listener_attach(evpl, listener, accept_callback, NULL);
+
+    CHECK(evpl_listen(listener, EVPL_STREAM_SOCKET_UNIX, ep) == 0,
+          "listen(UNIX, local endpoint) succeeds");
+
+    conn = evpl_connect(evpl, EVPL_STREAM_SOCKET_UNIX, NULL, ep,
+                        client_callback, NULL, NULL);
+    CHECK(conn != NULL, "connect(UNIX, local endpoint) succeeds");
+
+    for (i = 0; i < 1000000 && !got_conn; i++) {
+        evpl_continue(evpl);
+    }
+
+    CHECK(got_conn, "server observed the connection");
+
+    snprintf(path, sizeof(path), "unix:%s", sockpath);
+    CHECK(strcmp(server_local, path) == 0,
+          "listener renders as '%s'", server_local);
+
+    /* A unix client is unbound unless it explicitly binds, so accept() hands
+     * back just the family with an empty path. */
+    CHECK(strcmp(server_remote, "unix:*") == 0,
+          "unbound peer renders as '%s'", server_remote);
+
+    CHECK(strlen(server_local_trunc) == sizeof(server_local_trunc) - 1 &&
+          strncmp(server_local_trunc, "unix:/t", 7) == 0,
+          "long path truncates safely to '%s'", server_local_trunc);
+
+    evpl_listener_detach(evpl, binding);
+    evpl_listener_destroy(listener);
+    evpl_destroy(evpl);
+
+    evpl_endpoint_close(ep);
+    evpl_endpoint_close(abstract_ep);
+    evpl_endpoint_close(inet_ep);
+
+    printf("\n%s (%d failures)\n", failures ? "FAILED" : "PASSED", failures);
+
+    return failures != 0;
+} /* main */

--- a/src/core/tls/tls.c
+++ b/src/core/tls/tls.c
@@ -1041,17 +1041,23 @@ evpl_tls_attach(
 
 } /* evpl_tls_attach */
 
-void
+int
 evpl_tls_listen(
     struct evpl      *evpl,
     struct evpl_bind *listen_bind)
 {
     struct evpl_tls *t = evpl_bind_private(listen_bind);
+    char             addr_str[80];
     int              rc;
     const int        yes = 1;
 
     t->fd = socket(listen_bind->local->addr->sa_family, SOCK_STREAM, 0);
-    evpl_tls_abort_if(t->fd < 0, "Failed to create tcp listen socket: %s", strerror(errno));
+
+    if (t->fd < 0) {
+        evpl_tls_error("Failed to create tcp listen socket: %s",
+                       strerror(errno));
+        return -1;
+    }
 
     /* Matches the plain TCP listen path: without SO_REUSEADDR a listener
      * cannot rebind an address still held in TIME_WAIT by a recently closed
@@ -1061,12 +1067,32 @@ evpl_tls_listen(
     evpl_tls_abort_if(rc < 0, "Failed to set socket options: %s", strerror(errno));
 
     rc = bind(t->fd, listen_bind->local->addr, listen_bind->local->addrlen);
-    evpl_tls_abort_if(rc < 0, "Failed to bind listen socket: %s", strerror(errno));
+
+    if (rc < 0) {
+        evpl_address_get_address(listen_bind->local, addr_str, sizeof(addr_str));
+        evpl_tls_error("Failed to bind listen socket to %s: %s",
+                       addr_str, strerror(errno));
+        goto fail;
+    }
 
     rc = listen(t->fd, evpl_shared->config->max_pending);
-    evpl_tls_fatal_if(rc, "Failed to listen on listener fd");
+
+    if (rc < 0) {
+        evpl_tls_error("Failed to listen on listener fd: %s", strerror(errno));
+        goto fail;
+    }
 
     evpl_tls_init(evpl, t, t->fd, 1, 1);
+
+    return 0;
+
+ fail:
+
+    close(t->fd);
+
+    t->fd = -1;
+
+    return -1;
 } /* evpl_tls_listen */
 
 void

--- a/src/core/xlio/tcp.c
+++ b/src/core/xlio/tcp.c
@@ -259,7 +259,7 @@ evpl_xlio_tcp_connect(
 
 } /* evpl_xlio_tcp_connect */
 
-void
+int
 evpl_xlio_tcp_listen(
     struct evpl      *evpl,
     struct evpl_bind *listen_bind)
@@ -267,6 +267,7 @@ evpl_xlio_tcp_listen(
     struct evpl_xlio        *xlio;
     struct evpl_xlio_socket *s = evpl_bind_private(listen_bind);
     struct xlio_socket_attr  sock_attr;
+    char                     addr_str[80];
     int                      rc, yes = 1;
 
     s->evpl = evpl;
@@ -281,28 +282,50 @@ evpl_xlio_tcp_listen(
 
     rc = xlio->extra->xlio_socket_create(&sock_attr, &s->socket);
 
-    evpl_xlio_abort_if(rc, "Failed to create tcp listen socket: %s",
-                       strerror(errno));
+    if (rc) {
+        evpl_xlio_error("Failed to create tcp listen socket: %s",
+                        strerror(errno));
+        return -1;
+    }
 
     rc = xlio->extra->xlio_socket_setsockopt(
         s->socket, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
 
-    evpl_xlio_abort_if(rc < 0, "Failed to set SO_REUSEADDR");
+    if (rc < 0) {
+        evpl_xlio_error("Failed to set SO_REUSEADDR");
+        goto fail;
+    }
 
     rc = xlio->extra->xlio_socket_bind(
         s->socket, listen_bind->local->addr, listen_bind->local->addrlen);
 
-    evpl_xlio_abort_if(rc < 0, "Failed to bind listen socket: %s", strerror(
-                           errno));
+    if (rc < 0) {
+        evpl_address_get_address(listen_bind->local, addr_str, sizeof(addr_str));
+        evpl_xlio_error("Failed to bind listen socket to %s: %s",
+                        addr_str, strerror(errno));
+        goto fail;
+    }
 
     rc = xlio->extra->xlio_socket_listen(s->socket);
 
-    evpl_xlio_fatal_if(rc < 0, "Failed to listen on listener fd");
+    if (rc < 0) {
+        evpl_xlio_error("Failed to listen on listener fd: %s", strerror(errno));
+        goto fail;
+    }
 
     evpl_xlio_socket_init(evpl, xlio, s, 1, 0,
                           evpl_xlio_tcp_read,
                           evpl_xlio_tcp_write);
 
+    return 0;
+
+ fail:
+
+    xlio->extra->xlio_socket_destroy(s->socket);
+
+    s->socket = 0;
+
+    return -1;
 } /* evpl_xlio_tcp_listen */
 
 void

--- a/src/http/tests/http1_client.c
+++ b/src/http/tests/http1_client.c
@@ -131,7 +131,10 @@ server_function(void *ptr)
 
     server = evpl_http_attach(agent, listener, server_dispatch, NULL);
 
-    evpl_listen(listener, TEST_PROTOCOL, endpoint);
+    if (evpl_listen(listener, TEST_PROTOCOL, endpoint)) {
+        fprintf(stderr, "failed to listen\n");
+        exit(1);
+    }
 
     __sync_synchronize();
 

--- a/src/http/tests/http2_basic.c
+++ b/src/http/tests/http2_basic.c
@@ -94,7 +94,10 @@ server_function(void *ptr)
     listener = evpl_listener_create();
     server   = evpl_http_attach(agent, listener, server_dispatch, NULL);
 
-    evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint);
+    if (evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint)) {
+        fprintf(stderr, "failed to listen\n");
+        exit(1);
+    }
 
     __sync_synchronize();
     server_ctx->run = 1;

--- a/src/http/tests/http2_tls.c
+++ b/src/http/tests/http2_tls.c
@@ -94,7 +94,10 @@ server_function(void *ptr)
     listener = evpl_listener_create();
     server   = evpl_http_attach(agent, listener, server_dispatch, NULL);
 
-    evpl_listen(listener, EVPL_STREAM_SOCKET_TLS, endpoint);
+    if (evpl_listen(listener, EVPL_STREAM_SOCKET_TLS, endpoint)) {
+        fprintf(stderr, "failed to listen\n");
+        exit(1);
+    }
 
     __sync_synchronize();
     server_ctx->run = 1;

--- a/src/http/tests/http_basic.c
+++ b/src/http/tests/http_basic.c
@@ -124,7 +124,10 @@ server_function(void *ptr)
 
     server = evpl_http_attach(agent, listener, server_dispatch, NULL);
 
-    evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint);
+    if (evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint)) {
+        fprintf(stderr, "failed to listen\n");
+        exit(1);
+    }
 
     __sync_synchronize();
 

--- a/src/http/tests/http_chunked.c
+++ b/src/http/tests/http_chunked.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <pthread.h>
@@ -103,7 +104,10 @@ server_function(void *ptr)
 
     server = evpl_http_attach(agent, listener, server_dispatch, NULL);
 
-    evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint);
+    if (evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint)) {
+        fprintf(stderr, "failed to listen\n");
+        exit(1);
+    }
 
     __sync_synchronize();
 

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -2817,13 +2817,13 @@ evpl_rpc2_server_init(
     return server;
 } /* evpl_rpc2_listen */
 
-SYMBOL_EXPORT void
+SYMBOL_EXPORT int
 evpl_rpc2_server_start(
     struct evpl_rpc2_server *server,
     int                      protocol,
     struct evpl_endpoint    *endpoint)
 {
-    evpl_listen(
+    return evpl_listen(
         server->listener,
         protocol,
         endpoint);

--- a/src/tests/bulk_connected_msg.c
+++ b/src/tests/bulk_connected_msg.c
@@ -193,10 +193,14 @@ main(
         } /* switch */
     }
 
+    /* A local transport names one socket that both ends must agree on, so
+     * normalize here rather than at each endpoint. */
+    address = test_address(proto, address, argv[0]);
+
 
     evpl = evpl_create(NULL);
 
-    me = evpl_endpoint_create("0.0.0.0", port);
+    me = evpl_endpoint_create(test_listen_address(address), port);
 
     listener = evpl_listener_create();
 

--- a/src/tests/bulk_connected_msg.c
+++ b/src/tests/bulk_connected_msg.c
@@ -206,7 +206,8 @@ main(
 
     binding = evpl_listener_attach(evpl, listener, accept_callback, &state);
 
-    evpl_listen(listener, proto, me);
+    evpl_test_abort_if(evpl_listen(listener, proto, me),
+                       "failed to listen");
 
     pthread_create(&thr, NULL, client_thread, &state);
 

--- a/src/tests/bulk_stream.c
+++ b/src/tests/bulk_stream.c
@@ -205,9 +205,13 @@ main(
         } /* switch */
     }
 
+    /* A local transport names one socket that both ends must agree on, so
+     * normalize here rather than at each endpoint. */
+    address = test_address(proto, address, argv[0]);
+
     evpl = evpl_create(NULL);
 
-    me = evpl_endpoint_create("0.0.0.0", port);
+    me = evpl_endpoint_create(test_listen_address(address), port);
 
     listener = evpl_listener_create();
 

--- a/src/tests/bulk_stream.c
+++ b/src/tests/bulk_stream.c
@@ -217,7 +217,8 @@ main(
 
     binding = evpl_listener_attach(evpl, listener, accept_callback, &state);
 
-    evpl_listen(listener, proto, me);
+    evpl_test_abort_if(evpl_listen(listener, proto, me),
+                       "failed to listen");
 
     pthread_create(&thr, NULL, client_thread, &state);
 

--- a/src/tests/hello_world_connected_msg.c
+++ b/src/tests/hello_world_connected_msg.c
@@ -175,7 +175,8 @@ main(
 
     binding = evpl_listener_attach(evpl, listener, accept_callback, &run);
 
-    evpl_listen(listener, proto, ep);
+    evpl_test_abort_if(evpl_listen(listener, proto, ep),
+                       "failed to listen");
 
     pthread_create(&thr, NULL, client_thread, NULL);
 

--- a/src/tests/hello_world_connected_msg.c
+++ b/src/tests/hello_world_connected_msg.c
@@ -163,6 +163,10 @@ main(
         } /* switch */
     }
 
+    /* A local transport names one socket that both ends must agree on, so
+     * normalize here rather than at each endpoint. */
+    address = test_address(proto, address, argv[0]);
+
     evpl = evpl_create(NULL);
 
     ep = evpl_endpoint_create(address, port);

--- a/src/tests/hello_world_stream.c
+++ b/src/tests/hello_world_stream.c
@@ -170,7 +170,8 @@ main(
 
     binding = evpl_listener_attach(evpl, listener, accept_callback, &run);
 
-    evpl_listen(listener, proto, ep);
+    evpl_test_abort_if(evpl_listen(listener, proto, ep),
+                       "failed to listen");
 
     pthread_create(&thr, NULL, client_thread, NULL);
 

--- a/src/tests/hello_world_stream.c
+++ b/src/tests/hello_world_stream.c
@@ -158,6 +158,10 @@ main(
         } /* switch */
     }
 
+    /* A local transport names one socket that both ends must agree on, so
+     * normalize here rather than at each endpoint. */
+    address = test_address(proto, address, argv[0]);
+
     evpl = evpl_create(NULL);
 
     ep = evpl_endpoint_create(address, port);

--- a/src/tests/ping_pong_connected_msg.c
+++ b/src/tests/ping_pong_connected_msg.c
@@ -209,7 +209,8 @@ main(
 
     binding = evpl_listener_attach(evpl, listener, accept_callback, &state);
 
-    evpl_listen(listener, proto, me);
+    evpl_test_abort_if(evpl_listen(listener, proto, me),
+                       "failed to listen");
 
     pthread_create(&thr, NULL, client_thread, &state);
 

--- a/src/tests/ping_pong_connected_msg.c
+++ b/src/tests/ping_pong_connected_msg.c
@@ -195,11 +195,15 @@ main(
         } /* switch */
     }
 
+    /* A local transport names one socket that both ends must agree on, so
+     * normalize here rather than at each endpoint. */
+    address = test_address(proto, address, argv[0]);
+
     evpl = evpl_create(NULL);
 
     state.server_evpl = evpl;
 
-    me = evpl_endpoint_create("0.0.0.0", port);
+    me = evpl_endpoint_create(test_listen_address(address), port);
 
     listener = evpl_listener_create();
 

--- a/src/tests/ping_pong_stream.c
+++ b/src/tests/ping_pong_stream.c
@@ -202,9 +202,13 @@ main(
         } /* switch */
     }
 
+    /* A local transport names one socket that both ends must agree on, so
+     * normalize here rather than at each endpoint. */
+    address = test_address(proto, address, argv[0]);
+
     evpl = evpl_create(NULL);
 
-    ep = evpl_endpoint_create("0.0.0.0", port);
+    ep = evpl_endpoint_create(test_listen_address(address), port);
 
     listener = evpl_listener_create();
 

--- a/src/tests/ping_pong_stream.c
+++ b/src/tests/ping_pong_stream.c
@@ -214,7 +214,8 @@ main(
 
     binding = evpl_listener_attach(evpl, listener, accept_callback, &state);
 
-    evpl_listen(listener, proto, ep);
+    evpl_test_abort_if(evpl_listen(listener, proto, ep),
+                       "failed to listen");
 
     pthread_create(&thr, NULL, client_thread, &state);
 

--- a/src/tests/rand_full_duplex_stream.c
+++ b/src/tests/rand_full_duplex_stream.c
@@ -145,7 +145,8 @@ client_thread(void *arg)
     binding = evpl_listener_attach(evpl, listener, accept_callback, state);
 
     if (state->index == 0) {
-        evpl_listen(listener, proto, ep);
+        evpl_test_abort_if(evpl_listen(listener, proto, ep),
+                           "failed to listen");
     } else {
         evpl_connect(evpl, proto, NULL, ep, client_callback, NULL, state);
     }

--- a/src/tests/rand_full_duplex_stream.c
+++ b/src/tests/rand_full_duplex_stream.c
@@ -204,6 +204,10 @@ main(
         } /* switch */
     }
 
+    /* A local transport names one socket that both ends must agree on, so
+     * normalize here rather than at each endpoint. */
+    address = test_address(proto, address, argv[0]);
+
     srand(time(NULL));
 
     for (i = 0; i < 2; ++i) {

--- a/src/tests/rdma_ops.c
+++ b/src/tests/rdma_ops.c
@@ -406,7 +406,8 @@ main(
 
     binding = evpl_listener_attach(evpl, listener, accept_callback, &server_state);
 
-    evpl_listen(listener, proto, me);
+    evpl_test_abort_if(evpl_listen(listener, proto, me),
+                       "failed to listen");
 
     pthread_create(&thr, NULL, client_thread, &client_state);
 

--- a/src/tests/test_common.h
+++ b/src/tests/test_common.h
@@ -8,6 +8,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <errno.h>
 
 #include "evpl/evpl.h"
 
@@ -77,12 +80,16 @@ test_address_is_local(const char *address)
  *
  * IP protocols: returned unchanged (-a, else 127.0.0.1).
  *
- * Local protocols: an explicit -a path wins; otherwise synthesize a
- * per-binary, per-process path under TMPDIR.  A network namespace does not
- * isolate the filesystem, so unlike ports these names are shared across every
- * concurrently running test -- the binary name and pid are what keep
- * `ctest -j` collision-free, and they also guarantee a socket left behind by
- * a crashed run is never reused.
+ * Local protocols: a fully specified -a name wins.  "-a @" asks for an
+ * abstract socket with a generated name; anything else generates a pathname
+ * socket under EVPL_TEST_SOCKET_DIR (the build tree, set by ctest), falling
+ * back to TMPDIR.
+ *
+ * Either way the generated name carries the binary name and pid, which is
+ * what makes these tests safe to run concurrently without a network
+ * namespace: a namespace isolates ports, but the socket name is what needs to
+ * be unique here.  The pid also guarantees a socket left behind by a crashed
+ * run is never reused.
  */
 static inline const char *
 test_address(
@@ -90,17 +97,16 @@ test_address(
     const char           *address,
     const char           *argv0)
 {
-    const char *tmpdir, *base, *slash;
+    const char *dir, *base, *slash;
     int         len;
 
-    if (!evpl_protocol_is_local(proto) || test_address_is_local(address)) {
+    if (!evpl_protocol_is_local(proto)) {
         return address;
     }
 
-    tmpdir = getenv("TMPDIR");
-
-    if (!tmpdir || tmpdir[0] != '/') {
-        tmpdir = "/tmp";
+    /* A name the caller fully specified; use it as given. */
+    if (test_address_is_local(address) && address[1]) {
+        return address;
     }
 
     base  = argv0 ? argv0 : "evpl";
@@ -110,10 +116,35 @@ test_address(
         base = slash + 1;
     }
 
-    len = snprintf(test_path_buf, sizeof(test_path_buf),
-                   "%s/evpl-%.32s-%d.sock", tmpdir, base, (int) getpid());
+    /* "-a @" means "an abstract socket, name it for me".  Abstract names live
+     * outside the filesystem, so there is no directory to place them in. */
+    if (address && address[0] == '@') {
+        snprintf(test_path_buf, sizeof(test_path_buf), "@evpl-%.32s-%d",
+                 base, (int) getpid());
+        return test_path_buf;
+    }
 
-    /* sun_path is only 108 bytes, so a long TMPDIR would truncate into a
+    dir = getenv("EVPL_TEST_SOCKET_DIR");
+
+    if (!dir || dir[0] != '/') {
+        dir = getenv("TMPDIR");
+    }
+
+    if (!dir || dir[0] != '/') {
+        dir = "/tmp";
+    }
+
+    /* Created here rather than relied upon from the build: ctest points this
+     * at the build tree, which a clean removes, and the directory is only
+     * ever needed at run time. */
+    if (mkdir(dir, 0700) && errno != EEXIST) {
+        dir = "/tmp";
+    }
+
+    len = snprintf(test_path_buf, sizeof(test_path_buf),
+                   "%s/evpl-%.32s-%d.sock", dir, base, (int) getpid());
+
+    /* sun_path is only 108 bytes, so a deep build tree would truncate into a
      * nonsensical path; fall back to /tmp rather than guess. */
     if (len < 0 || (size_t) len >= sizeof(test_path_buf)) {
         snprintf(test_path_buf, sizeof(test_path_buf), "/tmp/evpl-%.32s-%d.sock",

--- a/src/tests/test_common.h
+++ b/src/tests/test_common.h
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "evpl/evpl.h"
 
@@ -50,3 +51,85 @@ test_evpl_config(void)
 
     evpl_init(config);
 } // test_setup_tls_config
+
+/*
+ * Endpoint helpers for the protocol-parameterized tests.
+ *
+ * A local (AF_UNIX) transport has no wildcard bind address and no port: both
+ * ends must name the same socket.  The IP convention of listening on 0.0.0.0
+ * while dialing 127.0.0.1 has no analogue, so each test normalizes its
+ * `address` global through test_address() once, right after getopt, and
+ * derives the listen address from test_listen_address().
+ *
+ * For IP protocols both are identities and behavior is unchanged.
+ */
+
+static char test_path_buf[108];
+
+static inline int
+test_address_is_local(const char *address)
+{
+    return address && (address[0] == '/' || address[0] == '@');
+} /* test_address_is_local */
+
+/*
+ * Resolve the effective address for this run.
+ *
+ * IP protocols: returned unchanged (-a, else 127.0.0.1).
+ *
+ * Local protocols: an explicit -a path wins; otherwise synthesize a
+ * per-binary, per-process path under TMPDIR.  A network namespace does not
+ * isolate the filesystem, so unlike ports these names are shared across every
+ * concurrently running test -- the binary name and pid are what keep
+ * `ctest -j` collision-free, and they also guarantee a socket left behind by
+ * a crashed run is never reused.
+ */
+static inline const char *
+test_address(
+    enum evpl_protocol_id proto,
+    const char           *address,
+    const char           *argv0)
+{
+    const char *tmpdir, *base, *slash;
+    int         len;
+
+    if (!evpl_protocol_is_local(proto) || test_address_is_local(address)) {
+        return address;
+    }
+
+    tmpdir = getenv("TMPDIR");
+
+    if (!tmpdir || tmpdir[0] != '/') {
+        tmpdir = "/tmp";
+    }
+
+    base  = argv0 ? argv0 : "evpl";
+    slash = strrchr(base, '/');
+
+    if (slash) {
+        base = slash + 1;
+    }
+
+    len = snprintf(test_path_buf, sizeof(test_path_buf),
+                   "%s/evpl-%.32s-%d.sock", tmpdir, base, (int) getpid());
+
+    /* sun_path is only 108 bytes, so a long TMPDIR would truncate into a
+     * nonsensical path; fall back to /tmp rather than guess. */
+    if (len < 0 || (size_t) len >= sizeof(test_path_buf)) {
+        snprintf(test_path_buf, sizeof(test_path_buf), "/tmp/evpl-%.32s-%d.sock",
+                 base, (int) getpid());
+    }
+
+    return test_path_buf;
+} /* test_address */
+
+/* The address a server should bind.  For IP that is the wildcard; a local
+ * transport has no wildcard, so it is the socket name itself.
+ *
+ * The endpoint itself still comes from plain evpl_endpoint_create(), which
+ * recognizes a leading '/' or '@' as a local socket name. */
+static inline const char *
+test_listen_address(const char *address)
+{
+    return test_address_is_local(address) ? address : "0.0.0.0";
+} /* test_listen_address */


### PR DESCRIPTION
Adds `EVPL_STREAM_SOCKET_UNIX`, a `SOCK_STREAM` AF_UNIX transport, and generalizes the endpoint layer so one endpoint concept covers both IP/hostname and local socket names.

### Endpoints

`evpl_endpoint_resolve()` always called `getaddrinfo()` with `ai_family` hardcoded to `AF_INET`, so no caller could obtain a `sockaddr_un` at all. It now branches on an endpoint kind and builds the `sockaddr_un` directly, resolving once since a socket name cannot change.

`evpl_endpoint_create_local()` is the explicit constructor; `evpl_endpoint_create()` also recognizes a leading `/` or `@`, since neither can begin a hostname or IP literal. Abstract (`@name`) sockets are supported — their `addrlen` must exclude the trailing NUL where a pathname socket includes it.

Pairing a local endpoint with a network protocol used to be fatal: the backend derives the socket domain from `sa_family`, so `socket()` and `connect()` both succeed and it died later on a `TCP_NODELAY` that AF_UNIX rejects. `evpl_connect`/`bind`/`listen` now reject the mismatch up front, and also check `evpl_endpoint_resolve()` for NULL, which they never did.

### Transport

Reuses tcp.c's read/write/error/accept verbatim, so only connect/listen/attach/pending_close are new. `SO_REUSEADDR` does nothing for AF_UNIX, so a crashed predecessor's socket file otherwise blocks `bind()` forever. On `EADDRINUSE` the listener probes the name with `connect()`: a live server answers and we fail rather than displace it, while `ECONNREFUSED` proves the entry is stale and it is unlinked. Only sockets are ever unlinked, so a mistyped path pointing at a regular file cannot delete it.

### Listen error path

`evpl_listen()` had no way to report a backend failure — the listen callback returned void and runs on the listener thread, so every backend aborted on `bind()`/`listen()` errors. Those are ordinary operating conditions, and especially routine for AF_UNIX where the name is a filesystem entry subject to permissions and leftovers. The callback now returns `int`, the status crosses the doorbell, and `evpl_listen()` returns it. `evpl_rpc2_server_start()` propagates it too; callers that ignore it still compile.

### Tests

The seven existing TCP stream bodies run over the new protocol, plus abstract-namespace variants and a new `core/endpoint_local` unit test. Socket-name tests need no network namespace — a namespace isolates ports, but what has to be unique here is the socket name — so they register directly with no wrapper and no resource lock, and run where `CAP_NET_ADMIN` is unavailable. Test sockets live in the build tree rather than `/tmp`.

### Incidental fixes in the code this touches

- `evpl_endpoint_resolve()` released `resolved_addr` before re-resolving without clearing it, so a failed re-resolution left a dangling pointer the next call released again.
- `getaddrinfo()` failure was tested with `rc < 0`; `EAI_*` are negative in glibc but positive on BSD, where that walks an uninitialized `addrinfo`.
- The read-to-write lock upgrade did not re-check the cache, so racing threads all re-resolved.
- `evpl_address_get_address()` had no fallback branch and left the caller's buffer uninitialized for any family other than AF_INET/INET6.
- `evpl_protocol_is_stream()`, `evpl_endpoint_address()` and `evpl_endpoint_port()` are declared in public headers but were never `SYMBOL_EXPORT`ed, so they were unusable under `-fvisibility=hidden`.