### PR TITLE
rpc2: report refused, failed and lost calls to the caller; authenticate GSS DESTROY

### DIFF
--- a/include/evpl/evpl_rpc2_program.h
+++ b/include/evpl/evpl_rpc2_program.h
@@ -20,6 +20,26 @@
  */
 #define EVPL_RPC2_REPLY_DECODE_ERROR (-1)
 
+/*
+ * Status passed to a client reply callback when the peer refused the call
+ * outright: an RFC 5531 MSG_DENIED reply, or a reply_stat that is neither
+ * MSG_ACCEPTED nor MSG_DENIED.  There are no results in either case, so the
+ * reply argument is NULL (or zero for a by-value reply).
+ *
+ * A call the peer accepted but did not run -- MSG_ACCEPTED with an accept_stat
+ * other than SUCCESS -- is reported as that accept_stat instead, which is
+ * positive and so distinguishable from the codes here.
+ */
+#define EVPL_RPC2_REPLY_DENIED       (-2)
+
+/*
+ * Status passed to a client reply callback when the connection was lost before
+ * a reply arrived.  Every call still outstanding on a connection is completed
+ * with this when it goes down, so that a caller is never left waiting on a
+ * completion that can no longer happen.
+ */
+#define EVPL_RPC2_REPLY_CONN_LOST    (-3)
+
 #include <pthread.h>
 struct prometheus_histogram_instance;
 
@@ -124,6 +144,7 @@ struct evpl_rpc2_program {
         xdr_iovec                   *iov,
         int                          niov,
         int                          length,
+        int                          status,
         void                        *callback_fn,
         void                        *callback_private_data);
 

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -2560,6 +2560,7 @@ evpl_rpc2_recv_msg(
         {
             /* AUTH_SHORT is not implemented - pass empty verifier */
             struct evpl_rpc2_verf verf = { .data = NULL, .len = 0 };
+            int                   reply_status;
 
             /* Find request by xid */
             HASH_FIND(hh, rpc2_conn->pending_calls, &rpc_msg.xid, sizeof(rpc_msg.xid), request);
@@ -2585,8 +2586,25 @@ evpl_rpc2_recv_msg(
             }
             request->msg = msg;
 
+            /* RFC 5531 sec 9: procedure results follow only on MSG_ACCEPTED
+             * with accept_stat SUCCESS.  Every other reply -- MSG_DENIED, an
+             * accept_stat the server set to report that it did not run the
+             * call, or a reply_stat that is neither -- carries no results, so
+             * whatever bytes follow must not be decoded as though they were.
+             * Handing them to the caller as a successful reply would report a
+             * refusal as a success and pass off the refuser's payload as the
+             * procedure's own output. */
+            if (rpc_msg.body.rbody.stat == MSG_ACCEPTED) {
+                reply_status = rpc_msg.body.rbody.areply.reply_data.stat;
+                if (reply_status == SUCCESS) {
+                    reply_status = 0;
+                }
+            } else {
+                reply_status = EVPL_RPC2_REPLY_DENIED;
+            }
+
             evpl_rpc2_client_handle_reply(request, &verf, req_iov, req_niov,
-                                          request_length, 0);
+                                          request_length, reply_status);
         }
         break;
         default:

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -1880,7 +1880,14 @@ evpl_rpc2_gss_handle_call(
             pthread_mutex_unlock(&evpl_rpc2_gss_lock);
             evpl_rpc2_debug("rpcsec_gss: integrity UNWRAP failed proc=%u seq=%u "
                             "reqlen=%d", cred.proc, cred.seq, *request_length_p);
-            evpl_rpc2_send_reply_denied(evpl, request, RPCSEC_GSS_CTXPROBLEM);
+            /* RFC 2203 sec 5.3.3.4.2 separates the two integrity failures.  A
+             * bad *header* verifier means the caller is not authenticated and
+             * is denied above; a bad checksum over the *call arguments* (or a
+             * databody seq_num that contradicts the header, sec 5.3.2.2) means
+             * the caller is known but its arguments are unusable, which is
+             * MSG_ACCEPTED with GARBAGE_ARGS.  Denying here instead would make
+             * a client tear down and re-establish a context that is fine. */
+            evpl_rpc2_send_reply_error(evpl, request, GARBAGE_ARGS);
             return 0;
         }
     }

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -2009,7 +2009,8 @@ evpl_rpc2_client_handle_reply(
     const struct evpl_rpc2_verf *verf,
     struct evpl_iovec           *reply_iov,
     int                          reply_niov,
-    int                          reply_length)
+    int                          reply_length,
+    int                          status)
 {
     struct evpl_rpc2_thread *thread = request->thread;
     struct evpl_rpc2_conn   *conn   = request->conn;
@@ -2046,6 +2047,7 @@ evpl_rpc2_client_handle_reply(
                                                   request->proc,
                                                   &request->read_chunk,
                                                   verf, reply_iov, reply_niov, reply_length,
+                                                  status,
                                                   request->callback,
                                                   request->callback_arg);
 
@@ -2583,7 +2585,8 @@ evpl_rpc2_recv_msg(
             }
             request->msg = msg;
 
-            evpl_rpc2_client_handle_reply(request, &verf, req_iov, req_niov, request_length);
+            evpl_rpc2_client_handle_reply(request, &verf, req_iov, req_niov,
+                                          request_length, 0);
         }
         break;
         default:

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -2640,8 +2640,18 @@ evpl_rpc2_event(
             DL_DELETE(rpc2_thread->conns, rpc2_conn);
             HASH_ITER(hh, rpc2_conn->pending_calls, rpc2_request, tmp)
             {
+                struct evpl_rpc2_verf verf = { .data = NULL, .len = 0 };
+
                 HASH_DELETE(hh, rpc2_conn->pending_calls, rpc2_request);
-                evpl_rpc2_request_free(rpc2_conn->thread, rpc2_request);
+
+                /* No reply can arrive for these now, so complete each caller
+                 * with EVPL_RPC2_REPLY_CONN_LOST instead of freeing the
+                 * request behind its back -- a callback that never runs leaves
+                 * the caller waiting forever on a call that is already dead.
+                 * handle_reply releases the request once the callback returns.
+                 */
+                evpl_rpc2_client_handle_reply(rpc2_request, &verf, NULL, 0, 0,
+                                              EVPL_RPC2_REPLY_CONN_LOST);
             }
             if (rpc2_conn->thread->notify_callback) {
                 rpc2_notify.notify_type = EVPL_RPC2_NOTIFY_DISCONNECTED;

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -1778,21 +1778,12 @@ evpl_rpc2_gss_handle_call(
                                       *request_length_p);
             return 0;
 
+        /* RFC 2203 sec 5.4: a DESTROY is an ordinary authenticated call.  It
+         * shares the DATA path below so that the context handle, the header
+         * MIC and the sequence number are all verified before anything is
+         * retired -- destroying on the strength of a handle alone would let
+         * any peer that can guess one retire another client's context. */
         case RPCSEC_GSS_DESTROY:
-            handle = 0;
-            if (cred.handle_len == sizeof(handle)) {
-                memcpy(&handle, cred.handle, sizeof(handle));
-            }
-            pthread_mutex_lock(&evpl_rpc2_gss_lock);
-            ctx = evpl_rpc2_gss_ctx_lookup(handle);
-            if (ctx) {
-                evpl_rpc2_gss_ctx_destroy(thread, ctx);
-            }
-            pthread_mutex_unlock(&evpl_rpc2_gss_lock);
-            /* Acknowledge with an empty successful reply. */
-            evpl_rpc2_send_reply_error(evpl, request, SUCCESS);
-            return 0;
-
         case RPCSEC_GSS_DATA:
             break;
 
@@ -1857,6 +1848,29 @@ evpl_rpc2_gss_handle_call(
         return 0;
     }
 
+    /* Pre-compute the reply verifier: a GSS MIC over the request seq_num.
+     * Computed here, ahead of any work on the body, because a DESTROY has no
+     * body but its reply still carries this verifier. */
+    seq_be = rpc2_hton32(cred.seq);
+    if (thread->gss_provider->get_mic(thread->gss_provider_arg, ctx->gss_ctx,
+                                      &seq_be, sizeof(seq_be),
+                                      &mic, &mic_len) == 0) {
+        request->reply_verf_data   = mic;
+        request->reply_verf_len    = mic_len;
+        request->reply_verf_flavor = RPCSEC_GSS;
+    }
+
+    /* RFC 2203 sec 5.4: now that the caller has proved it holds the context,
+     * retire it and acknowledge with an empty successful reply.  A DESTROY
+     * carries no arguments, so there is nothing to unwrap even under
+     * integrity. */
+    if (cred.proc == RPCSEC_GSS_DESTROY) {
+        evpl_rpc2_gss_ctx_destroy(thread, ctx);
+        pthread_mutex_unlock(&evpl_rpc2_gss_lock);
+        evpl_rpc2_send_reply_error(evpl, request, SUCCESS);
+        return 0;
+    }
+
     /* For integrity, unwrap rpc_gss_integ_data -> inner proc args (verifies the
      * databody checksum + embedded seq).  The reply is wrapped symmetrically in
      * evpl_rpc2_send_reply, keyed on request->gss_service. */
@@ -1869,16 +1883,6 @@ evpl_rpc2_gss_handle_call(
             evpl_rpc2_send_reply_denied(evpl, request, RPCSEC_GSS_CTXPROBLEM);
             return 0;
         }
-    }
-
-    /* Pre-compute the reply verifier: a GSS MIC over the request seq_num. */
-    seq_be = rpc2_hton32(cred.seq);
-    if (thread->gss_provider->get_mic(thread->gss_provider_arg, ctx->gss_ctx,
-                                      &seq_be, sizeof(seq_be),
-                                      &mic, &mic_len) == 0) {
-        request->reply_verf_data   = mic;
-        request->reply_verf_len    = mic_len;
-        request->reply_verf_flavor = RPCSEC_GSS;
     }
 
     /* Copy out the principal so the request never dereferences the context


### PR DESCRIPTION
Five RPC2 fixes found by model-based conformance testing against RFC 5531 and RFC 2203.

Submodule bumped to xdrzcc `7434cfe` (chimera-nas/xdrzcc#13, merged), which adds the `status` parameter the first commit needs.

- **Plumb a completion status through the client reply dispatch.** A reply callback could only be reached by decoding a body, so there was no way to complete a call with no results. Adds the status parameter and the two codes below. No behaviour change on its own.

- **Honour `reply_stat` and `accept_stat` on the client.** `evpl_rpc2_recv_msg` switched on `mtype` alone; neither field was read anywhere on the receive path. A `MSG_DENIED`, a non-SUCCESS `accept_stat`, or an undefined `reply_stat` fell through to the results decoder, so a refusal with a decodable body attached reached the caller as status 0 carrying the refuser's values. Results are now decoded only for MSG_ACCEPTED/SUCCESS; an accept_stat is reported as itself, anything else as `EVPL_RPC2_REPLY_DENIED`.

- **Complete outstanding calls when the connection drops.** The `EVPL_NOTIFY_DISCONNECTED` arm freed every entry of `conn->pending_calls` without invoking one callback, leaving each caller waiting on a completion that could no longer arrive. They are now completed with `EVPL_RPC2_REPLY_CONN_LOST`.

- **Authenticate `RPCSEC_GSS_DESTROY` before honouring it.** The DESTROY arm retired the context and replied SUCCESS ahead of the header-MIC verification that only the DATA arm performed, so neither the verifier nor the sequence number was checked. RFC 2203 sec 5.4 requires both, and handles are allocated sequentially and so enumerable, which left any peer that could reach the port able to destroy contexts it does not own. DESTROY now shares the DATA path and acts only after the context, header MIC and sequence number are verified.

- **Report argument integrity failures as GARBAGE_ARGS.** RFC 2203 sec 5.3.3.4.2 distinguishes a bad header verifier (MSG_DENIED) from a bad checksum over the call arguments (MSG_ACCEPTED / GARBAGE_ARGS). Both answered MSG_DENIED / RPCSEC_GSS_CTXPROBLEM, which makes a client tear down and re-establish a context that is fine. The sec 5.3.2.2 databody seq_num check shares the path and is covered.

Verified: libevpl standalone 101/101; conformance suite green (993 value cases, 127 defect cases, 97 client reply cases, zero known divergences); ASan debug clean. Full chimera suite run and every failure attributed: 38 pre-existing on main (including the 27 `pynfs/flex` tests, which are red on main independently of this change) and 10 load-induced flakes in SMB/io_uring paths this change does not touch, all passing on re-run.
