### PR TITLE
rpc2: model-based conformance test suite

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,7 +27,12 @@ RUN apt-get -y update && \
     libssl-dev openssl clangd uthash-dev libnuma-dev && \
     gem install jekyll bundler && \
     bundler install && \
-    npm install -g @anthropic-ai/claude-code
+    npm install -g @anthropic-ai/claude-code && \
+    # Quint drives the RPC2 conformance test: cmake detects it and generates
+    # that test's cases from the models at build time, so the version is pinned
+    # -- trace generation is seeded and reproducible for a given release, but
+    # different releases may sample the state space differently.
+    npm install -g @informalsystems/quint@0.32.0
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/src/rpc2/tests/CMakeLists.txt
+++ b/src/rpc2/tests/CMakeLists.txt
@@ -125,3 +125,110 @@ unit_test_rpc2_instance_named(rdma_ddp DATAGRAM_INPROC)
 unit_test_rpc2_instance_named(hello_world STREAM_INPROC)
 unit_test_rpc2_instance_named(builtin_bool STREAM_INPROC)
 unit_test_rpc2_instance_named(rdma_ddp STREAM_INPROC)
+
+# ---------------------------------------------------------------------------
+# Model-based XDR/RPC2 conformance test
+#
+# The cases this test runs are generated from the Quint models in quint/ by a
+# build step, so the traces and the resulting case table are build artifacts
+# under the build tree rather than checked-in files that could drift from the
+# models they came from.  That makes quint a build dependency, so the whole
+# test is registered only when quint and python3 are both present; without
+# them the rest of the suite builds and runs as normal.
+# ---------------------------------------------------------------------------
+
+find_program(QUINT_EXECUTABLE quint)
+find_program(PYTHON3_EXECUTABLE NAMES python3 python)
+
+if(QUINT_EXECUTABLE AND PYTHON3_EXECUTABLE)
+    set(QUINT_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/quint)
+    set(QUINT_WORK_DIR ${CMAKE_CURRENT_BINARY_DIR}/quint)
+    set(CONFORMANCE_CASES ${QUINT_WORK_DIR}/conformance_cases.h)
+
+    add_custom_command(
+        OUTPUT ${CONFORMANCE_CASES}
+        COMMAND ${QUINT_SRC_DIR}/generate_cases.sh
+                ${QUINT_EXECUTABLE} ${PYTHON3_EXECUTABLE}
+                ${QUINT_SRC_DIR} ${QUINT_WORK_DIR} ${CONFORMANCE_CASES}
+        DEPENDS ${QUINT_SRC_DIR}/values.qnt
+                ${QUINT_SRC_DIR}/defects.qnt
+                ${QUINT_SRC_DIR}/itf_to_cases.py
+                ${QUINT_SRC_DIR}/generate_cases.sh
+        COMMENT "Generating RPC2 conformance cases from the Quint models"
+        VERBATIM)
+
+    add_custom_target(conformance_cases DEPENDS ${CONFORMANCE_CASES})
+
+    unit_test_rpc2(conformance conformance.x conformance.c gss_stub.c)
+    target_link_libraries(evpl_rpc2_conformance m)
+    target_sources(evpl_rpc2_conformance PRIVATE ${CONFORMANCE_CASES})
+
+    # The ERR_VERS check builds an RPC-over-RDMA transport header by hand, so
+    # it needs the rpcrdma1 codec.  Compiled into the test rather than linked
+    # from libevpl_rpc2 (which does not export it): a conformance test that
+    # encoded with the same code it is checking would pass on any pair of
+    # matching bugs.
+    # Generated code, so it gets the same exemptions unit_test_rpc2 applies to
+    # the XDR it generates itself.
+    set_source_files_properties(
+        ${CMAKE_CURRENT_BINARY_DIR}/../rpcrdma1_xdr.c PROPERTIES
+        COMPILE_OPTIONS "-Wno-unused;-Wno-format-truncation"
+    )
+
+    target_sources(evpl_rpc2_conformance PRIVATE
+                   ${CMAKE_CURRENT_BINARY_DIR}/../rpcrdma1_xdr.c)
+    target_include_directories(evpl_rpc2_conformance PRIVATE
+                               ${CMAKE_CURRENT_BINARY_DIR}/..)
+    target_include_directories(evpl_rpc2_conformance PRIVATE ${QUINT_WORK_DIR})
+
+    unit_test_rpc2_instance(conformance STREAM_SOCKET_TCP 8104)
+
+    # Also over RDMA-on-TCP: that transport needs no RDMA hardware or verbs but
+    # does carry the RPC-over-RDMA framing, so it reaches the chunk-negotiation
+    # and rdma_msg paths in rpc2.c that the stream transport never touches.  The
+    # raw-socket defect phase self-skips there (record marking is stream-only).
+    unit_test_rpc2_instance(conformance DATAGRAM_TCP_RDMA 8205)
+
+    # The same models over the name-addressed transports.  Neither contends for
+    # a port, so neither needs a network namespace or the shared lock: the
+    # socket name test_address() derives carries the pid and lives under the
+    # build tree, which is what makes these safe to run concurrently.
+    #
+    # AF_UNIX is a stream transport with a descriptor of its own, so it runs
+    # the raw-socket defect phase too -- record marking is a property of the
+    # framing, not of the address family, so the whole defect matrix applies.
+    unit_test_rpc2_instance_named(conformance STREAM_SOCKET_UNIX)
+
+    # Inproc, both ways round: DATAGRAM_INPROC reports RDMA and so exercises
+    # the chunk and rdma_msg paths with no hardware and none of TCP_RDMA's
+    # emulation in the way, while STREAM_INPROC covers the same models over
+    # rpc2's stream framing.  Neither has a descriptor the defect phase could
+    # write to, so both self-skip it.
+    unit_test_rpc2_instance_named(conformance DATAGRAM_INPROC)
+    unit_test_rpc2_instance_named(conformance STREAM_INPROC)
+
+    # Several hundred RPCs per run, plus a raw-socket defect matrix in which a
+    # few cases deliberately wait out a reply timeout -- more than the 10s the
+    # macro grants by default.
+    foreach(proto STREAM_SOCKET_TCP DATAGRAM_TCP_RDMA STREAM_SOCKET_UNIX
+            DATAGRAM_INPROC STREAM_INPROC)
+        foreach(mech ${EVPL_MECHANISMS})
+            set_tests_properties(libevpl/rpc2/conformance_${proto}_${mech}
+                                 PROPERTIES TIMEOUT 120)
+        endforeach()
+    endforeach()
+
+    # The models checking themselves: scenario tests plus a random-simulation
+    # pass against their invariants.  Separate from generation so that a broken
+    # specification is a failing test rather than a failing build.
+    add_test(NAME libevpl/rpc2/quint_model
+             COMMAND ${QUINT_SRC_DIR}/check_models.sh
+                     ${QUINT_EXECUTABLE} ${QUINT_SRC_DIR})
+    set_tests_properties(libevpl/rpc2/quint_model PROPERTIES
+                         LABELS "quint" TIMEOUT 120)
+
+    message(STATUS "RPC2 conformance test enabled (quint: ${QUINT_EXECUTABLE})")
+else()
+    message(STATUS
+        "RPC2 conformance test disabled (needs quint and python3 on PATH)")
+endif()

--- a/src/rpc2/tests/CMakeLists.txt
+++ b/src/rpc2/tests/CMakeLists.txt
@@ -218,6 +218,51 @@ if(QUINT_EXECUTABLE AND PYTHON3_EXECUTABLE)
         endforeach()
     endforeach()
 
+    # -----------------------------------------------------------------------
+    # The same idea inverted: a hostile server driving libevpl's *client*.
+    #
+    # conformance.c can only reach the client's outbound path, because the
+    # replies it sees come from a real libevpl server and are therefore always
+    # well formed.  conformance_client.c is a raw socket pretending to be a
+    # server, so the reply bytes are chosen by the test; its model and case
+    # table are separate from the server-side ones.
+    #
+    # It reuses hello_world.x unmodified -- the reply defects live in the RPC
+    # envelope and in the framing, so a one-procedure program reaches all of
+    # them and keeps the hand-built bytes readable.
+    # -----------------------------------------------------------------------
+
+    set(CLIENT_CASES ${QUINT_WORK_DIR}/client_cases.h)
+
+    add_custom_command(
+        OUTPUT ${CLIENT_CASES}
+        COMMAND ${QUINT_SRC_DIR}/generate_client_cases.sh
+                ${QUINT_EXECUTABLE} ${PYTHON3_EXECUTABLE}
+                ${QUINT_SRC_DIR} ${QUINT_WORK_DIR} ${CLIENT_CASES}
+        DEPENDS ${QUINT_SRC_DIR}/client.qnt
+                ${QUINT_SRC_DIR}/itf_to_client_cases.py
+                ${QUINT_SRC_DIR}/generate_client_cases.sh
+        COMMENT "Generating RPC2 client reply cases from the Quint model"
+        VERBATIM)
+
+    add_custom_target(client_cases DEPENDS ${CLIENT_CASES})
+
+    unit_test_rpc2(conformance_client hello_world.x conformance_client.c)
+    target_sources(evpl_rpc2_conformance_client PRIVATE ${CLIENT_CASES})
+    target_include_directories(evpl_rpc2_conformance_client
+                               PRIVATE ${QUINT_WORK_DIR})
+
+    unit_test_rpc2_instance(conformance_client STREAM_SOCKET_TCP 8106)
+
+    # A hundred cases, a handful of which deliberately wait out a reply
+    # deadline to prove no callback arrives -- more than the 10s the macro
+    # grants by default.
+    foreach(mech ${EVPL_MECHANISMS})
+        set_tests_properties(
+            libevpl/rpc2/conformance_client_STREAM_SOCKET_TCP_${mech}
+            PROPERTIES TIMEOUT 120)
+    endforeach()
+
     # The models checking themselves: scenario tests plus a random-simulation
     # pass against their invariants.  Separate from generation so that a broken
     # specification is a failing test rather than a failing build.
@@ -225,6 +270,20 @@ if(QUINT_EXECUTABLE AND PYTHON3_EXECUTABLE)
              COMMAND ${QUINT_SRC_DIR}/check_models.sh
                      ${QUINT_EXECUTABLE} ${QUINT_SRC_DIR})
     set_tests_properties(libevpl/rpc2/quint_model PROPERTIES
+                         LABELS "quint" TIMEOUT 120)
+
+    # The client model checks itself the same way.  Registered directly rather
+    # than through check_models.sh so that the server-side script stays the
+    # server-side script.
+    add_test(NAME libevpl/rpc2/quint_client_model
+             COMMAND ${QUINT_EXECUTABLE} test ${QUINT_SRC_DIR}/client.qnt)
+    set_tests_properties(libevpl/rpc2/quint_client_model PROPERTIES
+                         LABELS "quint" TIMEOUT 120)
+
+    add_test(NAME libevpl/rpc2/quint_client_invariants
+             COMMAND ${QUINT_EXECUTABLE} run ${QUINT_SRC_DIR}/client.qnt
+                     --invariant=safety --max-samples=500 --max-steps=50)
+    set_tests_properties(libevpl/rpc2/quint_client_invariants PROPERTIES
                          LABELS "quint" TIMEOUT 120)
 
     message(STATUS "RPC2 conformance test enabled (quint: ${QUINT_EXECUTABLE})")

--- a/src/rpc2/tests/CONFORMANCE.md
+++ b/src/rpc2/tests/CONFORMANCE.md
@@ -1,0 +1,426 @@
+<!--
+SPDX-FileCopyrightText: 2026 Ben Jarvis
+
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+# Model-based XDR/RPC2 conformance test
+
+`conformance.x` + `conformance.c` + `quint/` form a conformance suite for
+xdrzcc's generated code and libevpl's RPC2 layer. Formal models written in
+[Quint](https://quint-lang.org) enumerate the test cases; a generator turns
+them into a C table; the test binary replays them against a real RPC2 server.
+
+The cases are generated from the models at build time, so quint and python3
+are build dependencies for this test. CMake detects them; when either is
+missing the test is simply not registered and the rest of the suite is
+unaffected:
+
+```
+-- RPC2 conformance test enabled (quint: /usr/local/bin/quint)
+-- RPC2 conformance test disabled (needs quint and python3 on PATH)
+```
+
+Pass `-DQUINT_EXECUTABLE=OFF` to force it off. The devcontainer installs a
+pinned quint, so it is enabled there.
+
+```
+ctest -R libevpl/rpc2/conformance --output-on-failure
+ctest -R libevpl/rpc2/quint_model --output-on-failure   # the models' own tests
+```
+
+Nothing generated is checked in. The ITF traces and the case table are build
+artifacts under `<build>/src/rpc2/tests/quint/`, regenerated whenever a model,
+the converter or the generator script changes. Seeds are fixed, so a given
+quint release always yields the same cases; a different release may sample
+differently, which is why the devcontainer pins one.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `conformance.x` | An RPC program instantiating every XDR construct xdrzcc supports, in every container shape |
+| `quint/values.qnt` | Boundary-value classes per type; the positive matrix |
+| `quint/defects.qnt` | Wire-defect taxonomy and the outcome each RFC requires |
+| `quint/itf_to_cases.py` | ITF trace → C case table |
+| `quint/generate_cases.sh` | Build step: models → traces → case table |
+| `quint/check_models.sh` | The `quint_model` test: scenario tests + invariants |
+| `<build>/…/quint/conformance_cases.h` | **Generated**, not checked in |
+| `conformance.c` | The driver: server, round-trip client, raw-socket defect injector |
+
+## The two phases
+
+**Values** call each procedure through the generated libevpl client with
+boundary values (`INT32_MIN`, `UINT32_MAX`, NaN, `-0.0`, empty/one/unaligned/
+at-bound lengths, absent/present optionals, list depths) and compare the reply
+to the request. Every handler echoes, so round-trip identity is the oracle and
+no model prediction is needed. Floats are compared bitwise, since NaN is not
+equal to itself and `-0.0` must not compare equal to `0.0`.
+
+**Defects** are written straight onto a TCP socket, because libevpl's own
+client cannot express them: it hardcodes `rpcvers = 2`, derives the program and
+procedure from the program struct, and never emits more than one record
+fragment. Each reply is classified and compared against what RFC 5531 / RFC
+4506 require.
+
+### Checks that sit outside the two models
+
+Two things the harnesses assert are neither an XDR value class nor a wire
+defect, so they are held as small explicit tables in the drivers rather than
+being bent into a model that is not about them:
+
+- **Connection notifications** (`conformance.c`). The rpc2 thread's notify
+  callback is how an application learns that a connection appeared, and that
+  one it holds a pointer to has been freed. The driver registers one and checks
+  the notifications are coherent rather than merely present: every connection
+  is announced before it is reported gone and only once each, accepts match the
+  connections the driver actually dialled, and the connection reported as
+  unaccepted is the one `evpl_rpc2_client_connect` returned.
+- **Outbound AUTH_SYS credentials** (`conformance_client.c`). The encode
+  direction, checked against the RFC's own byte layout rather than against
+  libevpl's decoder — sending the credential to a real server and asking what
+  it decoded would test the two halves against each other, where a pair of
+  mutually consistent bugs passes. The machine names cover all four XDR padding
+  residues and the group lists cover both ends of the declared `gids<16>`.
+
+`defects.qnt` deliberately encodes the **specification**, not libevpl's current
+behaviour. Encoding the latter would freeze today's bugs into the spec and
+guarantee the suite never finds them. Divergences are therefore expected; each
+reviewed one is listed in `known_divergences[]` in `conformance.c` with a note,
+which keeps the suite green while leaving the gaps visible and counted. An
+unlisted divergence fails the test.
+
+## Divergences found, and fixed
+
+The divergences below have all been fixed, so any recurrence fails the test.
+The table records what was wrong, since the fixes are spread across three
+repositories.  For the ones still outstanding, see "Divergences currently
+recorded".
+
+| What the RFC requires | What libevpl did | Fix |
+|---|---|---|
+| `PROG_MISMATCH` carries the supported version range | 8 bytes of uninitialised stack (observed `[64860, 2820603906]`) | `rpc2.c` now records the exported range on the request and fills `mismatch_info` |
+| Unexported program → `PROG_UNAVAIL` | `PROG_MISMATCH` | the program scan now distinguishes "not exported" from "exported at other versions", and reports the real range for the latter |
+| Procedure 0 is NULL and always succeeds (RFC 5531 §11.1) | `PROC_UNAVAIL` | xdrzcc generates a NULL procedure unless the `.x` declares proc 0 itself |
+| Undecodable credential → `AUTH_ERROR` | connection closed, no reply | the xid and mtype sit at fixed offsets ahead of the credential, so a CALL whose header fails to decode is now answered `AUTH_BADCRED` |
+| Oversized record mark → connection closed | stalled, buffering indefinitely | the `length < 0` guard ran after a comparison that promoted it to unsigned; reordered in all four transports, and the framing layer now refuses an oversized mark outright |
+| `bool` outside `{0,1}`, enum outside its declared set → `GARBAGE_ARGS` | accepted | the bool decoder rejects values above 1; generated decoders emit a domain check listing the declared enum values |
+| A returned Write chunk carries the length actually written (RFC 8166 §4.3.2) | the requester ignored the returned Write list and reported the length it had *advertised*, so every directly-placed result came back exactly `max_rdma_write_chunk` bytes long | the REPLY path now sums the returned segment lengths into `write_chunk.length` before the results are decoded |
+| A Responder may leave a Write chunk unused (RFC 8166 §3.4.6) | the requester assumed the decoder had taken the chunk and cleared it unconditionally, so a chunk libevpl had allocated and nobody claimed leaked one buffer reference per call | the chunk is released when it comes back empty, or when the reply carried no results to decode; a caller-supplied (borrowed) buffer is still never touched |
+| A Reply chunk too small for the Reply → `RDMA_ERROR` / `ERR_CHUNK` (RFC 8166 §4.5) | the per-segment capping loop silently dropped the overflow and announced a Reply short by exactly that much | the Reply chunk is now left unused and the Reply goes inline when it does not fit; `RDMA_ERROR` is still not implemented, which is the remaining gap |
+| A Requester provides a Reply chunk for a Reply that may not fit inline (RFC 8166 §4.3.3) | `evpl_rpc2_call` took `max_rdma_reply_chunk` and ignored it, so no Reply chunk ever reached the wire and the whole `RDMA_NOMSG` half of the protocol was dead on both sides | the call advertises the chunk, and `evpl_rpc2_recv_msg` consumes an `RDMA_NOMSG` reply out of it |
+
+Also addressed:
+
+- **Maximum RPC message size.** A record mark is unauthenticated input, and
+  the transport previously buffered whatever it claimed. `rpc2.c` now caps a
+  message at 4 MiB across all fragments, refusing an oversized frame at the
+  framing layer before anything is allocated for it.
+  `evpl_global_config_set_rpc2_max_message_size()` adjusts it. Two cases hold
+  that down: `RecordMarkHuge` refuses a single oversized mark on sight, and
+  `ReassemblyCapExceeded` walks the running total past the cap using fragments
+  that are each individually legal — the only thing that can stop the second
+  is a receiver counting across the fragments of one record. Because the
+  driver lowers the cap for its own run (`CONF_MAX_MESSAGE_SIZE`, 64 KiB, read
+  from the config on every fragment exactly as the default is), that case costs
+  tens of kilobytes rather than megabytes.
+- **Declared bounds are enforced, on all three shapes.** `opaque<N>` had the
+  bound plumbed through the runtime and ignored; counted arrays never checked
+  theirs; `string<N>` never even had its bound reach the decoder, because
+  codegen tested the string branch before the vector branch and dropped it. All
+  three now reject an over-bound length before it is used to alias or size an
+  allocation. The over-bound cases in the suite supply the bytes their length
+  claims, so the message stays perfectly well formed apart from exceeding the
+  bound — otherwise the whole-message length check would reject them anyway and
+  the cases would pass whether or not the bound were enforced. Disabling the
+  checks makes the suite report `SUCCESS` where `GARBAGE_ARGS` is required,
+  which is what an over-bound payload used to do.
+- **A 32-bit overflow bypassed the contig bounds check.** `iov_offset + len +
+  pad` was computed entirely in 32-bit unsigned arithmetic, so a length near
+  `UINT32_MAX` made `len + pad` wrap to a small value, the comparison succeed,
+  and the decoder hand back a pointer with a multi-gigabyte length into a
+  receive buffer. Reachable straight off the wire, ahead of any
+  authentication — an AUTH_SYS `machinename` is enough. The three affected
+  checks (string, opaque, fixed-opaque) now compute in 64 bits.
+- **`-Wno-switch` is gone.** xdrzcc emits a `default` arm for a union that
+  declares none, so generated code is `-Wswitch`-clean; the exemptions in
+  libevpl's test macro and in chimera's `nfs_common` were both removed. The
+  synthetic arm is deliberately inert rather than a decode failure: NFSv4 must
+  answer an unknown operation with `OP_ILLEGAL` rather than rejecting the whole
+  COMPOUND, and `nfs_argop4` is exactly such a union. Malformed input is still
+  caught, because the arm consumes nothing and the message-length check rejects
+  it.
+- **A zero-copy send dropped the caller's references.** `__marshall_opaque_zerocopy`
+  stopped its move loop on `length`, so a `zcopaque` handed over with no bytes
+  left its references stranded — unreachable to the sender, which had given up
+  ownership, and unknown to the send path. One buffer reference leaked per
+  message. The loop now takes every iovec it was given.
+
+The ownership rules that made that last one hard to see are worth stating,
+since neither is documented: for `zcopaque` the marshaller **moves** the
+caller's references (`xdr_iovec_move_private`) while the unmarshaller
+**clones** (`xdr_iovec_copy_private`). A sender must therefore not release what
+it handed over, and a receiver must release what it decoded — on replies as
+much as on calls, and even when the payload is empty, since the decoder returns
+one iovec regardless. Getting this backwards corrupts the allocator free list
+into a cycle, which surfaces as a hang in `evpl_allocator_destroy` at exit
+rather than an obvious double free.
+
+`evpl_create()` also takes ownership of the `evpl_thread_config` passed to it
+and releases it itself; this is intentional and is noted here only because
+releasing it in the caller is a double free.
+
+## Divergences currently recorded
+
+Five, all RPCSEC_GSS, all found by widening the model over the failure exits of
+the GSS state machine.  Each is listed in `known_divergences[]` with the RFC
+text it contradicts; removing an entry turns its case back into a hard failure,
+which is what should happen when the underlying issue is fixed.
+
+| What the RFC requires | What libevpl does |
+|---|---|
+| `seq_num` above `MAXSEQ` → reject with `RPCSEC_GSS_CTXPROBLEM` (RFC 2203 §5.3.3.3) | discarded in silence, like a replay; the client is never told to refresh and retries until it times out |
+| krb5i results that cannot be signed → send no response at all (RFC 2203 §5.3.3.4.1) | the results are returned **unwrapped** under MSG_ACCEPTED/SUCCESS, so an integrity-protected call completes with unauthenticated results |
+| an undecodable `rpc_gss_init_arg` is undecodable *arguments* → `GARBAGE_ARGS` (RFC 5531 §9), and §5.2.3.2 rules out both RPCSEC_GSS auth_stat values on a creation response | denied with `RPCSEC_GSS_CTXPROBLEM`, which tells the client to rebuild a context over what is really a malformed request |
+
+The unsigned-reply one is the serious one: `evpl_rpc2_send_reply` treats a
+failed `evpl_rpc2_gss_wrap_reply_integrity` as advisory and falls through with
+the bare body.  The comment there argues the client will notice, but that makes
+correctness depend on the peer, and a client that does notice cannot tell it
+apart from an attacker having stripped the wrapping.
+
+Everything else in the matrix matches the model on its own merits.  Getting
+there took nine fixes to `rpc2.c`, all of them found by these models and all
+confirmed against the RFC before being changed.  The four RPC-over-RDMA ones
+are in the table above; the rest are below:
+
+### Server side, RPCSEC_GSS
+
+- **An unauthenticated peer could destroy another client's security context.**
+  The `RPCSEC_GSS_DESTROY` arm looked up the handle and retired the context
+  before any verification, returning ahead of the header-MIC check that only
+  the DATA arm performed -- so neither the verifier nor the sequence number was
+  checked, and handles are allocated sequentially and therefore enumerable.
+  RFC 2203 sec 5.4 requires both checks.  DESTROY now shares the DATA path and
+  is acted on only after the context, the header MIC and the sequence number
+  have all been verified.
+
+- **Integrity failures over the call arguments were reported as AUTH_ERROR.**
+  RFC 2203 sec 5.3.3.4.2 separates the two cases: a bad *header* verifier means
+  the caller is not authenticated (MSG_DENIED), while a bad checksum over the
+  *arguments* means the caller is known but its arguments are unusable
+  (MSG_ACCEPTED / GARBAGE_ARGS).  Both answered MSG_DENIED with
+  RPCSEC_GSS_CTXPROBLEM, which makes a client tear down and re-establish a
+  context that was fine.  The argument path now answers GARBAGE_ARGS.
+
+- **A databody `seq_num` mismatch shared that fate**, since it exits through the
+  same path (RFC 2203 sec 5.3.2.2); the same fix covers it.
+
+### Client side
+
+- **The client never inspected the reply status, so a refusal arrived as a
+  success.**  `evpl_rpc2_recv_msg` switched on `mtype` alone -- `reply_stat` and
+  `accept_stat` were read nowhere on the receive path.  A `MSG_DENIED`, a
+  non-SUCCESS `accept_stat`, or an undefined `reply_stat` fell through to the
+  results decoder, so a refusal with a decodable body attached reached the
+  caller as status 0 carrying the refuser's values.  The reply status is now
+  inspected first: results are decoded only for MSG_ACCEPTED/SUCCESS, an
+  accept_stat is passed through as a positive status, and anything else
+  completes the call with `EVPL_RPC2_REPLY_DENIED`.
+
+- **Losing the connection lost the callbacks.**  The
+  `EVPL_NOTIFY_DISCONNECTED` arm freed every entry of `conn->pending_calls`
+  without invoking one callback, leaving each caller waiting on a completion
+  that could no longer arrive.  Pending calls are now completed with
+  `EVPL_RPC2_REPLY_CONN_LOST`.
+
+Delivering a status with no body to decode needed one supporting change: the
+xdrzcc-generated `recv_reply_dispatch` gained a `status` parameter, so a call
+can be completed without unmarshalling results that are not there.  Fixing this
+also exposed a latent fault in the client harness itself -- it kept per-call
+state on the stack frame of the case that started the call, which is only safe
+while abandoned calls never complete.  That state is now heap-allocated.
+
+## Open items parked along the way
+
+Recorded here rather than fixed, so they are not lost.  Nothing in this list
+currently makes the suite red.
+
+### Sharp edges (API/documentation, not defects)
+
+- **zcopaque ownership depends on how the payload arrived, and the decoded
+  value does not say which.**  Decoded inline, an `xdr_iovecr` holds clones the
+  receiver owns and must release (`xdr_iovec_copy_private`).  Decoded from an
+  RDMA read chunk, `__unmarshall_opaque_zerocopy_*` short-circuits to
+  `v->iov = chunk->iov` (xdr_builtin.c:1142) and the iovecs belong to the
+  request, which releases them at teardown.  So the same handler code
+  double-frees on one transport and leaks on the other.
+
+  The fix is to call `evpl_rpc2_encoding_take_read_chunk()` unconditionally
+  before using the payload: a no-op on a stream transport, an ownership
+  transfer on RDMA.  That requirement is currently discoverable only by reading
+  `rdma_ddp.c:155` or chimera's `nfs3_proc_write.c:138` -- it is not stated on
+  the `xdr_iovecr` type or in `evpl_rpc2_program.h`, and getting it wrong
+  presents as a hang in `evpl_allocator_destroy` at exit rather than as an
+  obvious fault.  Worth a comment at the definition.
+
+  Receiving a zcopaque *reply* as a client has the mirror-image split, and the
+  decoded value does not say which side of it you are on either.  Decoded
+  inline the iovecs are clones the client owns and must release.  Decoded out
+  of a Write chunk that the client supplied the buffer for (the `write_chunk_iov`
+  read-into form), they alias that buffer: no reference was taken anywhere
+  along the path, the caller still holds the one it allocated, and releasing
+  from the callback as well is a double free.  Where libevpl allocated the
+  chunk itself the client owns them again.  So the rule is "release unless you
+  supplied the buffer", and `conformance.c`'s `owns_reply_payload` is exactly
+  that predicate.
+
+- **A zero-length zcopaque used to hand back an iovec describing no bytes.**
+  Fixed here (the decoders now report `niov == 0`), but the same asymmetry is
+  what made it hard to see: the reference existed but nothing could reach it.
+
+### Unverified, from reading rather than from a failing test
+
+These came out of tracing rpc2.c and have not been reproduced, so treat them
+as leads rather than findings:
+
+- `evpl_rpc2_recv_msg` calls `abort()` when an RDMA chunk list carries too many
+  segments (around rpc2.c:2335 and :2350).  Unauthenticated input reaching an
+  abort is worth a defect case; the model would state that a malformed chunk
+  list must be answered or the connection dropped, never aborted.
+- The record-mark peek reads four bytes assuming `iovec[0]` holds them
+  contiguously.  Where a record boundary lands within four bytes of a receive
+  buffer boundary this would read stale bytes and trip an abort.
+- `evpl_iovec_ring_copyv` writes into an `alloca`'d array sized by
+  `config->max_num_iovec` with no cap on the incoming count.
+- `xdr_string.str` is not NUL-terminated on the vector (multi-iovec)
+  unmarshalling path: `xdr_dbuf_alloc_string` allocates exactly `len` bytes.
+  `hello_world.c` calls `strcmp` on a decoded string and passes only because
+  the contiguous path happens to leave the sender's zero padding in place --
+  which means the same handler reads past the end once a string arrives split
+  across iovecs.  Either the allocation should reserve the extra byte or the
+  field should be documented as counted-not-terminated.
+
+### Top remaining coverage gap in rpc2.c
+
+Every function is now reached.  What is left cold in the chunk paths is either
+defensive or needs input the harnesses cannot produce:
+
+- The `evpl_rpc2_abort` arms guarding `evpl_rpc2_iovec_cursor_move` failure.
+  Unreachable by construction -- the cursor is initialised over the very iovecs
+  it is then asked to walk.
+- The zero-length-target `continue` in the reply-chunk write loop, and the
+  multi-segment arithmetic generally.  libevpl's requester always advertises a
+  single segment per chunk, so a second target never exists.  Reaching it needs
+  either a multi-segment requester or a hand-built RPC-over-RDMA peer.
+- `evpl_rpc2_take_reply_chunk`'s two rejection arms (unknown xid, a Responder
+  claiming more bytes than it was given).  Both need a hostile RDMA peer; the
+  raw-socket defect phase cannot express RPC-over-RDMA framing, which is the
+  same reason phase 2 is TCP-only.
+- The AUTH_SYS branches of the RDMA read-chunk path (`ctx_authsys`).  The value
+  phase calls with AUTH_NONE throughout, so a credential-flavour dimension in
+  `values.qnt` would be needed to combine AUTH_SYS with direct placement.
+- `prometheus_time_histogram_sample` in the reply path and the
+  `reply_capture_cb` hook.  Neither is chunk-related.
+
+The RPCSEC_GSS block is worked out: `evpl_rpc2_gss_seq_check`,
+`evpl_rpc2_gss_handle_call`, `evpl_rpc2_gss_rd_u32`, `evpl_rpc2_gss_rd_opaque`
+and `evpl_rpc2_gss_decode_cred` are at 100% of lines, and the rest sit above
+79%.  What remains cold there is not reachable from the wire, and is recorded
+here so it is not chased again:
+
+- Allocator and `evpl_iovec_alloc` failure returns in `..._unwrap_integrity`
+  and `..._wrap_reply_integrity`, and the `evpl_rpc2_abort` in
+  `..._send_init_res`.
+- The bounds-check failures in `evpl_rpc2_gss_wr_u32` and `..._wr_opaque`.
+  Every caller either passes an `end` exactly the size of what it is about to
+  write, or a buffer sized from the same arithmetic, so the checks can only
+  fire if that arithmetic is changed.
+- The `db_pad > db_len` padding branch in `..._wrap_reply_integrity`.  XDR
+  encodings are always a multiple of four, so the databody is too, and the
+  padding is always empty.
+- `if (evpl_rpc2_gss_rd_u32(&lp, lenbuf + 4, ...))` in `..._handle_init`:
+  `lenbuf` is exactly the four bytes being read, so the cursor cannot overrun.
+  Likewise the token gather immediately after it, which has already been
+  bounds-checked against `request_length`.
+- The `!thread->gss_provider` arm of `..._handle_init`.  Its caller,
+  `..._handle_call`, makes the same check first and returns, so this one is
+  unreachable duplicate defence -- the `GssNoMechanism` cases cover the check
+  that does the work.
+
+### Ready to re-enable
+
+### RPC-over-RDMA chunk coverage
+
+`values.qnt`'s `ChunkCls` drives every chunk shape rpc2.c distinguishes:
+
+| Class | What it exercises |
+|---|---|
+| `ChunkNone` | inline, no direct placement |
+| `ChunkDdp` | a Read chunk: the call's payload placed by the Responder |
+| `ChunkReply` | a Reply chunk: the whole Reply placed as `RDMA_NOMSG` |
+| `ChunkReadInto` | a Write chunk into a caller-owned buffer |
+| `ChunkWriteAlloc` | a Write chunk into a buffer libevpl allocates |
+| `ChunkWriteExact` | a Write chunk sized exactly to the result |
+
+The last three are confined to `ECHO_ZBYTES` by the
+`writeChunkOnlyWhereItApplies` invariant, since a Write chunk is storage for a
+DDP-eligible *result* and that is the only reply carrying one -- offered
+anywhere else it would go unused and the case would be quietly testing the
+inline path.  The split between the three is the ownership question rpc2.c
+branches on, and the two directions of getting it wrong are a leak and a double
+free.  `ChunkWriteExact` is the at-bound class for chunk sizing: it is the only
+one where a segment is consumed to its last byte rather than capped short.
+
+They are inert on the stream transport (rpc2.c gates all of it on
+`conn->rdma`), so the one case table is meaningful on both, and the suite runs
+it over `STREAM_SOCKET_TCP` and `DATAGRAM_TCP_RDMA` alike.
+
+The oracle for `ECHO_ZBYTES` compares the payload bytes, not just its length.
+That matters once placement is by RDMA: the length arrives in the transport
+header's Write list while the bytes are written straight into the destination
+buffer, so a payload placed at the wrong offset, truncated, or never written at
+all still reports the right length.
+
+## What the suite does not cover
+
+- **A defect aimed at the RPC header itself.** The overflow described above is
+  fixed, but the suite reaches it only through procedure arguments. A case that
+  puts a hostile length in an AUTH_SYS `machinename` would exercise it on the
+  header path, which needs no valid program, version or procedure — worth
+  adding to `defects.qnt`, and worth running under ASan.
+- Concurrency: pipelined calls, out-of-order replies, duplicate xids.
+- **Defects aimed at the RPC-over-RDMA framing.** Phase 2 is TCP-only because
+  record marking does not exist on the RDMA transports, and the raw-socket
+  injector speaks record marks rather than `rdma_msg`. A chunk list with more
+  segments than rpc2.c's fixed arrays hold still reaches an `abort()`
+  (rpc2.c around the `write_segments` / `reply_segments` bounds checks), and a
+  Responder that over-reports what it wrote into a Reply chunk is rejected by
+  code no test executes. Both want a hand-built RPC-over-RDMA peer, which is
+  the natural next phase.
+- **`RDMA_ERROR`.** libevpl neither sends nor decodes it, so the RFC 8166 §4.5
+  error path -- a chunk too small, an unsupported version -- has no
+  representation. A Reply too large for the offered Reply chunk is answered
+  inline instead, which is safe but is not what the RFC asks for.
+- **A Reply chunk larger than one segment.** The requester advertises exactly
+  one, so the multi-segment distribution loop in the responder runs a single
+  iteration whatever the reply size.
+- xdrzcc's **frontend**: constructs it mis-compiles rather than rejects cannot
+  be tested from here, because the compiler never emits the thing under test.
+  Those need compile-time tests in `ext/xdrzcc/tests`. Known cases, documented
+  in the header comment of `conformance.x`: `hyper`/`quadruple` unsupported,
+  negative constants silently parsed as positive, `case 1:` rejected, `string`
+  inside an array silently losing its shape, and a typedef re-decorated at the
+  use site silently dropping the modifier (which changes the wire format —
+  chimera already works around this in `nfs4.x`).
+
+## Regenerating
+
+```sh
+cd quint && ./regen_cases.sh    # needs quint (or npx) and python3
+```
+
+The script runs each model's own tests and invariant check first, so a broken
+model cannot silently mint a broken-but-green suite. It de-duplicates cases on
+the fields each procedure actually reads, so the case count reflects distinct
+wire messages rather than distinct model states.

--- a/src/rpc2/tests/conformance.c
+++ b/src/rpc2/tests/conformance.c
@@ -1,0 +1,3882 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Ben Jarvis
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Model-based XDR/RPC2 conformance test.
+ *
+ * Two phases, both driven by cases generated from the Quint models in
+ * quint/ and compiled in as conformance_cases.h:
+ *
+ *   1. Values.  Every procedure of CONFORMANCE_PROGRAM (conformance.x) is
+ *      called through the generated libevpl client with boundary values for
+ *      each field, and the reply is compared to the request.  Every handler
+ *      echoes, so round-trip identity is the oracle -- no model prediction is
+ *      needed, and both the marshall and unmarshall paths of every generated
+ *      codec are exercised in both directions.
+ *
+ *   2. Defects.  Deliberately malformed calls are written straight onto a TCP
+ *      socket, bypassing libevpl's client (which cannot produce a bad RPC
+ *      version, a bogus record mark, or an unknown program).  The reply is
+ *      classified and compared against the outcome RFC 5531 / RFC 4506
+ *      require.
+ *
+ * The defect model encodes the SPECIFICATION, so a mismatch here is a
+ * candidate bug in libevpl rather than a broken test.  Known, reviewed
+ * divergences are listed in known_divergences[] with a note; anything not on
+ * that list fails the test.  That way the suite stays green while the
+ * outstanding gaps stay visible and counted.
+ *
+ * Phase 2 is TCP-only: record marking does not exist on the RDMA transports.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <math.h>
+#include <errno.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/un.h>
+#include <stddef.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_rpc2.h"
+
+/* Generated from rpcrdma1.x alongside rpc2 itself.  Needed here because the
+ * ERR_VERS check builds an RPC-over-RDMA transport header by hand -- the one
+ * thing libevpl's own client will never do. */
+#include "rpcrdma1_xdr.h"
+
+#include "core/test_log.h"
+#include "test_common.h"
+
+#include "gss_stub.h"
+#include "evpl/evpl_rpc2_gss.h"
+
+#include "conformance_xdr.h"
+#include "conformance_cases.h"
+
+static enum evpl_protocol_id    proto = EVPL_STREAM_SOCKET_TCP;
+/* The effective address for this run: a host for IP, a socket name for a
+ * name-addressed transport.  Resolved once from test_address(). */
+static const char              *g_address = "0.0.0.0";
+static int                      port      = 8000;
+
+/* The rpc2 thread the server runs on.  Only the RPCSEC_GSS cases need it, and
+ * only to reconfigure the mechanism mid-run: a server with no GSS provider is
+ * a state the defect matrix has to be able to reach, and registering one is a
+ * per-thread setting rather than something a call can carry. */
+static struct evpl_rpc2_thread *g_thread;
+
+#define CONF_PROG             44
+#define CONF_VERS             1
+
+/* Procedure numbers, from conformance.x. */
+#define PROC_ECHO_SCALARS     1
+#define PROC_ECHO_BYTES       2
+#define PROC_ECHO_ZBYTES      3
+#define PROC_ECHO_ARRAYS      4
+#define PROC_ECHO_UNION       5
+#define PROC_PROBE_STRICT     6
+#define PROC_ECHO_OPTIONAL    7
+#define PROC_ECHO_LIST        8
+#define PROC_ECHO_NESTED      9
+
+/* Outcomes the driver can observe that the model has no name for. */
+#define ACT_STALLED           100 /* no reply and no close before the deadline */
+#define ACT_MALFORMED         101 /* reply was not a decodable RPC reply       */
+#define ACT_SYSTEM_ERR        102
+#define ACT_BADRANGE          103 /* right reply, wrong supported-version range */
+
+/* Wall-clock budget for one raw-socket exchange.  Loopback replies land in
+ * microseconds, so anything approaching this is a server that has stopped
+ * making progress -- which is exactly what the record-mark cases look for.
+ * Kept small because several cases are expected to hit it. */
+#define REPLY_TIMEOUT_MS      300
+
+/*
+ * Cap on one reassembled RPC message, lowered for the whole run from
+ * libevpl's 4 MiB default.
+ *
+ * The ReassemblyCapExceeded case has to carry a record's running total past
+ * the cap using fragments that are each individually legal, which at the
+ * default would mean pushing 4 MiB across loopback to learn one bit.  The cap
+ * is read from the global config on every fragment, so lowering it tests
+ * exactly the same code for a few tens of kilobytes.  It stays an order of
+ * magnitude above the largest message anything else here builds -- the
+ * pathological-fragmentation case, a little over 2 KiB -- so no other case
+ * can tell the difference.
+ */
+#define CONF_MAX_MESSAGE_SIZE (64 * 1024)
+
+/*
+ * test_evpl_config() plus that one knob.  evpl_init consumes the global
+ * config and there is no way to revise it afterwards, so the value has to be
+ * chosen once, here, on behalf of every phase.
+ */
+static void
+conformance_evpl_config(void)
+{
+    struct evpl_global_config *config = evpl_global_config_init();
+
+    evpl_global_config_set_tls_verify_peer(config, 0);
+    evpl_global_config_set_rpc2_max_message_size(config, CONF_MAX_MESSAGE_SIZE);
+
+    test_evpl_set_core_mech(config);
+
+    evpl_init(config);
+} /* conformance_evpl_config */
+
+/* ------------------------------------------------------------------ *
+* Shared state
+* ------------------------------------------------------------------ */
+
+struct server_ctx {
+    struct CONFORMANCE_V1 prog;
+};
+
+struct results {
+    int value_run;
+    int value_failed;
+    int defect_run;
+    int defect_skipped;
+    int defect_matched;
+    int defect_known;
+    int defect_unknown;
+    int rdma_error_checks;
+    int value_chunked;
+    int rdma_capable;
+};
+
+static struct results g_results;
+
+/* Deterministic filler for strings, opaques and array elements. */
+#define MAX_PAYLOAD          1024
+static uint8_t        g_pattern[MAX_PAYLOAD];
+
+/*
+ * ReassemblyCapExceeded: how the running total is walked past the cap.
+ *
+ * Each fragment is far below the per-fragment limit, so none of them is
+ * refusable on its own -- only a receiver that counts across the fragments of
+ * one record can stop this, which is exactly the check under test.  The
+ * fragment count is a ceiling on how many it can take: every fragment adds
+ * its full length, so the total is past the cap after
+ * CONF_MAX_MESSAGE_SIZE / REASM_FLOOD_FRAG_LEN of them at the very latest,
+ * and the spare two absorb the short leading fragment and the one that
+ * finally crosses.  This buffer is never parsed by anything -- the record is
+ * refused on its length -- but it is filled with the same pattern as
+ * everything else rather than left zeroed, so that a receiver which somehow
+ * did parse it would not be being handed a convenient string of NULs.
+ */
+#define REASM_FLOOD_FRAG_LEN 4096
+#define REASM_FLOOD_FRAGS \
+        ((CONF_MAX_MESSAGE_SIZE / REASM_FLOOD_FRAG_LEN) + 2)
+
+static uint8_t           g_reasm_filler[REASM_FLOOD_FRAG_LEN];
+
+/* Destination buffer armed for the read-into case.  Ownership is the mirror
+ * image of an ordinary reply: libevpl borrows this buffer rather than taking
+ * it, so the reply's iovecs point straight at it and the callback must NOT
+ * release them -- the single reference is ours and is dropped once, here,
+ * after the call completes. */
+static struct evpl_iovec g_chunk_dest;
+static int               g_chunk_dest_held;
+
+static void
+pattern_init(void)
+{
+    unsigned int i;
+
+    for (i = 0; i < MAX_PAYLOAD; i++) {
+        g_pattern[i] = (uint8_t) (i * 7 + 13);
+    }
+    for (i = 0; i < sizeof(g_reasm_filler); i++) {
+        g_reasm_filler[i] = g_pattern[i % MAX_PAYLOAD];
+    }
+} /* pattern_init */
+
+/* ------------------------------------------------------------------ *
+* Known divergences from the specification
+*
+* Each entry records a case where libevpl's behaviour differs from what the
+* model requires, so the suite can stay green while the gap remains visible.
+* Removing an entry turns the corresponding case back into a hard failure,
+* which is what should happen once the underlying issue is fixed.
+* ------------------------------------------------------------------ */
+
+struct known_divergence {
+    int         defect;   /* DEF_* */
+    int         expect;   /* EXP_*, what the RFC requires */
+    int         actual;   /* EXP_ or ACT_ code: what libevpl does today */
+    const char *note;
+};
+
+/* Connections the driver dialled itself, raw or through the rpc2 client.  The
+* server must announce exactly this many accepts -- see conformance_notify. */
+static int                           g_connections_opened;
+
+static const struct known_divergence known_divergences[] = {
+    /* Add an entry here only for a divergence that has been reviewed and
+     * consciously deferred, with a note saying why -- an unlisted one fails
+     * the test, which is what keeps a regression from passing silently.
+     *
+     * The unmatchable first row keeps the array non-empty when every real
+     * entry has been retired, which is the state to aim for. */
+    { .defect = -1,
+      .expect = -1,
+      .actual = -1,
+      .note   = NULL },
+
+    /* RFC 2203 sec 5.3.3.3: "When the client's sequence number exceeds the
+     * maximum the server will allow, the server will reject the request with
+     * the reason RPCSEC_GSS_CTXPROBLEM."  This is the one sequence-number
+     * outcome the RFC asks for an answer to; the others (below the window, or
+     * already seen) are the silent discards sec 5.3.3.1 describes.  libevpl
+     * folds all three together in evpl_rpc2_gss_seq_check, which returns -1
+     * for seq > RPCSEC_GSS_MAXSEQ and leaves the caller to drop the request
+     * without a reply.  A client that walks its seq_num past MAXSEQ therefore
+     * gets silence instead of the CTXPROBLEM that would tell it to refresh the
+     * context, and retries until it times out. */
+    { .defect = DEF_GSSSEQABOVEMAX,
+      .expect = EXP_AUTHERROR,
+      .actual = EXP_NOREPLY,
+      .note   = "seq_num above MAXSEQ is discarded rather than rejected" },
+
+    /* RFC 2203 sec 5.3.3.4.1: "When GSS_GetMIC() is called to sign the call
+     * results (service is rpc_gss_svc_integrity), a failure results in no RPC
+     * response being sent."  libevpl's evpl_rpc2_send_reply treats a failed
+     * evpl_rpc2_gss_wrap_reply_integrity as advisory and falls through with
+     * the *unwrapped* body, so the client receives MSG_ACCEPTED/SUCCESS whose
+     * results are bare procedure results with no rpc_gss_integ_data around
+     * them.  The comment there argues that the client will reject the missing
+     * integrity, but that makes correctness depend on the peer noticing, and a
+     * client that does notice cannot tell this apart from an attacker having
+     * stripped the wrapping.  Both entries are the same code path reached two
+     * ways: a mechanism that will not sign, and one that returns a signature
+     * too large for the 512-byte checksum headroom. */
+    { .defect = DEF_GSSINTEGREPLYMICFAILS,
+      .expect = EXP_NOREPLY,
+      .actual = EXP_SUCCESS,
+      .note   = "unsignable krb5i results are returned unwrapped, not dropped" },
+    { .defect = DEF_GSSINTEGREPLYMICOVERSIZE,
+      .expect = EXP_NOREPLY,
+      .actual = EXP_SUCCESS,
+      .note   = "oversized krb5i MIC returns unwrapped results, not a drop" },
+
+    /* The GSS token of a context-creation call travels in the call ARGUMENTS
+     * (rpc_gss_init_arg, RFC 2203 sec 5.2.2), so a token that will not decode
+     * is undecodable arguments: GARBAGE_ARGS, per RFC 5531 sec 9 and the same
+     * reasoning sec 5.3.3.4.2 applies to the integrity service's arguments.
+     * libevpl denies instead, and specifically with the one auth_stat that RFC
+     * 2203 sec 5.2.3.2 rules out here: "neither of these two
+     * [RPCSEC_GSS_CREDPROBLEM and RPCSEC_GSS_CTXPROBLEM] can be returned in
+     * responses to context creation requests."  The practical cost is that a
+     * client seeing CTXPROBLEM is being told to tear down and rebuild a
+     * context over what is really a malformed request. */
+    { .defect = DEF_GSSINITTOKENMALFORMED,
+      .expect = EXP_GARBAGEARGS,
+      .actual = EXP_AUTHERROR,
+      .note   = "undecodable init token denied, not GARBAGE_ARGS" },
+    { .defect = DEF_GSSCONTINUEINITTOKENMALFORMED,
+      .expect = EXP_GARBAGEARGS,
+      .actual = EXP_AUTHERROR,
+      .note   = "undecodable continue-init token denied, not GARBAGE_ARGS" },
+};
+
+static const char *
+outcome_name(int o)
+{
+    switch (o) {
+        case EXP_SUCCESS:      return "SUCCESS";
+        case EXP_PROGUNAVAIL:  return "PROG_UNAVAIL";
+        case EXP_PROGMISMATCH: return "PROG_MISMATCH";
+        case EXP_PROCUNAVAIL:  return "PROC_UNAVAIL";
+        case EXP_GARBAGEARGS:  return "GARBAGE_ARGS";
+        case EXP_RPCMISMATCH:  return "RPC_MISMATCH";
+        case EXP_AUTHERROR:    return "AUTH_ERROR";
+        case EXP_CLOSED:       return "CONN_CLOSED";
+        case EXP_NOREPLY:      return "NO_REPLY";
+        case ACT_STALLED:      return "STALLED";
+        case ACT_MALFORMED:    return "MALFORMED_REPLY";
+        case ACT_SYSTEM_ERR:   return "SYSTEM_ERR";
+        case ACT_BADRANGE:     return "BAD_VERSION_RANGE";
+        default:               return "?";
+    } /* switch */
+} /* outcome_name */
+
+static const char *
+defect_name(int d)
+{
+    switch (d) {
+        case DEF_NODEFECT:                return "NoDefect";
+        case DEF_RPCVERSWRONG:            return "RpcVersWrong";
+        case DEF_PROGRAMUNKNOWN:          return "ProgramUnknown";
+        case DEF_VERSIONUNSUPPORTED:      return "VersionUnsupported";
+        case DEF_PROCEDUREUNKNOWN:        return "ProcedureUnknown";
+        case DEF_PROCEDURENULL:           return "ProcedureNull";
+        case DEF_AUTHFLAVORUNSUPPORTED:   return "AuthFlavorUnsupported";
+        case DEF_CREDBODYOVERLONG:        return "CredBodyOverlong";
+        case DEF_ARGSTRUNCATED:           return "ArgsTruncated";
+        case DEF_ARGSTRAILINGGARBAGE:     return "ArgsTrailingGarbage";
+        case DEF_STRINGLENOVERFLOW:       return "StringLenOverflow";
+        case DEF_STRINGLENBEYONDMESSAGE:  return "StringLenBeyondMessage";
+        case DEF_STRINGEXCEEDSBOUND:      return "StringExceedsBound";
+        case DEF_OPAQUEEXCEEDSBOUND:      return "OpaqueExceedsBound";
+        case DEF_ARRAYCOUNTEXCEEDSBOUND:  return "ArrayCountExceedsBound";
+        case DEF_ARRAYCOUNTHUGE:          return "ArrayCountHuge";
+        case DEF_DISCRIMINANTUNMATCHED:   return "DiscriminantUnmatched";
+        case DEF_BOOLNOTZEROORONE:        return "BoolNotZeroOrOne";
+        case DEF_ENUMNOTDECLARED:         return "EnumNotDeclared";
+        case DEF_RECORDMARKHUGE:          return "RecordMarkHuge";
+        case DEF_RECORDMARKZEROLENGTH:    return "RecordMarkZeroLength";
+        case DEF_CALLSPLITACROSSFRAGMENTS: return "CallSplitAcrossFragments";
+        case DEF_CALLSPLITPATHOLOGICAL:   return "CallSplitPathological";
+        case DEF_REASSEMBLYCAPEXCEEDED:   return "ReassemblyCapExceeded";
+        case DEF_GSSINITESTABLISHES:      return "GssInitEstablishes";
+        case DEF_GSSINITCONTINUES:        return "GssInitContinues";
+        case DEF_GSSINITMECHFAILS:        return "GssInitMechFails";
+        case DEF_GSSDATAVALID:            return "GssDataValid";
+        case DEF_GSSCREDVERSIONWRONG:     return "GssCredVersionWrong";
+        case DEF_GSSPROCUNKNOWN:          return "GssProcUnknown";
+        case DEF_GSSSERVICEPRIVACY:       return "GssServicePrivacy";
+        case DEF_GSSHANDLEUNKNOWN:        return "GssHandleUnknown";
+        case DEF_GSSVERIFIERNOTGSS:       return "GssVerifierNotGss";
+        case DEF_GSSMICWRONG:             return "GssMicWrong";
+        case DEF_GSSSEQREPLAYED:          return "GssSeqReplayed";
+        case DEF_AUTHSYSVALID:            return "AuthSysValid";
+        case DEF_GSSINTEGDATAVALID:       return "GssIntegDataValid";
+        case DEF_GSSINTEGCHECKSUMWRONG:   return "GssIntegChecksumWrong";
+        case DEF_GSSINTEGSEQMISMATCH:     return "GssIntegSeqMismatch";
+        case DEF_GSSDESTROYCONTEXT:       return "GssDestroyContext";
+        case DEF_GSSDESTROYUNAUTHENTICATED: return "GssDestroyUnauthenticated";
+        case DEF_GSSSEQABOVEMAX:          return "GssSeqAboveMax";
+        case DEF_GSSSEQWINDOWJUMP:        return "GssSeqWindowJump";
+        case DEF_GSSSEQTOOOLD:            return "GssSeqTooOld";
+        case DEF_GSSSEQOUTOFORDER:        return "GssSeqOutOfOrder";
+        case DEF_GSSCREDTRUNCATED:        return "GssCredTruncated";
+        case DEF_GSSCREDHANDLEOVERRUNS:   return "GssCredHandleOverruns";
+        case DEF_GSSNOMECHANISM:          return "GssNoMechanism";
+        case DEF_GSSCONTINUEINITUNKNOWNHANDLE: return "GssContinueInitUnknownHandle";
+        case DEF_GSSINITTOKENMALFORMED:   return "GssInitTokenMalformed";
+        case DEF_GSSCONTINUEINITTOKENMALFORMED: return "GssContinueInitTokenMalformed";
+        case DEF_GSSINITMECHFAILSWITHTOKEN: return "GssInitMechFailsWithToken";
+        case DEF_GSSINTEGFRAMINGBAD:      return "GssIntegFramingBad";
+        case DEF_GSSINTEGEMPTYARGS:       return "GssIntegEmptyArgs";
+        case DEF_GSSINTEGSPLITACROSSFRAGMENTS: return "GssIntegSplitAcrossFragments";
+        case DEF_GSSINTEGREPLYMICFAILS:   return "GssIntegReplyMicFails";
+        case DEF_GSSINTEGREPLYMICOVERSIZE: return "GssIntegReplyMicOversize";
+        default:                          return "?";
+    } /* switch */
+} /* defect_name */
+
+static int
+is_known_divergence(
+    int defect,
+    int expect,
+    int actual)
+{
+    unsigned int i;
+
+    for (i = 0; i < sizeof(known_divergences) / sizeof(known_divergences[0]); i++) {
+        if (known_divergences[i].defect == defect &&
+            known_divergences[i].expect == expect &&
+            known_divergences[i].actual == actual) {
+            return 1;
+        }
+    }
+    return 0;
+} /* is_known_divergence */
+
+/* ------------------------------------------------------------------ *
+* Connection notifications
+*
+* rpc2 reports connection lifecycle to a callback registered on the thread.
+* An application learns from it that a connection it never asked for has
+* appeared, and -- more sharply -- that one it holds a pointer to has been
+* freed, so a missed or duplicated notification is a use-after-free waiting
+* to happen rather than a cosmetic fault.
+*
+* The bookkeeping here is what turns "the callback ran" into a check: a
+* connection must be announced before it can be reported gone, may only be
+* announced once, and may only be reported gone once.  Ordering is not an
+* assumption -- the accept callback installs the rpc2 conn and the transport
+* then reports the bind established, so on the server side ACCEPTED always
+* precedes CONNECTED.  A CONNECTED with no accept before it is therefore the
+* connection this process dialled, which is how the client's own conn is
+* identified without racing the assignment of the pointer it returns.
+* ------------------------------------------------------------------ */
+
+/* Sized for the defect phase: each case dials a connection and closes it, but
+ * the server retires them lazily, so many can be live at once. */
+#define NOTIFY_MAX_LIVE 1024
+
+struct notify_state {
+    struct evpl_rpc2_conn *live[NOTIFY_MAX_LIVE];
+    int                    num_live;
+    int                    accepted;
+    int                    connected;
+    int                    disconnected;
+    /* The conn identified as this process's client connection, and its
+     * notification counts, kept apart from the server-side totals. */
+    struct evpl_rpc2_conn *client_conn;
+    int                    client_connected;
+    int                    client_disconnected;
+    int                    errors;
+};
+
+static struct notify_state g_notify;
+
+/* What evpl_rpc2_server_attach and evpl_rpc2_thread_init were handed. */
+static void               *g_server_private;
+static void               *g_thread_private;
+
+#define notify_check(cond, ...)             \
+        do {                                    \
+            if (!(cond)) {                      \
+                evpl_test_error(__VA_ARGS__);   \
+                g_notify.errors++;              \
+            }                                   \
+        } while (0)
+
+static int
+notify_find(struct evpl_rpc2_conn *conn)
+{
+    int i;
+
+    for (i = 0; i < g_notify.num_live; i++) {
+        if (g_notify.live[i] == conn) {
+            return i;
+        }
+    }
+    return -1;
+} /* notify_find */
+
+static void
+notify_add(struct evpl_rpc2_conn *conn)
+{
+    evpl_test_abort_if(g_notify.num_live >= NOTIFY_MAX_LIVE,
+                       "live connection table exhausted; raise NOTIFY_MAX_LIVE");
+    g_notify.live[g_notify.num_live++] = conn;
+} /* notify_add */
+
+static void
+notify_remove(int idx)
+{
+    g_notify.live[idx] = g_notify.live[--g_notify.num_live];
+} /* notify_remove */
+
+static void
+conformance_notify(
+    struct evpl_rpc2_thread *thread,
+    struct evpl_rpc2_conn   *conn,
+    struct evpl_rpc2_notify *notify,
+    void                    *private_data)
+{
+    int idx = notify_find(conn);
+
+    notify_check(conn != NULL, "notification %u carried no connection",
+                 notify->notify_type);
+
+    switch (notify->notify_type) {
+        case EVPL_RPC2_NOTIFY_ACCEPTED:
+            /* Note the asymmetry, which is libevpl's and not a typo here: an
+             * accept reports the *server's* private data (what
+             * evpl_rpc2_server_attach was given), while the two conn-lifecycle
+             * notifications report the *thread's* (what evpl_rpc2_thread_init
+             * was given).  Asserted rather than smoothed over, so that
+             * changing it is a visible decision. */
+            notify_check(private_data == g_server_private,
+                         "ACCEPTED carried private data %p, expected the "
+                         "server's %p", private_data, g_server_private);
+            notify_check(idx < 0,
+                         "ACCEPTED for connection %p, which is already live",
+                         (void *) conn);
+            notify_add(conn);
+            g_notify.accepted++;
+            break;
+
+        case EVPL_RPC2_NOTIFY_CONNECTED:
+            notify_check(private_data == g_thread_private,
+                         "CONNECTED carried private data %p, expected the "
+                         "thread's %p", private_data, g_thread_private);
+            g_notify.connected++;
+            if (idx < 0) {
+                /* No accept preceded it: this is the connection we dialled. */
+                notify_check(g_notify.client_conn == NULL,
+                             "a second unaccepted connection %p was reported "
+                             "connected", (void *) conn);
+                g_notify.client_conn = conn;
+                g_notify.client_connected++;
+                notify_add(conn);
+            }
+            break;
+
+        case EVPL_RPC2_NOTIFY_DISCONNECTED:
+            notify_check(private_data == g_thread_private,
+                         "DISCONNECTED carried private data %p, expected the "
+                         "thread's %p", private_data, g_thread_private);
+            notify_check(idx >= 0,
+                         "DISCONNECTED for connection %p, which was never "
+                         "announced (or was already reported gone)",
+                         (void *) conn);
+            if (idx >= 0) {
+                notify_remove(idx);
+            }
+            g_notify.disconnected++;
+            if (conn == g_notify.client_conn) {
+                g_notify.client_disconnected++;
+            }
+            break;
+
+        default:
+            notify_check(0, "unknown notification type %u",
+                         notify->notify_type);
+    } /* switch */
+} /* conformance_notify */
+
+/*
+ * Check the notification tallies against what the run actually did.  Called
+ * once the rpc2 thread is destroyed: that closes every surviving connection
+ * and pumps until rpc2 has retired it, so by then nothing further can arrive
+ * and every announced connection must have been accounted for.
+ */
+static void
+check_notifications(void)
+{
+    notify_check(g_notify.num_live == 0,
+                 "%d connection(s) were announced but never reported gone",
+                 g_notify.num_live);
+
+    /* One accept per connection this process dialled, raw sockets included --
+     * the defect phase's connections are announced exactly like any other. */
+    notify_check(g_notify.accepted == g_connections_opened,
+                 "%d accepts announced for %d connections opened",
+                 g_notify.accepted, g_connections_opened);
+
+    /* Each accepted bind is reported established once the transport attaches
+     * it, and the client's own connection adds the one accept never saw. */
+    notify_check(g_notify.connected == g_notify.accepted + 1,
+                 "%d connects announced, expected %d (one per accept, plus "
+                 "this process's own client connection)",
+                 g_notify.connected, g_notify.accepted + 1);
+
+    notify_check(g_notify.disconnected == g_notify.connected,
+                 "%d disconnects for %d connects",
+                 g_notify.disconnected, g_notify.connected);
+
+    notify_check(g_notify.client_connected == 1 &&
+                 g_notify.client_disconnected == 1,
+                 "the client connection was reported connected %d time(s) and "
+                 "disconnected %d time(s), expected once each",
+                 g_notify.client_connected, g_notify.client_disconnected);
+} /* check_notifications */
+
+/* ------------------------------------------------------------------ *
+* Server: every procedure echoes its argument
+* ------------------------------------------------------------------ */
+
+/*
+ * Exercise the connection accessors, and check what they say.
+ *
+ * These are part of the public rpc2 surface but nothing else in the suite has
+ * any reason to call them, so they would otherwise never be executed.  Using
+ * the private-data slot as the "seen this connection already" marker means the
+ * round trip is actually verified rather than merely performed: the slot must
+ * start NULL, and every later request on the same connection must read back
+ * exactly what the first one stored.  rpc2 itself never touches the slot, so
+ * borrowing it cannot disturb anything.
+ */
+static const char conn_seen;
+#define CONN_SEEN_MARKER ((void *) &conn_seen)
+
+static void
+check_conn_accessors(struct evpl_rpc2_conn *conn)
+{
+    char  local[256]  = "";
+    char  remote[256] = "";
+    void *seen        = evpl_rpc2_conn_get_private_data(conn);
+
+    if (seen == CONN_SEEN_MARKER) {
+        return;
+    }
+
+    evpl_test_abort_if(seen != NULL,
+                       "connection private data started out as %p, not NULL",
+                       seen);
+
+    evpl_rpc2_conn_get_local_address(conn, local, sizeof(local));
+    evpl_rpc2_conn_get_remote_address(conn, remote, sizeof(remote));
+
+    evpl_test_abort_if(local[0] == '\0', "local address came back empty");
+    evpl_test_abort_if(remote[0] == '\0', "remote address came back empty");
+
+    evpl_rpc2_conn_set_private_data(conn, CONN_SEEN_MARKER);
+
+    evpl_test_abort_if(evpl_rpc2_conn_get_private_data(conn) != CONN_SEEN_MARKER,
+                       "connection private data did not round-trip");
+} /* check_conn_accessors */
+
+#define ECHO_HANDLER(NAME, TYPE, PROC)                                       \
+        static void                                                              \
+        server_ ## NAME(                                                         \
+            struct evpl *evpl,                                     \
+            struct evpl_rpc2_conn *conn,                                     \
+            struct evpl_rpc2_cred *cred,                                     \
+            struct TYPE *call,                                     \
+            struct evpl_rpc2_encoding *encoding,                                 \
+            void *private_data)                             \
+        {                                                                        \
+            struct server_ctx *ctx = private_data;                               \
+            int                rc;                                               \
+                                                                             \
+            check_conn_accessors(conn);                                          \
+                                                                             \
+            rc = ctx->prog.send_reply_ ## PROC(evpl, NULL, call, encoding);      \
+            evpl_test_abort_if(rc, "send_reply_" #PROC " failed: %d", rc);       \
+        }
+
+ECHO_HANDLER(echo_scalars, scalars, ECHO_SCALARS)
+ECHO_HANDLER(echo_bytes, bytes, ECHO_BYTES)
+ECHO_HANDLER(echo_arrays, arrays, ECHO_ARRAYS)
+ECHO_HANDLER(echo_union, tagged, ECHO_UNION)
+ECHO_HANDLER(echo_optional, opt_msg, ECHO_OPTIONAL)
+ECHO_HANDLER(echo_list, list_msg, ECHO_LIST)
+ECHO_HANDLER(echo_nested, nested, ECHO_NESTED)
+
+/*
+ * zcopaque is the one field type that is never copied, so echoing it would
+ * hand the reply marshaller iovecs the request still owns.  Rather than take
+ * a position on that ownership transfer, report the length that was decoded
+ * and return an empty payload: the decode path -- the direction that sees
+ * untrusted input -- is still fully exercised, and the client verifies the
+ * server saw the right length.
+ */
+static void
+server_echo_zbytes(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct zbytes             *call,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct server_ctx *ctx = private_data;
+    struct zbytes      reply;
+    int                i, rc;
+
+    /* A true echo: the zcopaque payload is handed straight back.  The
+     * marshaller moves these references onward, so they must not be released
+     * here -- only the ones the decoder cloned are ours to drop, below. */
+    /*
+     * Take ownership of the decoded zero-copy payload before doing anything
+     * with it.  On a stream transport this is a no-op and the iovecs are
+     * clones the receiver already owns; on an RDMA transport it moves them out
+     * of the request's read chunk so that request teardown will not release
+     * them a second time.  Calling it unconditionally is what makes a handler
+     * transport-agnostic -- see rdma_ddp.c and chimera's nfs3_proc_write.c,
+     * which use the same idiom.
+     */
+    evpl_rpc2_encoding_take_read_chunk(encoding, NULL, NULL);
+
+    memset(&reply, 0, sizeof(reply));
+    reply.head = call->z.length;
+    reply.tail = call->tail;
+    reply.z    = call->z;
+
+    rc = ctx->prog.send_reply_ECHO_ZBYTES(evpl, NULL, &reply, encoding);
+    evpl_test_abort_if(rc, "send_reply_ECHO_ZBYTES failed: %d", rc);
+
+    (void) i;
+} /* server_echo_zbytes */
+
+/*
+ * "strict" has no default arm, so a discriminant that matches no case leaves
+ * the arm untouched.  Echoing it would re-marshall whatever the decoder left
+ * behind, so report the discriminant instead.
+ */
+static void
+server_probe_strict(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct strict             *call,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct server_ctx  *ctx = private_data;
+    struct probe_result reply;
+    int                 rc;
+
+    memset(&reply, 0, sizeof(reply));
+    reply.seen_k = call->k;
+    reply.seen_i = (call->k == K_INT) ? call->i : 0;
+
+    rc = ctx->prog.send_reply_PROBE_STRICT(evpl, NULL, &reply, encoding);
+    evpl_test_abort_if(rc, "send_reply_PROBE_STRICT failed: %d", rc);
+} /* server_probe_strict */
+
+static void
+conformance_program_init(struct server_ctx *ctx)
+{
+    CONFORMANCE_V1_init(&ctx->prog);
+    ctx->prog.recv_call_ECHO_SCALARS  = server_echo_scalars;
+    ctx->prog.recv_call_ECHO_BYTES    = server_echo_bytes;
+    ctx->prog.recv_call_ECHO_ZBYTES   = server_echo_zbytes;
+    ctx->prog.recv_call_ECHO_ARRAYS   = server_echo_arrays;
+    ctx->prog.recv_call_ECHO_UNION    = server_echo_union;
+    ctx->prog.recv_call_PROBE_STRICT  = server_probe_strict;
+    ctx->prog.recv_call_ECHO_OPTIONAL = server_echo_optional;
+    ctx->prog.recv_call_ECHO_LIST     = server_echo_list;
+    ctx->prog.recv_call_ECHO_NESTED   = server_echo_nested;
+} /* conformance_program_init */
+
+/*
+ * Deadline helper for the raw-socket phase, which cannot block: the server
+ * shares this thread's event loop, so waiting on recv() would deadlock.
+ */
+static uint64_t
+now_ms(void)
+{
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+} /* now_ms */
+
+/* ------------------------------------------------------------------ *
+* Class -> value mapping
+* ------------------------------------------------------------------ */
+
+static int32_t
+int_value(uint8_t cls)
+{
+    switch (cls) {
+        case CLS_I32MIN:  return INT32_MIN;
+        case CLS_I32NEG1: return -1;
+        case CLS_I32ZERO: return 0;
+        case CLS_I32ONE:  return 1;
+        default:          return INT32_MAX;
+    } /* switch */
+} /* int_value */
+
+static uint32_t
+uint_value(uint8_t cls)
+{
+    switch (cls) {
+        case CLS_U32ZERO: return 0;
+        case CLS_U32ONE:  return 1;
+        default:          return UINT32_MAX;
+    } /* switch */
+} /* uint_value */
+
+static int64_t
+long_value(uint8_t cls)
+{
+    switch (cls) {
+        case CLS_I64MIN:  return INT64_MIN;
+        case CLS_I64NEG1: return -1;
+        case CLS_I64ZERO: return 0;
+        default:          return INT64_MAX;
+    } /* switch */
+} /* long_value */
+
+static uint64_t
+ulong_value(uint8_t cls)
+{
+    switch (cls) {
+        case CLS_U64ZERO: return 0;
+        case CLS_U64ONE:  return 1;
+        default:          return UINT64_MAX;
+    } /* switch */
+} /* ulong_value */
+
+static float
+float_value(uint8_t cls)
+{
+    switch (cls) {
+        case CLS_FZERO:    return 0.0f;
+        case CLS_FNEGZERO: return -0.0f;
+        case CLS_FONE:     return 1.0f;
+        case CLS_FNEGONE:  return -1.0f;
+        case CLS_FLARGE:   return 3.4e38f;
+        default:           return nanf("");
+    } /* switch */
+} /* float_value */
+
+static double
+double_value(uint8_t cls)
+{
+    switch (cls) {
+        case CLS_FZERO:    return 0.0;
+        case CLS_FNEGZERO: return -0.0;
+        case CLS_FONE:     return 1.0;
+        case CLS_FNEGONE:  return -1.0;
+        case CLS_FLARGE:   return 1.7e308;
+        default:           return nan("");
+    } /* switch */
+} /* double_value */
+
+/* Byte length for a counted byte field. */
+static uint32_t
+len_bytes(uint8_t cls)
+{
+    switch (cls) {
+        case CLS_LEMPTY:     return 0;
+        case CLS_LONE:       return 1;
+        case CLS_LUNALIGNED: return 5;
+        case CLS_LALIGNED:   return 4;
+        case CLS_LATBOUND:   return BOUNDED_MAX;
+        default:             return 1000;
+    } /* switch */
+} /* len_bytes */
+
+/* Element count for an array, list length, or recursion depth.  Bounded well
+ * below the per-message dbuf so a "large" case tests breadth, not exhaustion
+ * (exhaustion is the ArrayCountHuge defect's job). */
+static uint32_t
+len_count(uint8_t cls)
+{
+    switch (cls) {
+        case CLS_LEMPTY:     return 0;
+        case CLS_LONE:       return 1;
+        case CLS_LUNALIGNED: return 5;
+        case CLS_LALIGNED:   return 4;
+        case CLS_LATBOUND:   return BOUNDED_MAX;
+        default:             return 64;
+    } /* switch */
+} /* len_count */
+
+static color
+color_value(uint8_t cls)
+{
+    switch (cls) {
+        case CLS_COLRED:   return RED;
+        case CLS_COLGREEN: return GREEN;
+        default:           return BLUE;
+    } /* switch */
+} /* color_value */
+
+/* ------------------------------------------------------------------ *
+* Deep comparison helpers
+* ------------------------------------------------------------------ */
+
+static int
+scalars_equal(
+    const struct scalars *a,
+    const struct scalars *b)
+{
+    /* Floats are compared bitwise: a value comparison would report NaN as
+     * unequal to itself and -0.0 as equal to 0.0, and the round trip must
+     * preserve both exactly. */
+    return a->s32 == b->s32 && a->u32 == b->u32 &&
+           a->s64 == b->s64 && a->u64 == b->u64 &&
+           memcmp(&a->f32, &b->f32, sizeof(a->f32)) == 0 &&
+           memcmp(&a->f64, &b->f64, sizeof(a->f64)) == 0 &&
+           a->b == b->b && a->c == b->c;
+} /* scalars_equal */
+
+static int
+bytes_equal(
+    const struct bytes *a,
+    const struct bytes *b)
+{
+    if (a->s.len != b->s.len ||
+        (a->s.len && memcmp(a->s.str, b->s.str, a->s.len))) {
+        return 0;
+    }
+    if (a->bounded_s.len != b->bounded_s.len ||
+        (a->bounded_s.len &&
+         memcmp(a->bounded_s.str, b->bounded_s.str, a->bounded_s.len))) {
+        return 0;
+    }
+    if (a->v.len != b->v.len ||
+        (a->v.len && memcmp(a->v.data, b->v.data, a->v.len))) {
+        return 0;
+    }
+    if (a->bounded.len != b->bounded.len ||
+        (a->bounded.len && memcmp(a->bounded.data, b->bounded.data, a->bounded.len))) {
+        return 0;
+    }
+    return memcmp(a->f, b->f, FIXED_OPAQUE_LEN) == 0;
+} /* bytes_equal */
+
+static int
+point_equal(
+    const struct point *a,
+    const struct point *b)
+{
+    return a->x == b->x && a->y == b->y;
+} /* point_equal */
+
+static int
+arrays_equal(
+    const struct arrays *a,
+    const struct arrays *b)
+{
+    unsigned int i;
+
+    if (memcmp(a->fixed_u32, b->fixed_u32, sizeof(a->fixed_u32))) {
+        return 0;
+    }
+    if (a->num_var_u32 != b->num_var_u32) {
+        return 0;
+    }
+    for (i = 0; i < a->num_var_u32; i++) {
+        if (a->var_u32[i] != b->var_u32[i]) {
+            return 0;
+        }
+    }
+    if (a->num_bounded_u32 != b->num_bounded_u32) {
+        return 0;
+    }
+    for (i = 0; i < a->num_bounded_u32; i++) {
+        if (a->bounded_u32[i] != b->bounded_u32[i]) {
+            return 0;
+        }
+    }
+    for (i = 0; i < 2; i++) {
+        if (!point_equal(&a->fixed_pt[i], &b->fixed_pt[i])) {
+            return 0;
+        }
+    }
+    if (a->num_var_pt != b->num_var_pt) {
+        return 0;
+    }
+    for (i = 0; i < a->num_var_pt; i++) {
+        if (!point_equal(&a->var_pt[i], &b->var_pt[i])) {
+            return 0;
+        }
+    }
+    return 1;
+} /* arrays_equal */
+
+static int
+tagged_equal(
+    const struct tagged *a,
+    const struct tagged *b)
+{
+    if (a->k != b->k) {
+        return 0;
+    }
+    switch (a->k) {
+        case K_INT:
+            return a->i == b->i;
+        case K_STR:
+            return a->s.len == b->s.len &&
+                   (a->s.len == 0 || memcmp(a->s.str, b->s.str, a->s.len) == 0);
+        case K_PT:
+            return point_equal(&a->p, &b->p);
+        default:
+            return 1;  /* K_NONE and the default arm carry nothing */
+    } /* switch */
+} /* tagged_equal */
+
+static int
+opt_msg_equal(
+    const struct opt_msg *a,
+    const struct opt_msg *b)
+{
+    if (a->head != b->head || a->tail != b->tail) {
+        return 0;
+    }
+    if ((a->opt == NULL) != (b->opt == NULL)) {
+        return 0;
+    }
+    return a->opt == NULL || point_equal(a->opt, b->opt);
+} /* opt_msg_equal */
+
+static int
+list_msg_equal(
+    const struct list_msg *a,
+    const struct list_msg *b)
+{
+    const struct lnode *x = a->head, *y = b->head;
+
+    if (a->trailer != b->trailer) {
+        return 0;
+    }
+    while (x && y) {
+        if (x->value != y->value) {
+            return 0;
+        }
+        x = x->nextnode;
+        y = y->nextnode;
+    }
+    return x == NULL && y == NULL;
+} /* list_msg_equal */
+
+static int
+rec_equal(
+    const struct rec *a,
+    const struct rec *b)
+{
+    while (a && b) {
+        if (a->depth != b->depth) {
+            return 0;
+        }
+        a = a->chain;
+        b = b->chain;
+    }
+    return a == NULL && b == NULL;
+} /* rec_equal */
+
+static int
+nested_equal(
+    const struct nested *a,
+    const struct nested *b)
+{
+    return point_equal(&a->inner_pt, &b->inner_pt) &&
+           scalars_equal(&a->inner_scalars, &b->inner_scalars) &&
+           a->tail == b->tail &&
+           rec_equal(a->chain, b->chain);
+} /* nested_equal */
+
+/* ------------------------------------------------------------------ *
+* Value phase
+* ------------------------------------------------------------------ */
+
+struct value_state {
+    volatile int done;
+    int          matched;
+    int          status;
+    const void  *expect;
+    uint32_t     zbytes_len;
+    uint32_t     zbytes_tail;
+    int          owns_reply_payload;
+};
+
+#define REPLY_CALLBACK(NAME, TYPE, CMP)                                      \
+        static void                                                              \
+        client_reply_ ## NAME(                                                   \
+            struct evpl *evpl,                                   \
+            const struct evpl_rpc2_verf *verf,                                   \
+            struct TYPE *reply,                                  \
+            int status,                                 \
+            void *private_data)                           \
+        {                                                                        \
+            struct value_state *st = private_data;                               \
+                                                                             \
+            st->status  = status;                                                \
+            st->matched = (status == 0) && reply &&                              \
+                CMP(reply, (const struct TYPE *) st->expect);                    \
+            st->done = 1;                                                     \
+        }
+
+REPLY_CALLBACK(scalars, scalars, scalars_equal)
+REPLY_CALLBACK(bytes, bytes, bytes_equal)
+REPLY_CALLBACK(arrays, arrays, arrays_equal)
+REPLY_CALLBACK(tagged, tagged, tagged_equal)
+REPLY_CALLBACK(opt_msg, opt_msg, opt_msg_equal)
+REPLY_CALLBACK(list_msg, list_msg, list_msg_equal)
+REPLY_CALLBACK(nested, nested, nested_equal)
+
+/*
+ * Compare the bytes of a decoded zcopaque payload against the pattern the
+ * request carried.
+ *
+ * Checking the length alone was enough while every payload travelled inline,
+ * because then the length and the bytes come from the same decode.  Once the
+ * responder places the payload by RDMA the two are independent: the length
+ * arrives in the transport header's Write list while the bytes are written
+ * straight into the destination buffer, so a payload placed at the wrong
+ * offset, truncated, or never written at all still reports the right length.
+ * Only comparing the bytes distinguishes those.
+ *
+ * The iovecs may describe more than `len` bytes -- a read-into destination is
+ * as large as the caller advertised, not as large as the reply -- so each one
+ * is clamped to what is left rather than trusted whole.
+ */
+static int
+zpayload_matches(
+    const struct zbytes *reply,
+    uint32_t             len)
+{
+    uint32_t off = 0;
+    uint32_t n;
+    int      i;
+
+    for (i = 0; i < reply->z.niov && off < len; i++) {
+        n = reply->z.iov[i].length;
+
+        if (n > len - off) {
+            n = len - off;
+        }
+
+        if (memcmp(evpl_iovec_data(&reply->z.iov[i]), g_pattern + off, n)) {
+            return 0;
+        }
+
+        off += n;
+    }
+
+    return off == len;
+} /* zpayload_matches */
+
+static void
+client_reply_zbytes(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct zbytes               *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct value_state *st = private_data;
+    int                 i;
+
+    /* head carries back the zcopaque length the server decoded, and the
+     * echoed payload must come back with it. */
+    st->status  = status;
+    st->matched = (status == 0) && reply &&
+        reply->head == st->zbytes_len &&
+        reply->tail == st->zbytes_tail &&
+        reply->z.length == st->zbytes_len &&
+        zpayload_matches(reply, st->zbytes_len);
+    st->done = 1;
+
+    if (!st->matched && status == 0 && reply) {
+        evpl_test_error(
+            "zbytes mismatch: head=%u (want %u) tail=%u (want %u) z.length=%u (want %u) z.niov=%d bytes=%s",
+            reply->head, st->zbytes_len, reply->tail, st->zbytes_tail,
+            reply->z.length, st->zbytes_len, reply->z.niov,
+            zpayload_matches(reply, st->zbytes_len) ? "ok" : "WRONG");
+    }
+
+    /* Decoding a zcopaque field means owning the references the decoder
+     * cloned into it, on a reply exactly as much as on a call, so drop them
+     * before the reply goes out of scope.  The decoder hands back one iovec
+     * even for a zero-length payload, so this is not conditional on there
+     * being any bytes. */
+    /* Ownership depends on whether direct placement actually happened.  With a
+     * buffer armed on an RDMA transport the reply is written into it and the
+     * iovecs merely reference it -- the caller holds the one reference and
+     * drops it after the call.  Everywhere else (including the same request on
+     * a stream transport, where rpc2.c ignores the chunk arguments entirely)
+     * the decoder cloned them and they are ours to release.  Releasing in the
+     * borrowed case corrupts the allocator free list into a cycle, which
+     * surfaces as a hang in evpl_allocator_destroy at exit. */
+    if (reply && st->owns_reply_payload) {
+        for (i = 0; i < reply->z.niov; i++) {
+            evpl_iovec_release(evpl, &reply->z.iov[i]);
+        }
+    }
+} /* client_reply_zbytes */
+
+static int
+wait_for_reply(
+    struct evpl        *evpl,
+    struct value_state *st)
+{
+    int spins = 0;
+
+    while (!st->done) {
+        evpl_continue(evpl);
+        if (++spins > 100000000) {
+            return -1;
+        }
+    }
+    return 0;
+} /* wait_for_reply */
+
+/* Deliberately far below the reply the ERR_CHUNK check provokes, and below
+ * the 512-byte floor rpc2 applies before it will use a Reply chunk at all,
+ * so the responder is forced to refuse rather than quietly go inline. */
+#define REPLY_CHUNK_TOO_SMALL_BYTES 600
+
+/*
+ * A Reply chunk too small for the Reply must be answered with RDMA_ERROR /
+ * ERR_CHUNK (RFC 8166 sec 4.5), not by truncating the Reply and not by
+ * silently falling back to an inline one.
+ *
+ * Driven directly rather than from the value model because the model's oracle
+ * is round-trip equality -- a call that is *supposed* to fail has no reply to
+ * compare.  Both halves of the exchange are under test here: the Responder
+ * must detect that the chunk cannot hold the Reply and say so, and the
+ * Requester must turn that into a failed call rather than waiting for a reply
+ * that will never come.
+ *
+ * RDMA only: on TCP there are no chunks to get wrong.
+ */
+static void
+check_reply_chunk_too_small(
+    struct evpl           *evpl,
+    struct CONFORMANCE_V1 *prog,
+    struct evpl_rpc2_conn *conn)
+{
+    struct value_state st;
+    struct bytes       arg;
+
+    if (!conn->rdma) {
+        return;
+    }
+
+    memset(&st, 0, sizeof(st));
+    memset(&arg, 0, sizeof(arg));
+
+    /* A reply comfortably over the 512-byte floor below which rpc2 does not
+     * bother with a Reply chunk at all, and comfortably over what we offer. */
+    arg.s.len         = MAX_PAYLOAD;
+    arg.s.str         = (char *) g_pattern;
+    arg.bounded_s.len = BOUNDED_MAX;
+    arg.bounded_s.str = (char *) g_pattern;
+    arg.v.len         = MAX_PAYLOAD;
+    arg.v.data        = g_pattern;
+    arg.bounded.len   = BOUNDED_MAX;
+    arg.bounded.data  = g_pattern;
+    memcpy(arg.f, g_pattern, FIXED_OPAQUE_LEN);
+
+    st.expect = &arg;
+
+    prog->send_call_ECHO_BYTES(&prog->rpc2, evpl, conn, NULL, &arg,
+                               1, 0, NULL, 0, REPLY_CHUNK_TOO_SMALL_BYTES,
+                               client_reply_bytes, &st);
+
+    evpl_test_abort_if(wait_for_reply(evpl, &st),
+                       "reply-chunk-too-small: no completion arrived");
+
+    evpl_test_abort_if(st.status != EVPL_RPC2_REPLY_RDMA_ERROR,
+                       "reply-chunk-too-small: expected EVPL_RPC2_REPLY_RDMA_ERROR (%d), got %d",
+                       EVPL_RPC2_REPLY_RDMA_ERROR, st.status);
+
+    g_results.rdma_error_checks++;
+
+    /* ERR_CHUNK is a per-request refusal, not a transport failure: the
+     * connection must still carry an ordinary call afterwards.  Without this
+     * the test would pass just as well against an implementation that dropped
+     * the connection. */
+    memset(&st, 0, sizeof(st));
+    memset(&arg, 0, sizeof(arg));
+    arg.s.len         = 4;
+    arg.s.str         = (char *) g_pattern;
+    arg.bounded_s.len = 4;
+    arg.bounded_s.str = (char *) g_pattern;
+    arg.v.len         = 4;
+    arg.v.data        = g_pattern;
+    arg.bounded.len   = 4;
+    arg.bounded.data  = g_pattern;
+    memcpy(arg.f, g_pattern, FIXED_OPAQUE_LEN);
+    st.expect = &arg;
+
+    prog->send_call_ECHO_BYTES(&prog->rpc2, evpl, conn, NULL, &arg,
+                               0, 0, NULL, 0, 0, client_reply_bytes, &st);
+
+    evpl_test_abort_if(wait_for_reply(evpl, &st),
+                       "reply-chunk-too-small: the connection did not survive");
+    evpl_test_abort_if(st.status != 0 || !st.matched,
+                       "reply-chunk-too-small: follow-up call failed (status %d, matched %d)",
+                       st.status, st.matched);
+
+    g_results.rdma_error_checks++;
+} /* check_reply_chunk_too_small */
+
+/*
+ * State for the ERR_VERS check below.
+ */
+struct vers_probe {
+    volatile int done;
+    int          got_rdma_error;
+    int          err;
+    uint32_t     vers_low;
+    uint32_t     vers_high;
+};
+
+static void
+vers_probe_callback(
+    struct evpl        *evpl,
+    struct evpl_bind   *bind,
+    struct evpl_notify *notify,
+    void               *private_data)
+{
+    struct vers_probe *vp = private_data;
+    struct rdma_msg    reply;
+    xdr_dbuf          *dbuf;
+
+    if (notify->notify_type != EVPL_NOTIFY_RECV_MSG) {
+        return;
+    }
+
+    dbuf = xdr_dbuf_alloc(4096);
+
+    if (dbuf &&
+        unmarshall_rdma_msg(&reply, notify->recv_msg.iovec,
+                            notify->recv_msg.niov, NULL, dbuf) > 0 &&
+        reply.rdma_body.proc == RDMA_ERROR) {
+        vp->got_rdma_error = 1;
+        vp->err            = reply.rdma_body.rdma_error.err;
+
+        if (reply.rdma_body.rdma_error.err == ERR_VERS) {
+            vp->vers_low  = reply.rdma_body.rdma_error.range.rdma_vers_low;
+            vp->vers_high = reply.rdma_body.rdma_error.range.rdma_vers_high;
+        }
+    }
+
+    if (dbuf) {
+        xdr_dbuf_free(dbuf);
+    }
+
+    evpl_iovecs_release(evpl, notify->recv_msg.iovec, notify->recv_msg.niov);
+
+    vp->done = 1;
+} /* vers_probe_callback */
+
+/*
+ * A transport header naming a version we do not speak must be answered with
+ * RDMA_ERROR / ERR_VERS carrying the range we do (RFC 8166 sec 4.5).
+ *
+ * libevpl's own client always stamps version 1, so this cannot be provoked
+ * through the rpc2 client API: it needs a peer that builds the transport
+ * header itself.  A plain bind on the same transport is exactly that -- the
+ * transport still does its own framing, so what is under test is the
+ * RPC-over-RDMA header handling and nothing else.
+ *
+ * RDMA only, and skipped if a plain bind cannot be established.
+ */
+static void
+check_rdma_version_mismatch(
+    struct evpl          *evpl,
+    struct evpl_endpoint *endpoint,
+    int                   proto,
+    int                   rdma)
+{
+    struct vers_probe vp;
+    struct rdma_msg   bad;
+    struct evpl_bind *bind;
+    struct evpl_iovec iov, out_iov;
+    int               len, niov, out_niov = 0, spins = 0;
+
+    if (!rdma) {
+        return;
+    }
+
+    memset(&vp, 0, sizeof(vp));
+    memset(&bad, 0, sizeof(bad));
+
+    bind = evpl_connect(evpl, proto, NULL, endpoint, vers_probe_callback,
+                        NULL, &vp);
+
+    evpl_test_abort_if(!bind, "version probe: failed to connect a plain bind");
+
+    /* This is a connection the driver dialled like any other, so it has to be
+     * counted or check_notifications will see an accept it cannot account
+     * for. */
+    g_connections_opened++;
+
+    /* Everything but the version is well formed, so the only thing that can
+     * make the server refuse it is the version itself.  The first three
+     * fields are at fixed positions in every version (RFC 8166 sec 4.2), so
+     * a responder is always able to read the xid and answer. */
+    bad.rdma_xid       = 0x56455253;
+    bad.rdma_vers      = 2;
+    bad.rdma_credit    = 1;
+    bad.rdma_body.proc = RDMA_MSG;
+
+    bad.rdma_body.rdma_msg.rdma_reads  = NULL;
+    bad.rdma_body.rdma_msg.rdma_writes = NULL;
+    bad.rdma_body.rdma_msg.rdma_reply  = NULL;
+
+    len  = marshall_length_rdma_msg(&bad);
+    niov = evpl_iovec_alloc(evpl, len, 0, 1, 0, &iov);
+
+    evpl_test_abort_if(niov != 1, "version probe: iovec alloc failed");
+
+    marshall_rdma_msg(&bad, &iov, &out_iov, &out_niov, NULL, 0);
+
+    if (out_niov > 0) {
+        evpl_iovec_release(evpl, &out_iov);
+    }
+
+    evpl_iovec_set_length(&iov, len);
+
+    evpl_sendv(evpl, bind, &iov, 1, len, EVPL_SEND_FLAG_TAKE_REF);
+
+    while (!vp.done && ++spins < 100000000) {
+        evpl_continue(evpl);
+    }
+
+    evpl_test_abort_if(!vp.done, "version probe: no answer to a bad version");
+    evpl_test_abort_if(!vp.got_rdma_error,
+                       "version probe: answer was not an RDMA_ERROR");
+    evpl_test_abort_if(vp.err != ERR_VERS,
+                       "version probe: expected ERR_VERS (%d), got %d",
+                       ERR_VERS, vp.err);
+    evpl_test_abort_if(vp.vers_low != 1 || vp.vers_high != 1,
+                       "version probe: reported range %u-%u, expected 1-1",
+                       vp.vers_low, vp.vers_high);
+
+    g_results.rdma_error_checks++;
+
+    evpl_close(evpl, bind);
+} /* check_rdma_version_mismatch */
+
+/* ------------------------------------------------------------------ *
+* RPC-over-RDMA data placement
+*
+* Every generated send_call_* takes (ddp, max_rdma_write_chunk,
+* write_chunk_iov, write_chunk_niov, max_rdma_reply_chunk).  rpc2.c gates all
+* of it on conn->rdma, so these are inert on the stream transport and select
+* real chunk-negotiation paths on RDMA-on-TCP -- which is why the same case
+* table is run over both.
+* ------------------------------------------------------------------ */
+
+#define CHUNK_BUF_BYTES       MAX_PAYLOAD
+
+/*
+ * A reply chunk has to hold the entire RPC reply message, not just a payload,
+ * and the largest reply in the matrix (ECHO_BYTES with two 1000-byte fields)
+ * runs past 2 KiB.  Sized well clear of that: a responder handed a reply chunk
+ * too small for the reply truncates it silently rather than reporting
+ * ERR_CHUNK, so an undersized buffer here would look like a decode failure
+ * with no hint as to why.  See CONFORMANCE.md.
+ */
+#define REPLY_CHUNK_BUF_BYTES 8192
+
+struct chunk_params {
+    int                ddp;
+    int                max_write;
+    struct evpl_iovec *iov;
+    int                niov;
+    int                max_reply;
+};
+
+static void
+chunk_params_init(
+    struct evpl                  *evpl,
+    struct chunk_params          *cp,
+    const struct conf_value_case *c)
+{
+    memset(cp, 0, sizeof(*cp));
+
+    switch (c->chunk) {
+        case CLS_CHUNKNONE:
+            break;
+        case CLS_CHUNKDDP:
+            cp->ddp = 1;
+            break;
+        case CLS_CHUNKREPLY:
+            cp->ddp       = 1;
+            cp->max_reply = REPLY_CHUNK_BUF_BYTES;
+            break;
+        case CLS_CHUNKWRITEALLOC:
+            /* A write chunk with no buffer supplied: libevpl allocates the
+             * destination itself and the decoded reply points into it, so the
+             * references are the client's to release like any other decode. */
+            cp->max_write = CHUNK_BUF_BYTES;
+            break;
+        case CLS_CHUNKWRITEEXACT:
+            /* Offer room for exactly the payload the reply will carry, so the
+             * responder consumes the segment to its last byte instead of
+             * capping it short.  Only ECHO_ZBYTES reaches here (the model
+             * confines the write-chunk classes to it), so the reply's payload
+             * length is the request's.  A zero-length payload asks for no
+             * chunk at all, which is the honest reading of "exactly zero
+             * bytes" and leaves the case equivalent to the inline one. */
+            cp->max_write = len_bytes(c->opaque_len);
+            break;
+        default:  /* CLS_CHUNKREADINTO */
+            evpl_test_abort_if(
+                evpl_iovec_alloc(evpl, CHUNK_BUF_BYTES, 1, 1, 0, &g_chunk_dest) != 1,
+                "evpl_iovec_alloc failed for the read-into destination");
+            memset(evpl_iovec_data(&g_chunk_dest), 0, CHUNK_BUF_BYTES);
+            g_chunk_dest_held = 1;
+            cp->max_write     = CHUNK_BUF_BYTES;
+            cp->iov           = &g_chunk_dest;
+            cp->niov          = 1;
+            break;
+    } /* switch */
+} /* chunk_params_init */
+
+static void
+chunk_params_release(struct evpl *evpl)
+{
+    if (g_chunk_dest_held) {
+        evpl_iovec_release(evpl, &g_chunk_dest);
+        g_chunk_dest_held = 0;
+    }
+} /* chunk_params_release */
+
+/* Scratch storage for request construction. */
+static struct evpl_iovec g_ziov;
+static uint32_t          g_u32_scratch[128];
+static struct point      g_pt_scratch[128];
+static struct lnode      g_node_scratch[128];
+static struct rec        g_rec_scratch[128];
+
+static void
+fill_scalars(
+    struct scalars               *s,
+    const struct conf_value_case *c)
+{
+    s->s32 = int_value(c->i);
+    s->u32 = uint_value(c->u);
+    s->s64 = long_value(c->l);
+    s->u64 = ulong_value(c->ul);
+    s->f32 = float_value(c->f);
+    s->f64 = double_value(c->f);
+    s->b   = (c->b == CLS_BTRUE);
+    s->c   = color_value(c->col);
+} /* fill_scalars */
+
+static void
+run_value_case(
+    struct evpl                  *evpl,
+    struct CONFORMANCE_V1        *prog,
+    struct evpl_rpc2_conn        *conn,
+    const struct conf_value_case *c)
+{
+    struct value_state  st;
+    struct chunk_params cp;
+    unsigned int        i, n;
+    int                 rc;
+
+    memset(&st, 0, sizeof(st));
+    chunk_params_init(evpl, &cp, c);
+
+    /* Who owns the iovecs a decoded zcopaque reply points at.
+    *
+    * Normally the decoder clones into the reply and the client releases what
+    * it decoded.  The one exception is a case that armed its own destination
+    * buffer (ChunkReadInto) on a transport that honours it: there the
+    * responder RDMA-wrote into that buffer, rpc2.c moved the borrowed iovec
+    * into the request's read chunk, and the unmarshaller short-circuited the
+    * reply's payload to alias it.  No reference was taken anywhere along that
+    * path, so the single reference is the one this driver allocated and it is
+    * dropped exactly once, by chunk_params_release.  Releasing it again from
+    * the callback corrupts the allocator free list into a cycle, which
+    * surfaces as a hang in evpl_allocator_destroy at exit. */
+    st.owns_reply_payload = !(c->chunk == CLS_CHUNKREADINTO && conn->rdma);
+
+    switch (c->proc) {
+        case CLS_ECHOSCALARS: {
+            static struct scalars arg;
+
+            fill_scalars(&arg, c);
+            st.expect = &arg;
+            prog->send_call_ECHO_SCALARS(&prog->rpc2, evpl, conn, NULL, &arg,
+                                         cp.ddp, cp.max_write, cp.iov, cp.niov, cp.max_reply,
+                                         client_reply_scalars, &st);
+            break;
+        }
+
+        case CLS_ECHOBYTES: {
+            static struct bytes arg;
+
+            arg.s.len = len_bytes(c->str_len);
+            arg.s.str = (char *) g_pattern;
+            /* Bounded, so it takes the bounded-length class rather than the
+             * string one, which may exceed the declared bound. */
+            arg.bounded_s.len = len_bytes(c->bounded_len);
+            arg.bounded_s.str = (char *) g_pattern;
+            arg.v.len         = len_bytes(c->opaque_len);
+            arg.v.data        = g_pattern;
+            arg.bounded.len   = len_bytes(c->bounded_len);
+            arg.bounded.data  = g_pattern;
+            memcpy(arg.f, g_pattern, FIXED_OPAQUE_LEN);
+            st.expect = &arg;
+            prog->send_call_ECHO_BYTES(&prog->rpc2, evpl, conn, NULL, &arg,
+                                       cp.ddp, cp.max_write, cp.iov, cp.niov, cp.max_reply,
+                                       client_reply_bytes, &st);
+            break;
+        }
+
+        case CLS_ECHOZBYTES: {
+            static struct zbytes arg;
+            uint32_t             zlen = len_bytes(c->opaque_len);
+
+            memset(&arg, 0, sizeof(arg));
+            arg.head = uint_value(c->u);
+            arg.tail = ~uint_value(c->u);
+
+            if (zlen) {
+                /*
+                 * Ownership: __marshall_opaque_zerocopy MOVES this reference
+                 * into the send path (xdr_iovec_move_private), so the sender
+                 * must not release it afterwards -- doing so double-frees and
+                 * corrupts the allocator's free list.  The receiving side is
+                 * the opposite: the unmarshaller clones, so a handler that
+                 * decodes a zcopaque field does have to release it.
+                 */
+                evpl_test_abort_if(evpl_iovec_alloc(evpl, zlen, 1, 1, 0, &g_ziov) != 1,
+                                   "evpl_iovec_alloc failed for %u bytes", zlen);
+                memcpy(evpl_iovec_data(&g_ziov), g_pattern, zlen);
+                arg.z.iov    = &g_ziov;
+                arg.z.niov   = 1;
+                arg.z.length = zlen;
+            }
+
+            st.zbytes_len  = zlen;
+            st.zbytes_tail = arg.tail;
+            prog->send_call_ECHO_ZBYTES(&prog->rpc2, evpl, conn, NULL, &arg,
+                                        cp.ddp, cp.max_write, cp.iov, cp.niov, cp.max_reply,
+                                        client_reply_zbytes, &st);
+            break;
+        }
+
+        case CLS_ECHOARRAYS: {
+            static struct arrays arg;
+
+            memset(&arg, 0, sizeof(arg));
+            for (i = 0; i < FIXED_ARRAY_LEN; i++) {
+                arg.fixed_u32[i] = uint_value(c->u) ^ i;
+            }
+            n = len_count(c->arr_len);
+            for (i = 0; i < n; i++) {
+                g_u32_scratch[i] = i * 3 + 1;
+            }
+            arg.num_var_u32 = n;
+            arg.var_u32     = g_u32_scratch;
+
+            arg.num_bounded_u32 = len_count(c->bounded_len);
+            arg.bounded_u32     = g_u32_scratch;
+
+            for (i = 0; i < 2; i++) {
+                arg.fixed_pt[i].x = (int32_t) i;
+                arg.fixed_pt[i].y = -(int32_t) i;
+            }
+            n = len_count(c->arr_len);
+            for (i = 0; i < n; i++) {
+                g_pt_scratch[i].x = (int32_t) i;
+                g_pt_scratch[i].y = (int32_t) (i * 2);
+            }
+            arg.num_var_pt = n;
+            arg.var_pt     = g_pt_scratch;
+
+            st.expect = &arg;
+            prog->send_call_ECHO_ARRAYS(&prog->rpc2, evpl, conn, NULL, &arg,
+                                        cp.ddp, cp.max_write, cp.iov, cp.niov, cp.max_reply,
+                                        client_reply_arrays, &st);
+            break;
+        }
+
+        case CLS_ECHOUNION: {
+            static struct tagged arg;
+
+            memset(&arg, 0, sizeof(arg));
+            switch (c->arm) {
+                case CLS_ARMNONE:
+                    arg.k = K_NONE;
+                    break;
+                case CLS_ARMINT:
+                    arg.k = K_INT;
+                    arg.i = int_value(c->i);
+                    break;
+                case CLS_ARMSTR:
+                    arg.k     = K_STR;
+                    arg.s.len = len_bytes(c->str_len);
+                    arg.s.str = (char *) g_pattern;
+                    break;
+                default:
+                    arg.k   = K_PT;
+                    arg.p.x = int_value(c->i);
+                    arg.p.y = -int_value(c->i);
+                    break;
+            } /* switch */
+            st.expect = &arg;
+            prog->send_call_ECHO_UNION(&prog->rpc2, evpl, conn, NULL, &arg,
+                                       cp.ddp, cp.max_write, cp.iov, cp.niov, cp.max_reply,
+                                       client_reply_tagged, &st);
+            break;
+        }
+
+        case CLS_ECHOOPTIONAL: {
+            static struct opt_msg arg;
+            static struct point   pt;
+
+            pt.x     = int_value(c->i);
+            pt.y     = -int_value(c->i);
+            arg.head = uint_value(c->u);
+            arg.tail = ~uint_value(c->u);
+            arg.opt  = (c->opt_present == CLS_OPTPRESENT) ? &pt : NULL;
+
+            st.expect = &arg;
+            prog->send_call_ECHO_OPTIONAL(&prog->rpc2, evpl, conn, NULL, &arg,
+                                          cp.ddp, cp.max_write, cp.iov, cp.niov, cp.max_reply,
+                                          client_reply_opt_msg, &st);
+            break;
+        }
+
+        case CLS_ECHOLIST: {
+            static struct list_msg arg;
+
+            n           = len_count(c->depth);
+            arg.trailer = uint_value(c->u);
+            arg.head    = NULL;
+            for (i = 0; i < n; i++) {
+                g_node_scratch[i].value    = i * 11 + 5;
+                g_node_scratch[i].nextnode = (i + 1 < n) ? &g_node_scratch[i + 1] : NULL;
+            }
+            if (n) {
+                arg.head = &g_node_scratch[0];
+            }
+
+            st.expect = &arg;
+            prog->send_call_ECHO_LIST(&prog->rpc2, evpl, conn, NULL, &arg,
+                                      cp.ddp, cp.max_write, cp.iov, cp.niov, cp.max_reply,
+                                      client_reply_list_msg, &st);
+            break;
+        }
+
+        default: {
+            static struct nested arg;
+
+            memset(&arg, 0, sizeof(arg));
+            arg.inner_pt.x = int_value(c->i);
+            arg.inner_pt.y = -int_value(c->i);
+            fill_scalars(&arg.inner_scalars, c);
+            arg.tail = uint_value(c->u);
+
+            n = len_count(c->depth);
+            for (i = 0; i < n; i++) {
+                g_rec_scratch[i].depth = i;
+                g_rec_scratch[i].chain = (i + 1 < n) ? &g_rec_scratch[i + 1] : NULL;
+            }
+            arg.chain = n ? &g_rec_scratch[0] : NULL;
+
+            st.expect = &arg;
+            prog->send_call_ECHO_NESTED(&prog->rpc2, evpl, conn, NULL, &arg,
+                                        cp.ddp, cp.max_write, cp.iov, cp.niov, cp.max_reply,
+                                        client_reply_nested, &st);
+            break;
+        }
+    } /* switch */
+
+    g_results.value_run++;
+
+    rc = wait_for_reply(evpl, &st);
+
+    chunk_params_release(evpl);
+
+    if (rc) {
+        evpl_test_error("value case proc=%u: no reply", c->proc);
+        g_results.value_failed++;
+        return;
+    }
+
+    if (!st.matched) {
+        evpl_test_error(
+            "value case proc=%u status=%d: round trip did not preserve the value "
+            "(classes i=%u u=%u l=%u ul=%u f=%u b=%u col=%u str=%u opq=%u bnd=%u arr=%u opt=%u arm=%u depth=%u chunk=%u)",
+            c->proc, st.status, c->i, c->u, c->l, c->ul, c->f, c->b, c->col,
+            c->str_len, c->opaque_len, c->bounded_len, c->arr_len,
+            c->opt_present, c->arm, c->depth, c->chunk);
+        g_results.value_failed++;
+    }
+} /* run_value_case */
+
+/*
+ * The value phase runs the server and the client in a single event loop, the
+ * way hello_world does: evpl_continue drives both sides, so a call and its
+ * reply complete without a second thread.  Two concurrently live evpl
+ * instances are deliberately avoided -- evpl_destroy tears down process-wide
+ * allocator state, so overlapping lifetimes do not compose.
+ */
+static void
+run_value_phase(
+    struct evpl           *evpl,
+    struct CONFORMANCE_V1 *prog,
+    struct evpl_rpc2_conn *conn)
+{
+    unsigned int i;
+
+    g_results.rdma_capable = conn->rdma;
+
+    for (i = 0; i < CONF_NUM_VALUE_CASES; i++) {
+        /* A case asking for a chunk exercises direct placement on a transport
+         * that reports RDMA and the inline fallback on one that does not, so
+         * the same case is two different tests depending on where it runs.
+         * Counted here so the summary says which of the two this run was. */
+        if (conf_value_cases[i].chunk != CLS_CHUNKNONE) {
+            g_results.value_chunked++;
+        }
+        run_value_case(evpl, prog, conn, &conf_value_cases[i]);
+    }
+
+    /* Not a model case -- see the comment on the function. */
+    check_reply_chunk_too_small(evpl, prog, conn);
+} /* run_value_phase */
+
+/* ------------------------------------------------------------------ *
+* Defect phase: hand-built wire messages over a raw TCP socket
+* ------------------------------------------------------------------ */
+
+struct wirebuf {
+    uint8_t  data[4096];
+    uint32_t len;
+};
+
+static void
+put32(
+    struct wirebuf *b,
+    uint32_t        v)
+{
+    evpl_test_abort_if(b->len + 4 > sizeof(b->data), "wire buffer overflow");
+    b->data[b->len++] = (uint8_t) (v >> 24);
+    b->data[b->len++] = (uint8_t) (v >> 16);
+    b->data[b->len++] = (uint8_t) (v >> 8);
+    b->data[b->len++] = (uint8_t) v;
+} /* put32 */
+
+static void
+put_bytes(
+    struct wirebuf *b,
+    const void     *src,
+    uint32_t        n)
+{
+    uint32_t pad = (4 - (n & 3)) & 3;
+
+    evpl_test_abort_if(b->len + n + pad > sizeof(b->data), "wire buffer overflow");
+    memcpy(b->data + b->len, src, n);
+    b->len += n;
+    memset(b->data + b->len, 0, pad);
+    b->len += pad;
+} /* put_bytes */
+
+static uint32_t
+get32(const uint8_t *p)
+{
+    return ((uint32_t) p[0] << 24) | ((uint32_t) p[1] << 16) |
+           ((uint32_t) p[2] << 8) | (uint32_t) p[3];
+} /* get32 */
+
+/*
+ * Offsets of the fields the payload defects target, within each baseline
+ * argument encoding below.  Kept as named constants so that a change to a
+ * baseline is an obvious compile-time-adjacent edit rather than a silent
+ * mis-aimed poke.
+ */
+#define BYTES_OFF_STRING_LEN   0    /* bytes.s.len                             */
+#define BYTES_OFF_BOUNDED_STR  8    /* bytes.bounded_s.len (after s)           */
+#define BYTES_OFF_BOUNDED_LEN  24   /* bytes.bounded.len (after s, bounded_s, v) */
+#define ARRAYS_OFF_VAR_COUNT   16   /* arrays.num_var_u32 (after fixed)   */
+#define ARRAYS_OFF_BOUNDED_CNT 28   /* arrays.num_bounded_u32             */
+#define SCALARS_OFF_BOOL       36   /* scalars.b                          */
+#define SCALARS_OFF_ENUM       40   /* scalars.c                          */
+#define STRICT_OFF_DISCRIM     0    /* strict.k                           */
+
+static int
+target_proc(uint8_t target)
+{
+    switch (target) {
+        case TGT_TSCALARS: return PROC_ECHO_SCALARS;
+        case TGT_TBYTES:   return PROC_ECHO_BYTES;
+        case TGT_TARRAYS:  return PROC_ECHO_ARRAYS;
+        default:           return PROC_PROBE_STRICT;
+    } /* switch */
+} /* target_proc */
+
+/* Build a valid argument encoding for the given target. */
+static void
+build_args(
+    struct wirebuf *b,
+    uint8_t         target)
+{
+    uint32_t i;
+
+    b->len = 0;
+
+    switch (target) {
+        case TGT_TSCALARS:
+            put32(b, 1);            /* s32 */
+            put32(b, 2);            /* u32 */
+            put32(b, 0); put32(b, 3); /* s64 */
+            put32(b, 0); put32(b, 4); /* u64 */
+            put32(b, 0x3f800000);   /* f32 = 1.0 */
+            put32(b, 0x3ff00000); put32(b, 0); /* f64 = 1.0 */
+            put32(b, 1);            /* b = TRUE */
+            put32(b, GREEN);        /* c */
+            break;
+
+        case TGT_TBYTES:
+            put32(b, 4);            /* s.len          */
+            put_bytes(b, g_pattern, 4);
+            put32(b, 4);            /* bounded_s.len  */
+            put_bytes(b, g_pattern, 4);
+            put32(b, 4);            /* v.len          */
+            put_bytes(b, g_pattern, 4);
+            put32(b, 4);            /* bounded.len */
+            put_bytes(b, g_pattern, 4);
+            put_bytes(b, g_pattern, FIXED_OPAQUE_LEN);
+            break;
+
+        case TGT_TARRAYS:
+            for (i = 0; i < FIXED_ARRAY_LEN; i++) {
+                put32(b, i);        /* fixed_u32[4] */
+            }
+            put32(b, 2);            /* num_var_u32  */
+            put32(b, 10); put32(b, 11);
+            put32(b, 2);            /* num_bounded_u32 */
+            put32(b, 20); put32(b, 21);
+            put32(b, 1); put32(b, 2);       /* fixed_pt[0] */
+            put32(b, 3); put32(b, 4);       /* fixed_pt[1] */
+            put32(b, 1);            /* num_var_pt  */
+            put32(b, 5); put32(b, 6);
+            break;
+
+        default:
+            put32(b, K_INT);        /* strict.k */
+            put32(b, 7);            /* strict.i */
+            break;
+    } /* switch */
+} /* build_args */
+
+/*
+ * A valid `bytes` call whose unbounded opaque carries a large blob.
+ *
+ * The pathological-fragmentation case needs a message it can divide into more
+ * record-mark fragments than the receiver's payload iovec ceiling.  The
+ * fragment loop floors a fragment at 4 bytes, so reaching several hundred
+ * fragments takes a payload of a few KiB -- far more than the ordinary
+ * targets, whose calls run to a hundred bytes or so.  Everything else about
+ * the encoding is exactly what build_args(TGT_TBYTES) produces, so the only
+ * thing under test is the framing.
+ */
+#define PATHOLOGICAL_BLOB_LEN  (2 * MAX_PAYLOAD)
+
+/*
+ * Fragment count for that case.  Must exceed the receiver's payload iovec
+ * ceiling (EVPL_RPC2_MAX_PAYLOAD_NIOV, 256) for the flattening path to be
+ * reached at all; the surplus is margin so the case keeps its meaning if that
+ * ceiling is raised a little.
+ */
+#define PATHOLOGICAL_FRAGMENTS 400
+
+static void
+build_args_large_bytes(struct wirebuf *b)
+{
+    uint32_t i;
+
+    b->len = 0;
+
+    put32(b, 4);                              /* s.len              */
+    put_bytes(b, g_pattern, 4);
+    put32(b, 4);                              /* bounded_s.len      */
+    put_bytes(b, g_pattern, 4);
+
+    /* Written as pattern-sized chunks; MAX_PAYLOAD is a multiple of 4, so no
+     * padding lands in the middle of the blob. */
+    put32(b, PATHOLOGICAL_BLOB_LEN);          /* v.len -- opaque<>  */
+    for (i = 0; i < PATHOLOGICAL_BLOB_LEN; i += MAX_PAYLOAD) {
+        put_bytes(b, g_pattern, MAX_PAYLOAD);
+    }
+
+    put32(b, 4);                              /* bounded.len        */
+    put_bytes(b, g_pattern, 4);
+    put_bytes(b, g_pattern, FIXED_OPAQUE_LEN);
+} /* build_args_large_bytes */
+
+/*
+ * Over-bound argument encodings that stay length-consistent.
+ *
+ * Poking an over-bound length into an otherwise normal message also breaks
+ * the total length, so the dispatcher's whole-message check would reject it
+ * whether or not the declared bound is enforced -- the case would pass for
+ * the wrong reason.  These builders supply the bytes the over-bound length
+ * claims, leaving the message perfectly well formed except for exceeding the
+ * bound, so only a real bound check can reject it.
+ */
+static void
+build_bytes_over_bound(
+    struct wirebuf *b,
+    uint32_t        str_len,
+    uint32_t        opaque_len)
+{
+    b->len = 0;
+    put32(b, 4);                                /* s.len          */
+    put_bytes(b, g_pattern, 4);
+    put32(b, str_len);                          /* bounded_s.len  */
+    put_bytes(b, g_pattern, str_len);
+    put32(b, 4);                                /* v.len          */
+    put_bytes(b, g_pattern, 4);
+    put32(b, opaque_len);                       /* bounded.len    */
+    put_bytes(b, g_pattern, opaque_len);
+    put_bytes(b, g_pattern, FIXED_OPAQUE_LEN);  /* f              */
+} /* build_bytes_over_bound */
+
+static void
+build_arrays_over_bound(
+    struct wirebuf *b,
+    uint32_t        bounded_count)
+{
+    uint32_t i;
+
+    b->len = 0;
+    for (i = 0; i < FIXED_ARRAY_LEN; i++) {
+        put32(b, i);                            /* fixed_u32[4]      */
+    }
+    put32(b, 2);                                /* num_var_u32       */
+    put32(b, 10); put32(b, 11);
+    put32(b, bounded_count);                    /* num_bounded_u32   */
+    for (i = 0; i < bounded_count; i++) {
+        put32(b, 20 + i);
+    }
+    put32(b, 1); put32(b, 2);                   /* fixed_pt[0]       */
+    put32(b, 3); put32(b, 4);                   /* fixed_pt[1]       */
+    put32(b, 1);                                /* num_var_pt        */
+    put32(b, 5); put32(b, 6);
+} /* build_arrays_over_bound */
+
+static void
+poke32(
+    struct wirebuf *b,
+    uint32_t        off,
+    uint32_t        v)
+{
+    evpl_test_abort_if(off + 4 > b->len, "poke past end of args");
+    b->data[off]     = (uint8_t) (v >> 24);
+    b->data[off + 1] = (uint8_t) (v >> 16);
+    b->data[off + 2] = (uint8_t) (v >> 8);
+    b->data[off + 3] = (uint8_t) v;
+} /* poke32 */
+
+/* Is this defect meaningful against this target?  The RPCSEC_GSS cases are
+ * absent here on purpose: they act on the RPC header rather than on procedure
+ * arguments, so they are meaningful against every target and useful against
+ * exactly one.  run_defect_case picks that one -- see defect_case_first_time. */
+static int
+defect_applies(
+    uint8_t defect,
+    uint8_t target)
+{
+    switch (defect) {
+        case DEF_STRINGLENOVERFLOW:
+        case DEF_STRINGLENBEYONDMESSAGE:
+        case DEF_STRINGEXCEEDSBOUND:
+        case DEF_OPAQUEEXCEEDSBOUND:
+            return target == TGT_TBYTES;
+        case DEF_ARRAYCOUNTEXCEEDSBOUND:
+        case DEF_ARRAYCOUNTHUGE:
+            return target == TGT_TARRAYS;
+        case DEF_DISCRIMINANTUNMATCHED:
+            return target == TGT_TSTRICT;
+        case DEF_BOOLNOTZEROORONE:
+        case DEF_ENUMNOTDECLARED:
+            return target == TGT_TSCALARS;
+        /* Needs a payload big enough to divide into hundreds of fragments,
+        * and is meant to run once rather than across the target matrix. */
+        case DEF_CALLSPLITPATHOLOGICAL:
+            return target == TGT_TBYTES;
+        default:
+            return 1;
+    } /* switch */
+} /* defect_applies */
+
+static int
+connect_raw(void)
+{
+    struct sockaddr_storage ss;
+    struct sockaddr_in     *in;
+    struct sockaddr_un     *un;
+    socklen_t               len;
+    int                     fd, flag = 1, family;
+
+    memset(&ss, 0, sizeof(ss));
+
+    /* The defect phase writes record-marked bytes onto a socket of its own,
+     * so it follows whichever stream transport the run is using.  Record
+     * marking is a property of the framing rather than of the address family,
+     * so the same defects are expressible over AF_UNIX as over TCP. */
+    if (evpl_protocol_is_local(proto)) {
+        family = AF_UNIX;
+        un     = (struct sockaddr_un *) &ss;
+
+        un->sun_family = AF_UNIX;
+        snprintf(un->sun_path, sizeof(un->sun_path), "%s", g_address);
+
+        /* An abstract name is a leading NUL followed by the name, not a
+         * NUL-terminated path. */
+        if (g_address[0] == '@') {
+            un->sun_path[0] = '\0';
+            len             = offsetof(struct sockaddr_un, sun_path) +
+                1 + strlen(g_address + 1);
+        } else {
+            len = sizeof(*un);
+        }
+    } else {
+        family = AF_INET;
+        in     = (struct sockaddr_in *) &ss;
+
+        in->sin_family      = AF_INET;
+        in->sin_port        = htons(port);
+        in->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        len                 = sizeof(*in);
+    }
+
+    fd = socket(family, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    if (fd < 0) {
+        return -1;
+    }
+
+    /* Loopback connect completes into the listen backlog without the server
+     * having accepted yet, so EINPROGRESS here is success as far as writing
+     * the request goes. */
+    if (connect(fd, (struct sockaddr *) &ss, len) < 0 &&
+        errno != EINPROGRESS) {
+        close(fd);
+        return -1;
+    }
+
+    if (family == AF_INET) {
+        setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+    }
+
+    g_connections_opened++;
+
+    return fd;
+} /* connect_raw */
+
+static int
+send_all(
+    struct evpl *evpl,
+    int          fd,
+    const void  *buf,
+    size_t       len)
+{
+    const uint8_t *p        = buf;
+    uint64_t       deadline = now_ms() + REPLY_TIMEOUT_MS;
+    ssize_t        n;
+
+    while (len) {
+        n = send(fd, p, len, MSG_NOSIGNAL);
+        if (n > 0) {
+            p   += n;
+            len -= n;
+            continue;
+        }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            evpl_continue(evpl);
+            if (now_ms() > deadline) {
+                return -1;
+            }
+            continue;
+        }
+        return -1;
+    }
+    return 0;
+} /* send_all */
+
+/*
+ * Write one record-mark fragment: the 4-byte mark, terminal bit set only for
+ * the last of a record, followed by the payload.  Returns -1 if either write
+ * could not be completed, which on a connection the server has already
+ * dropped is an outcome rather than an error.
+ */
+static int
+send_fragment(
+    struct evpl *evpl,
+    int          fd,
+    const void  *data,
+    uint32_t     len,
+    int          last)
+{
+    uint8_t  hdr[4];
+    uint32_t m = (last ? 0x80000000u : 0u) | len;
+
+    hdr[0] = (uint8_t) (m >> 24);
+    hdr[1] = (uint8_t) (m >> 16);
+    hdr[2] = (uint8_t) (m >> 8);
+    hdr[3] = (uint8_t) m;
+
+    if (send_all(evpl, fd, hdr, 4)) {
+        return -1;
+    }
+
+    return len ? send_all(evpl, fd, data, len) : 0;
+} /* send_fragment */
+
+/*
+ * Read one record-marked reply and classify it.  Returns an EXP_ or ACT_ code.
+ */
+static int
+read_outcome_full(
+    struct evpl *evpl,
+    int          fd,
+    uint32_t    *out_lo,
+    uint32_t    *out_hi,
+    uint8_t     *results,
+    uint32_t    *results_len)
+{
+    uint8_t  buf[4096];
+    uint32_t mark, want, off = 0;
+    uint64_t deadline = now_ms() + REPLY_TIMEOUT_MS;
+    ssize_t  n;
+    uint32_t xid, mtype, rstat, pos;
+
+    *out_lo = *out_hi = 0;
+
+    /* Record mark.  evpl_continue drives the server, which shares this
+     * thread, so the reply can only arrive while we are pumping. */
+    while (off < 4) {
+        n = recv(fd, buf + off, 4 - off, 0);
+        if (n == 0) {
+            return EXP_CLOSED;
+        }
+        if (n < 0) {
+            if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                return EXP_CLOSED;
+            }
+            evpl_continue(evpl);
+            if (now_ms() > deadline) {
+                return ACT_STALLED;
+            }
+            continue;
+        }
+        off += n;
+    }
+
+    mark = get32(buf);
+    want = mark & 0x7fffffff;
+    if (want > sizeof(buf)) {
+        return ACT_MALFORMED;
+    }
+
+    off = 0;
+    while (off < want) {
+        n = recv(fd, buf + off, want - off, 0);
+        if (n == 0) {
+            return EXP_CLOSED;
+        }
+        if (n < 0) {
+            if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                return EXP_CLOSED;
+            }
+            evpl_continue(evpl);
+            if (now_ms() > deadline) {
+                return ACT_STALLED;
+            }
+            continue;
+        }
+        off += n;
+    }
+
+    if (want < 12) {
+        return ACT_MALFORMED;
+    }
+
+    xid   = get32(buf);
+    mtype = get32(buf + 4);
+    rstat = get32(buf + 8);
+    (void) xid;
+
+    if (mtype != 1) {  /* REPLY */
+        return ACT_MALFORMED;
+    }
+
+    if (rstat == 0) {  /* MSG_ACCEPTED */
+        uint32_t verf_len, astat;
+
+        if (want < 20) {
+            return ACT_MALFORMED;
+        }
+        verf_len = get32(buf + 16);
+        pos      = 20 + ((verf_len + 3) & ~3u);
+        if (pos + 4 > want) {
+            return ACT_MALFORMED;
+        }
+        astat = get32(buf + pos);
+        pos  += 4;
+
+        if (results && results_len) {
+            uint32_t avail = want - pos;
+
+            if (avail > *results_len) {
+                avail = *results_len;
+            }
+            memcpy(results, buf + pos, avail);
+            *results_len = avail;
+        }
+
+        switch (astat) {
+            case 0: return EXP_SUCCESS;
+            case 1: return EXP_PROGUNAVAIL;
+            case 2:
+                if (pos + 8 <= want) {
+                    *out_lo = get32(buf + pos);
+                    *out_hi = get32(buf + pos + 4);
+                }
+                return EXP_PROGMISMATCH;
+            case 3: return EXP_PROCUNAVAIL;
+            case 4: return EXP_GARBAGEARGS;
+            case 5: return ACT_SYSTEM_ERR;
+            default: return ACT_MALFORMED;
+        } /* switch */
+    }
+
+    if (rstat == 1) {  /* MSG_DENIED */
+        uint32_t jstat;
+
+        if (want < 16) {
+            return ACT_MALFORMED;
+        }
+        jstat = get32(buf + 12);
+        if (jstat == 0) {  /* RPC_MISMATCH */
+            if (want >= 24) {
+                *out_lo = get32(buf + 16);
+                *out_hi = get32(buf + 20);
+            }
+            return EXP_RPCMISMATCH;
+        }
+        return EXP_AUTHERROR;
+    }
+
+    return ACT_MALFORMED;
+} /* read_outcome */
+
+static int
+read_outcome(
+    struct evpl *evpl,
+    int          fd,
+    uint32_t    *out_lo,
+    uint32_t    *out_hi)
+{
+    return read_outcome_full(evpl, fd, out_lo, out_hi, NULL, NULL);
+} /* read_outcome */
+
+static int
+read_outcome_body(
+    struct evpl *evpl,
+    int          fd,
+    uint8_t     *results,
+    uint32_t    *results_len)
+{
+    uint32_t lo, hi;
+
+    return read_outcome_full(evpl, fd, &lo, &hi, results, results_len);
+} /* read_outcome_body */
+
+/* Append an argument encoding to a message already under construction. */
+static void
+build_args_into(
+    struct wirebuf *b,
+    uint8_t         target)
+{
+    struct wirebuf tmp;
+
+    build_args(&tmp, target);
+    evpl_test_abort_if(b->len + tmp.len > sizeof(b->data),
+                       "wire buffer overflow");
+    memcpy(b->data + b->len, tmp.data, tmp.len);
+    b->len += tmp.len;
+} /* build_args_into */
+
+/*
+ * A well-formed AUTH_SYS credential body (RFC 5531 sec 8.2): stamp,
+ * machinename<255>, uid, gid, gids<16>.  The other AUTH_SYS case in the matrix
+ * declares a length that runs off the end of the message, so without this one
+ * the flavor's accepted path -- the whole of the credential decode -- would
+ * never be reached by anything.
+ */
+static void
+build_authsys_cred(struct wirebuf *b)
+{
+    static const char machine[] = "conformance";
+    uint32_t          i;
+
+    b->len = 0;
+    put32(b, 0x53595300);                        /* stamp        */
+    put32(b, (uint32_t) (sizeof(machine) - 1));  /* machinename  */
+    put_bytes(b, machine, sizeof(machine) - 1);
+    put32(b, 1000);                              /* uid          */
+    put32(b, 100);                               /* gid          */
+    put32(b, 3);                                 /* gids<16>     */
+    for (i = 0; i < 3; i++) {
+        put32(b, 200 + i);
+    }
+} /* build_authsys_cred */
+
+/* ------------------------------------------------------------------ *
+* RPCSEC_GSS (RFC 2203)
+*
+* libevpl owns the RPCSEC_GSS framing but links no mechanism, so these cases
+* run against the deterministic provider in gss_stub.c.  Because the stub's
+* MIC is reproducible here, the driver can present verifiers the server
+* accepts -- which is what makes the success paths reachable instead of only
+* the rejections.
+* ------------------------------------------------------------------ */
+
+#define RPCSEC_GSS_FLAVOR    6
+#define RPCSEC_GSS_VERS_1    1
+
+#define RPCSEC_GSS_DATA      0
+#define RPCSEC_GSS_INIT      1
+#define RPCSEC_GSS_CONT_INIT 2
+#define RPCSEC_GSS_DESTROY   3
+
+#define GSS_SVC_NONE         1
+#define GSS_SVC_INTEGRITY    2
+#define GSS_SVC_PRIVACY      3
+
+/* Bytes the client signs: the header from the xid through the credential,
+ * i.e. xid..proc (24) + the credential's flavor and length (8) + the
+ * credential body, padded.  Mirrors rpc2.c's signed_len computation. */
+static uint32_t
+gss_signed_len(uint32_t cred_len)
+{
+    return 24 + 8 + ((cred_len + 3) & ~3u);
+} /* gss_signed_len */
+
+/* Append an RPCSEC_GSS credential and return its unpadded body length. */
+static uint32_t
+put_gss_cred(
+    struct wirebuf *b,
+    uint32_t        version,
+    uint32_t        gss_proc,
+    uint32_t        seq,
+    uint32_t        service,
+    const uint32_t *handle)
+{
+    uint32_t body_len = 4 * 4 + 4 + (handle ? 4 : 0);
+
+    put32(b, RPCSEC_GSS_FLAVOR);
+    put32(b, body_len);
+    put32(b, version);
+    put32(b, gss_proc);
+    put32(b, seq);
+    put32(b, service);
+    if (handle) {
+        put32(b, 4);
+        put32(b, *handle);
+    } else {
+        put32(b, 0);
+    }
+    return body_len;
+} /* put_gss_cred */
+
+/* Send one framed message and read the reply's accept/reject classification,
+ * optionally handing back the results body so a caller can parse it. */
+static int
+gss_exchange(
+    struct evpl    *evpl,
+    int             fd,
+    struct wirebuf *msg,
+    uint8_t        *results,
+    uint32_t       *results_len)
+{
+    uint8_t  hdr[4];
+    uint32_t m = 0x80000000u | msg->len;
+
+    hdr[0] = (uint8_t) (m >> 24);
+    hdr[1] = (uint8_t) (m >> 16);
+    hdr[2] = (uint8_t) (m >> 8);
+    hdr[3] = (uint8_t) m;
+
+    if (send_all(evpl, fd, hdr, 4) || send_all(evpl, fd, msg->data, msg->len)) {
+        return ACT_MALFORMED;
+    }
+
+    return read_outcome_body(evpl, fd, results, results_len);
+} /* gss_exchange */
+
+/*
+ * The same exchange, but with the call delivered as two record fragments split
+ * at `split_at` bytes.  RFC 5531 sec 10 puts no constraint on where a fragment
+ * boundary falls, and the security flavor is not supposed to notice: the
+ * server has to reassemble first and verify afterwards.  The interesting
+ * consequence is that the reassembled message reaches the GSS layer as several
+ * buffers rather than one, so every byte range it needs -- the signed header,
+ * the databody, the checksum -- has to be gathered across them.
+ */
+static int
+gss_exchange_split(
+    struct evpl    *evpl,
+    int             fd,
+    struct wirebuf *msg,
+    uint32_t        split_at,
+    uint8_t        *results,
+    uint32_t       *results_len)
+{
+    uint8_t  hdr[4];
+    uint32_t part[2], off = 0;
+    int      i;
+
+    evpl_test_abort_if(split_at == 0 || split_at >= msg->len,
+                       "gss fragment split point outside the message");
+
+    part[0] = split_at;
+    part[1] = msg->len - split_at;
+
+    for (i = 0; i < 2; i++) {
+        uint32_t m = (i == 1 ? 0x80000000u : 0u) | part[i];
+
+        hdr[0] = (uint8_t) (m >> 24);
+        hdr[1] = (uint8_t) (m >> 16);
+        hdr[2] = (uint8_t) (m >> 8);
+        hdr[3] = (uint8_t) m;
+
+        if (send_all(evpl, fd, hdr, 4) ||
+            send_all(evpl, fd, msg->data + off, part[i])) {
+            return ACT_MALFORMED;
+        }
+        off += part[i];
+    }
+
+    return read_outcome_body(evpl, fd, results, results_len);
+} /* gss_exchange_split */
+
+/* How the GSS token in an rpc_gss_init_arg should be encoded. */
+#define INIT_TOKEN_GOOD    0   /* a well-formed opaque<>                    */
+#define INIT_TOKEN_ABSENT  1   /* no arguments at all: not even a length    */
+#define INIT_TOKEN_OVERRUN 2   /* a length that runs past the message       */
+
+/*
+ * Build one leg of the context-establishment handshake.  The handshake rides
+ * on the program's NULL procedure and its arguments are an rpc_gss_init_arg,
+ * i.e. a lone opaque token (RFC 2203 sec 5.2.2).
+ */
+static void
+build_gss_init_call(
+    struct wirebuf *msg,
+    uint32_t        xid,
+    uint32_t        gss_proc,
+    const uint32_t *handle,
+    int             token_mode)
+{
+    msg->len = 0;
+    put32(msg, xid);
+    put32(msg, 0);                      /* CALL */
+    put32(msg, 2);
+    put32(msg, CONF_PROG);
+    put32(msg, CONF_VERS);
+    put32(msg, 0);                      /* NULL procedure */
+    put_gss_cred(msg, RPCSEC_GSS_VERS_1, gss_proc, 0, GSS_SVC_NONE, handle);
+    put32(msg, 0);                      /* verf AUTH_NONE */
+    put32(msg, 0);
+
+    switch (token_mode) {
+        case INIT_TOKEN_ABSENT:
+            break;
+        case INIT_TOKEN_OVERRUN:
+            put32(msg, 0x10000);        /* token<> longer than the message */
+            put_bytes(msg, "INIT", 4);
+            break;
+        default:
+            put32(msg, 4);              /* token<> */
+            put_bytes(msg, "INIT", 4);
+            break;
+    } /* switch */
+} /* build_gss_init_call */
+
+/*
+ * Drive the context-establishment handshake and return the handle the server
+ * assigned.  The handshake rides on the program's NULL procedure, so this also
+ * exercises the interaction between RPCSEC_GSS and the generated proc 0.
+ */
+static int
+gss_establish(
+    struct evpl *evpl,
+    int          fd,
+    uint32_t    *out_handle,
+    int          legs)
+{
+    struct wirebuf msg;
+    uint8_t        results[512];
+    uint32_t       results_len, hlen;
+    int            outcome, leg;
+
+    for (leg = 0; leg < legs; leg++) {
+        build_gss_init_call(&msg, 0x47535331 + leg,
+                            leg == 0 ? RPCSEC_GSS_INIT : RPCSEC_GSS_CONT_INIT,
+                            leg == 0 ? NULL : out_handle,
+                            INIT_TOKEN_GOOD);
+
+        results_len = sizeof(results);
+        outcome     = gss_exchange(evpl, fd, &msg, results, &results_len);
+
+        if (outcome != EXP_SUCCESS) {
+            return outcome;
+        }
+
+        /* rpc_gss_init_res: handle<>, major, minor, seq_window, token<> */
+        if (results_len < 12) {
+            return ACT_MALFORMED;
+        }
+        hlen = get32(results);
+        if (hlen != 4) {
+            return ACT_MALFORMED;
+        }
+        *out_handle = get32(results + 4);
+    }
+
+    return EXP_SUCCESS;
+} /* gss_establish */
+
+/* Build a DATA call carrying a correctly computed header MIC. */
+static void
+build_gss_data_call(
+    struct wirebuf *msg,
+    uint32_t        xid,
+    uint32_t        handle,
+    uint32_t        seq,
+    uint32_t        service,
+    int             good_mic,
+    int             gss_verf)
+{
+    uint8_t  mic[GSS_STUB_MIC_LEN];
+    uint32_t cred_len;
+
+    msg->len = 0;
+    put32(msg, xid);
+    put32(msg, 0);                          /* CALL */
+    put32(msg, 2);
+    put32(msg, CONF_PROG);
+    put32(msg, CONF_VERS);
+    put32(msg, PROC_ECHO_SCALARS);
+    cred_len = put_gss_cred(msg, RPCSEC_GSS_VERS_1, RPCSEC_GSS_DATA,
+                            seq, service, &handle);
+
+    if (gss_verf) {
+        gss_stub_mic(msg->data, gss_signed_len(cred_len), mic);
+        if (!good_mic) {
+            mic[0] ^= 0xff;
+        }
+        put32(msg, RPCSEC_GSS_FLAVOR);
+        put32(msg, GSS_STUB_MIC_LEN);
+        put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+    } else {
+        put32(msg, 0);                      /* verf AUTH_NONE */
+        put32(msg, 0);
+    }
+
+    build_args_into(msg, TGT_TSCALARS);
+} /* build_gss_data_call */
+
+/*
+ * Build an integrity-service (krb5i) DATA call.  RFC 2203 sec 5.3.2.2 puts the
+ * arguments on the wire as
+ *   rpc_gss_integ_data { opaque databody<>; opaque checksum<>; }
+ * where databody is seq_num || proc_args and checksum is a MIC over it.
+ *
+ * body_seq is taken separately from the credential's seq so that a case can
+ * make the two disagree -- the one thing the RFC forbids about an otherwise
+ * well-formed databody -- while still presenting a checksum that verifies.
+ *
+ * with_args selects between a procedure that takes arguments and NULLPROC,
+ * whose databody is nothing but the seq_num.  A zero-length inner call is not
+ * an edge case dreamt up for the test: proc 0 is mandatory (RFC 5531 sec 11.1)
+ * and clients use it as a ping, so it is the first krb5i call a real client
+ * makes.
+ */
+static void
+build_gss_integ_call(
+    struct wirebuf *msg,
+    uint32_t        xid,
+    uint32_t        handle,
+    uint32_t        seq,
+    uint32_t        body_seq,
+    int             good_checksum,
+    int             with_args)
+{
+    struct wirebuf databody;
+    uint8_t        mic[GSS_STUB_MIC_LEN];
+    uint32_t       cred_len;
+
+    msg->len = 0;
+    put32(msg, xid);
+    put32(msg, 0);                          /* CALL */
+    put32(msg, 2);
+    put32(msg, CONF_PROG);
+    put32(msg, CONF_VERS);
+    put32(msg, with_args ? PROC_ECHO_SCALARS : 0);
+    cred_len = put_gss_cred(msg, RPCSEC_GSS_VERS_1, RPCSEC_GSS_DATA,
+                            seq, GSS_SVC_INTEGRITY, &handle);
+
+    /* The header MIC covers the message up to and including the credential,
+     * so it has to be taken before the verifier or the arguments land. */
+    gss_stub_mic(msg->data, gss_signed_len(cred_len), mic);
+    put32(msg, RPCSEC_GSS_FLAVOR);
+    put32(msg, GSS_STUB_MIC_LEN);
+    put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+
+    databody.len = 0;
+    put32(&databody, body_seq);
+    if (with_args) {
+        build_args_into(&databody, TGT_TSCALARS);
+    }
+
+    put32(msg, databody.len);
+    put_bytes(msg, databody.data, databody.len);
+
+    /* The checksum covers the unpadded databody, which is what the server
+     * gathers back out of the message. */
+    gss_stub_mic(databody.data, databody.len, mic);
+    if (!good_checksum) {
+        mic[0] ^= 0xff;
+    }
+    put32(msg, GSS_STUB_MIC_LEN);
+    put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+} /* build_gss_integ_call */
+
+/* Ways an rpc_gss_integ_data can fail to decode.  Each one keeps the
+ * credential, the header MIC and the sequence number valid, so the caller is
+ * authenticated and only the argument framing is at fault -- which is what
+ * makes GARBAGE_ARGS rather than a denial the required answer (RFC 2203
+ * sec 5.3.3.4.2). */
+#define INTEG_BAD_NO_LENGTH   0   /* arguments too short to hold a length   */
+#define INTEG_BAD_SHORT_BODY  1   /* databody shorter than its own seq_num  */
+#define INTEG_BAD_LONG_BODY   2   /* databody length past the message       */
+#define INTEG_BAD_NO_CHECKSUM 3   /* message ends where the checksum begins */
+#define INTEG_BAD_LONG_CKSUM  4   /* checksum length past the message       */
+
+static void
+build_gss_integ_bad_call(
+    struct wirebuf *msg,
+    uint32_t        xid,
+    uint32_t        handle,
+    uint32_t        seq,
+    int             mode)
+{
+    struct wirebuf databody;
+    uint8_t        mic[GSS_STUB_MIC_LEN];
+    uint32_t       cred_len;
+
+    msg->len = 0;
+    put32(msg, xid);
+    put32(msg, 0);                          /* CALL */
+    put32(msg, 2);
+    put32(msg, CONF_PROG);
+    put32(msg, CONF_VERS);
+    put32(msg, PROC_ECHO_SCALARS);
+    cred_len = put_gss_cred(msg, RPCSEC_GSS_VERS_1, RPCSEC_GSS_DATA,
+                            seq, GSS_SVC_INTEGRITY, &handle);
+
+    gss_stub_mic(msg->data, gss_signed_len(cred_len), mic);
+    put32(msg, RPCSEC_GSS_FLAVOR);
+    put32(msg, GSS_STUB_MIC_LEN);
+    put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+
+    if (mode == INTEG_BAD_NO_LENGTH) {
+        /* Two bytes of arguments: not enough for the databody's length
+         * prefix, let alone a databody. */
+        msg->data[msg->len++] = 0;
+        msg->data[msg->len++] = 0;
+        return;
+    }
+
+    if (mode == INTEG_BAD_SHORT_BODY) {
+        /* A databody too short to carry the seq_num it must begin with. */
+        put32(msg, 2);
+        put_bytes(msg, "\0\0", 2);
+        put32(msg, GSS_STUB_MIC_LEN);
+        put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+        return;
+    }
+
+    databody.len = 0;
+    put32(&databody, seq);
+    build_args_into(&databody, TGT_TSCALARS);
+
+    if (mode == INTEG_BAD_LONG_BODY) {
+        put32(msg, databody.len + 4096);
+        put_bytes(msg, databody.data, databody.len);
+        put32(msg, GSS_STUB_MIC_LEN);
+        put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+        return;
+    }
+
+    put32(msg, databody.len);
+    put_bytes(msg, databody.data, databody.len);
+
+    if (mode == INTEG_BAD_NO_CHECKSUM) {
+        return;                             /* no checksum opaque at all */
+    }
+
+    /* INTEG_BAD_LONG_CKSUM */
+    gss_stub_mic(databody.data, databody.len, mic);
+    put32(msg, 4096);
+    put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+} /* build_gss_integ_bad_call */
+
+/*
+ * Build a DATA call whose RPCSEC_GSS credential is deliberately undecodable.
+ * Everything after it is well formed, so the credential is the only thing
+ * wrong with the call and the auth_stat cannot be blamed on anything else.
+ */
+static void
+build_gss_bad_cred_call(
+    struct wirebuf *msg,
+    uint32_t        xid,
+    int             overrun)
+{
+    msg->len = 0;
+    put32(msg, xid);
+    put32(msg, 0);                          /* CALL */
+    put32(msg, 2);
+    put32(msg, CONF_PROG);
+    put32(msg, CONF_VERS);
+    put32(msg, PROC_ECHO_SCALARS);
+
+    put32(msg, RPCSEC_GSS_FLAVOR);
+    if (overrun) {
+        /* Complete through the fixed fields, then a handle<> whose length
+         * runs off the end of the credential body. */
+        put32(msg, 20);
+        put32(msg, RPCSEC_GSS_VERS_1);
+        put32(msg, RPCSEC_GSS_DATA);
+        put32(msg, 1);                      /* seq     */
+        put32(msg, GSS_SVC_NONE);
+        put32(msg, 64);                     /* handle<> length */
+    } else {
+        /* Stops after the fixed fields: the handle<> length is simply not
+         * there. */
+        put32(msg, 16);
+        put32(msg, RPCSEC_GSS_VERS_1);
+        put32(msg, RPCSEC_GSS_DATA);
+        put32(msg, 1);                      /* seq     */
+        put32(msg, GSS_SVC_NONE);
+    }
+
+    put32(msg, 0);                          /* verf AUTH_NONE */
+    put32(msg, 0);
+    build_args_into(msg, TGT_TSCALARS);
+} /* build_gss_bad_cred_call */
+
+/*
+ * Check that a reply came back wrapped for the integrity service: the results
+ * must be an rpc_gss_integ_data whose databody is the request's seq_num
+ * followed by the procedure results, under a checksum that verifies.  Without
+ * this, a server that skipped the wrapping entirely would still look like a
+ * success, since the accept status alone says nothing about the wrapping.
+ */
+static int
+check_integ_reply(
+    const uint8_t *results,
+    uint32_t       len,
+    uint32_t       seq,
+    int            with_args)
+{
+    struct wirebuf args;
+    uint8_t        expect[GSS_STUB_MIC_LEN];
+    uint32_t       db_len, db_pad, ck_len;
+
+    if (len < 8) {
+        return 0;
+    }
+
+    db_len = get32(results);
+    db_pad = (db_len + 3) & ~3u;
+    if (db_len < 4 || 4 + db_pad + 4 > len) {
+        return 0;
+    }
+
+    ck_len = get32(results + 4 + db_pad);
+    if (ck_len != GSS_STUB_MIC_LEN || 4 + db_pad + 4 + ck_len > len) {
+        return 0;
+    }
+
+    gss_stub_mic(results + 4, db_len, expect);
+    if (memcmp(expect, results + 4 + db_pad + 4, GSS_STUB_MIC_LEN)) {
+        return 0;
+    }
+
+    if (get32(results + 4) != seq) {
+        return 0;
+    }
+
+    /* NULLPROC returns nothing, so its wrapped databody is the seq_num and
+     * not a byte more.  A server that padded it out with something would
+     * still checksum correctly, so the length is the only thing that says
+     * the empty result survived the wrapping intact. */
+    if (!with_args) {
+        return db_len == 4;
+    }
+
+    /* Every handler echoes, so the unwrapped results must be the arguments
+     * that went in -- which is what proves the server decoded the inner call
+     * rather than handing back the wrapper it was given. */
+    build_args(&args, TGT_TSCALARS);
+    return db_len - 4 == args.len &&
+           memcmp(results + 8, args.data, args.len) == 0;
+} /* check_integ_reply */
+
+/*
+ * Build an RPCSEC_GSS_DESTROY control message.  RFC 2203 sec 5.4: framed like
+ * a data request, but with gss_proc set to DESTROY, NULLPROC in the header and
+ * no procedure arguments.
+ */
+static void
+build_gss_destroy_call(
+    struct wirebuf *msg,
+    uint32_t        xid,
+    uint32_t        handle,
+    uint32_t        seq,
+    int             gss_verf)
+{
+    uint8_t  mic[GSS_STUB_MIC_LEN];
+    uint32_t cred_len;
+
+    msg->len = 0;
+    put32(msg, xid);
+    put32(msg, 0);                          /* CALL */
+    put32(msg, 2);
+    put32(msg, CONF_PROG);
+    put32(msg, CONF_VERS);
+    put32(msg, 0);                          /* NULLPROC */
+    cred_len = put_gss_cred(msg, RPCSEC_GSS_VERS_1, RPCSEC_GSS_DESTROY,
+                            seq, GSS_SVC_NONE, &handle);
+
+    if (gss_verf) {
+        gss_stub_mic(msg->data, gss_signed_len(cred_len), mic);
+        put32(msg, RPCSEC_GSS_FLAVOR);
+        put32(msg, GSS_STUB_MIC_LEN);
+        put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+    } else {
+        put32(msg, 0);                      /* verf AUTH_NONE */
+        put32(msg, 0);
+    }
+} /* build_gss_destroy_call */
+
+/*
+ * Compare one observed outcome against what the model requires and record it.
+ * Shared by the byte-level defect path and the RPCSEC_GSS path so both report
+ * divergences the same way.
+ */
+static void
+record_outcome(
+    const struct conf_defect_case *c,
+    int                            actual,
+    uint32_t                       lo,
+    uint32_t                       hi)
+{
+    /* For the mismatch outcomes the version range is part of the contract: a
+     * client uses it to decide what to retry, so the right reply carrying the
+     * wrong range is still a divergence. */
+    if (actual == c->expect &&
+        (actual == EXP_PROGMISMATCH || actual == EXP_RPCMISMATCH) &&
+        c->expect_lo >= 0 &&
+        ((int32_t) lo != c->expect_lo || (int32_t) hi != c->expect_hi)) {
+        if (!is_known_divergence(c->defect, c->expect, ACT_BADRANGE)) {
+            evpl_test_error(
+                "defect %s: %s reported version range [%u,%u], expected [%d,%d]",
+                defect_name(c->defect), outcome_name(actual), lo, hi,
+                c->expect_lo, c->expect_hi);
+            g_results.defect_unknown++;
+            return;
+        }
+        g_results.defect_known++;
+        return;
+    }
+
+    if (actual == c->expect) {
+        g_results.defect_matched++;
+        return;
+    }
+
+    if (is_known_divergence(c->defect, c->expect, actual)) {
+        g_results.defect_known++;
+        return;
+    }
+
+    evpl_test_error("defect %s (target %u): expected %s, got %s",
+                    defect_name(c->defect), c->target,
+                    outcome_name(c->expect), outcome_name(actual));
+    g_results.defect_unknown++;
+} /* record_outcome */
+
+/*
+ * Is this one of the RPCSEC_GSS cases?  Enumerated rather than expressed as an
+ * enum range: the generated enum's order follows the model's defect list, and
+ * a later defect appended between two GSS ones would silently break a range
+ * test while this one still compiles into the right answer.
+ */
+static int
+defect_is_gss(uint8_t defect)
+{
+    switch (defect) {
+        case DEF_GSSINITESTABLISHES:
+        case DEF_GSSINITCONTINUES:
+        case DEF_GSSINITMECHFAILS:
+        case DEF_GSSDATAVALID:
+        case DEF_GSSCREDVERSIONWRONG:
+        case DEF_GSSPROCUNKNOWN:
+        case DEF_GSSSERVICEPRIVACY:
+        case DEF_GSSHANDLEUNKNOWN:
+        case DEF_GSSVERIFIERNOTGSS:
+        case DEF_GSSMICWRONG:
+        case DEF_GSSSEQREPLAYED:
+        case DEF_GSSINTEGDATAVALID:
+        case DEF_GSSINTEGCHECKSUMWRONG:
+        case DEF_GSSINTEGSEQMISMATCH:
+        case DEF_GSSDESTROYCONTEXT:
+        case DEF_GSSDESTROYUNAUTHENTICATED:
+        case DEF_GSSSEQABOVEMAX:
+        case DEF_GSSSEQWINDOWJUMP:
+        case DEF_GSSSEQTOOOLD:
+        case DEF_GSSSEQOUTOFORDER:
+        case DEF_GSSCREDTRUNCATED:
+        case DEF_GSSCREDHANDLEOVERRUNS:
+        case DEF_GSSNOMECHANISM:
+        case DEF_GSSCONTINUEINITUNKNOWNHANDLE:
+        case DEF_GSSINITTOKENMALFORMED:
+        case DEF_GSSCONTINUEINITTOKENMALFORMED:
+        case DEF_GSSINITMECHFAILSWITHTOKEN:
+        case DEF_GSSINTEGFRAMINGBAD:
+        case DEF_GSSINTEGEMPTYARGS:
+        case DEF_GSSINTEGSPLITACROSSFRAGMENTS:
+        case DEF_GSSINTEGREPLYMICFAILS:
+        case DEF_GSSINTEGREPLYMICOVERSIZE:
+            return 1;
+        default:
+            return 0;
+    } /* switch */
+} /* defect_is_gss */
+
+/*
+ * A defect that acts on the envelope or the framing rather than on the
+ * procedure arguments -- every RPCSEC_GSS case, and the reassembly cap,
+ * which is decided before a single argument byte is read -- is worth running
+ * once, against whichever target the model
+ * happened to pair it with first.  Pinning it to a single named target instead
+ * would make the case silently vanish on any run where the sampler never drew
+ * that one pair -- which is not a hypothetical: the generated table routinely
+ * omits a handful of (defect, target) combinations.
+ *
+ * "Once" means once per (defect, param): a parameterised GSS defect carries
+ * its variant in the param, so de-duplicating on the defect alone would run
+ * the first value the sampler produced and silently drop every other -- which
+ * is exactly the opposite of what enumerating the values in the model was
+ * for.
+ */
+struct defect_case_key {
+    uint8_t defect;
+    int64_t param;
+};
+
+static struct defect_case_key g_defect_case_seen[256];
+static unsigned int           g_defect_case_nseen;
+
+static int
+defect_case_first_time(
+    uint8_t defect,
+    int64_t param)
+{
+    unsigned int i;
+
+    for (i = 0; i < g_defect_case_nseen; i++) {
+        if (g_defect_case_seen[i].defect == defect &&
+            g_defect_case_seen[i].param == param) {
+            return 0;
+        }
+    }
+
+    evpl_test_abort_if(g_defect_case_nseen >= sizeof(g_defect_case_seen) /
+                       sizeof(g_defect_case_seen[0]),
+                       "too many distinct RPCSEC_GSS cases");
+
+    g_defect_case_seen[g_defect_case_nseen].defect = defect;
+    g_defect_case_seen[g_defect_case_nseen].param  = param;
+    g_defect_case_nseen++;
+    return 1;
+} /* defect_case_first_time */
+
+/*
+ * Turn the absence of a reply into a verdict.
+ *
+ * Silence alone does not distinguish a deliberate discard from a server that
+ * has stopped making progress, so a case that was met with nothing has to
+ * prove the connection still works: a fresh, valid sequence number on the same
+ * context must still be answered.  If it is, the silence was a decision --
+ * NO_REPLY -- and if it is not, the server is simply stalled.  `outcome` is
+ * passed through untouched when a reply did arrive, so this can wrap any
+ * exchange whose answer may or may not be silence.
+ */
+static int
+gss_classify_silence(
+    struct evpl *evpl,
+    int          fd,
+    int          outcome,
+    uint32_t     handle,
+    uint32_t     next_seq)
+{
+    struct wirebuf msg;
+
+    if (outcome != ACT_STALLED) {
+        return outcome;
+    }
+
+    build_gss_data_call(&msg, 0x47535360 + next_seq, handle, next_seq,
+                        GSS_SVC_NONE, 1, 1);
+    if (gss_exchange(evpl, fd, &msg, NULL, NULL) != EXP_SUCCESS) {
+        return ACT_STALLED;
+    }
+    return EXP_NOREPLY;
+} /* gss_classify_silence */
+
+/*
+ * Run one RPCSEC_GSS case on its own connection.
+ *
+ * Cases that act on an established context perform the handshake first, so
+ * each one is self-contained: the context, its handle and its sequence window
+ * all belong to this connection and cannot leak into another case.
+ */
+static int
+run_gss_case(
+    struct evpl                   *evpl,
+    const struct conf_defect_case *c,
+    int                            fd)
+{
+    struct wirebuf msg;
+    uint32_t       handle = 0;
+    uint32_t       lo, hi;
+    int            outcome;
+
+    /* The stub's behaviour is part of the case, not a fixed backdrop. */
+    gss_stub_set_behaviour(
+        c->defect == DEF_GSSINITMECHFAILS ? GSS_STUB_ACCEPT_FAIL :
+        c->defect == DEF_GSSINITMECHFAILSWITHTOKEN ? GSS_STUB_ACCEPT_FAIL_TOK :
+        c->defect == DEF_GSSINITCONTINUES ||
+        c->defect == DEF_GSSCONTINUEINITTOKENMALFORMED
+            ? GSS_STUB_ACCEPT_CONTINUE :
+        GSS_STUB_ACCEPT_COMPLETE,
+        GSS_STUB_VERIFY_HONEST,
+        /* Only the reply-signing cases break get_mic, and only for the
+         * databody: the handshake below has to succeed first, and its
+         * verifiers are MICs too. */
+        c->defect == DEF_GSSINTEGREPLYMICFAILS ? GSS_STUB_MIC_FAIL_BODY :
+        c->defect == DEF_GSSINTEGREPLYMICOVERSIZE ? GSS_STUB_MIC_HUGE_BODY :
+        GSS_STUB_MIC_HONEST);
+
+    switch (c->defect) {
+        case DEF_GSSINITESTABLISHES:
+            return gss_establish(evpl, fd, &handle, 1);
+
+        case DEF_GSSINITCONTINUES:
+            /* Two legs: the first must be answered so the second can follow. */
+            return gss_establish(evpl, fd, &handle, 2);
+
+        case DEF_GSSINITMECHFAILS:
+        case DEF_GSSINITMECHFAILSWITHTOKEN:
+            return gss_establish(evpl, fd, &handle, 1);
+
+        case DEF_GSSINITTOKENMALFORMED:
+            /* An INIT whose rpc_gss_init_arg cannot be decoded.  No context
+             * exists yet, so whatever the server made to hold one has to be
+             * unmade before it answers. */
+            build_gss_init_call(&msg, 0x4753534c, RPCSEC_GSS_INIT, NULL,
+                                c->param == 0 ? INIT_TOKEN_ABSENT
+                                              : INIT_TOKEN_OVERRUN);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSCONTINUEINITUNKNOWNHANDLE:
+            /* A CONTINUE_INIT for a context the server never issued. */
+            handle = 0xdeadbeef;
+            build_gss_init_call(&msg, 0x4753534d, RPCSEC_GSS_CONT_INIT,
+                                &handle, INIT_TOKEN_GOOD);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSCREDTRUNCATED:
+        case DEF_GSSCREDHANDLEOVERRUNS:
+            build_gss_bad_cred_call(&msg, 0x4753534e,
+                                    c->defect == DEF_GSSCREDHANDLEOVERRUNS);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSNOMECHANISM:
+            /* Take the mechanism away for the duration of one call: libevpl
+            * carries the RPCSEC_GSS framing but links no mechanism of its
+            * own, so "flavor 6 arrives at a server that has none configured"
+            * is the shipped default, not a contrived state.  Both entry
+            * points have to refuse it -- a context-creation request (param
+            * 0) and a data request (param 1) reach the check separately. */
+            evpl_rpc2_set_gss_provider(g_thread, NULL, NULL);
+
+            if (c->param == 0) {
+                build_gss_init_call(&msg, 0x47535361, RPCSEC_GSS_INIT, NULL,
+                                    INIT_TOKEN_GOOD);
+            } else {
+                build_gss_data_call(&msg, 0x47535362, 1, 1, GSS_SVC_NONE,
+                                    1, 1);
+            }
+            outcome = gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+            evpl_rpc2_set_gss_provider(g_thread, gss_stub_provider(), NULL);
+            return outcome;
+
+        case DEF_GSSCREDVERSIONWRONG:
+        case DEF_GSSPROCUNKNOWN:
+            msg.len = 0;
+            put32(&msg, 0x47535332);
+            put32(&msg, 0);
+            put32(&msg, 2);
+            put32(&msg, CONF_PROG);
+            put32(&msg, CONF_VERS);
+            put32(&msg, PROC_ECHO_SCALARS);
+            put_gss_cred(&msg,
+                         c->defect == DEF_GSSCREDVERSIONWRONG
+                             ? (uint32_t) c->param : RPCSEC_GSS_VERS_1,
+                         c->defect == DEF_GSSPROCUNKNOWN
+                             ? (uint32_t) c->param : RPCSEC_GSS_DATA,
+                         0, GSS_SVC_NONE, &handle);
+            put32(&msg, 0);
+            put32(&msg, 0);
+            build_args_into(&msg, TGT_TSCALARS);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSSERVICEPRIVACY:
+            build_gss_data_call(&msg, 0x47535333, handle, 1,
+                                GSS_SVC_PRIVACY, 1, 0);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSHANDLEUNKNOWN:
+            build_gss_data_call(&msg, 0x47535334, 0xdeadbeef, 1,
+                                GSS_SVC_NONE, 1, 1);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        default:
+            break;
+    } /* switch */
+
+    /* Everything below needs a live context. */
+    outcome = gss_establish(evpl, fd, &handle, 1);
+    if (outcome != EXP_SUCCESS) {
+        return outcome;
+    }
+
+    switch (c->defect) {
+        case DEF_GSSDATAVALID:
+            build_gss_data_call(&msg, 0x47535340, handle, 1, GSS_SVC_NONE, 1, 1);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSCONTINUEINITTOKENMALFORMED:
+            /* The handshake above stopped at CONTINUE_NEEDED, so the handle
+             * names a real half-built context.  Its second leg then carries a
+             * token that cannot be decoded: the context must survive the
+             * refusal -- it is the caller's argument that was bad, not the
+             * context -- which is the opposite of the INIT case, where there
+             * is nothing worth keeping. */
+            build_gss_init_call(&msg, 0x4753534f, RPCSEC_GSS_CONT_INIT,
+                                &handle, INIT_TOKEN_OVERRUN);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSVERIFIERNOTGSS:
+            /* A DATA call whose verifier is AUTH_NONE rather than a MIC. */
+            build_gss_data_call(&msg, 0x47535341, handle, 1, GSS_SVC_NONE, 1, 0);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSMICWRONG:
+            build_gss_data_call(&msg, 0x47535342, handle, 1, GSS_SVC_NONE, 0, 1);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSINTEGDATAVALID:
+        {
+            uint8_t  results[512];
+            uint32_t results_len = sizeof(results);
+
+            build_gss_integ_call(&msg, 0x47535346, handle, 1, 1, 1, 1);
+            outcome = gss_exchange(evpl, fd, &msg, results, &results_len);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+            return check_integ_reply(results, results_len, 1, 1)
+                   ? EXP_SUCCESS : ACT_MALFORMED;
+        }
+
+        case DEF_GSSINTEGEMPTYARGS:
+        {
+            uint8_t  results[512];
+            uint32_t results_len = sizeof(results);
+
+            build_gss_integ_call(&msg, 0x47535350, handle, 1, 1, 1, 0);
+            outcome = gss_exchange(evpl, fd, &msg, results, &results_len);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+            return check_integ_reply(results, results_len, 1, 0)
+                   ? EXP_SUCCESS : ACT_MALFORMED;
+        }
+
+        case DEF_GSSINTEGSPLITACROSSFRAGMENTS:
+        {
+            uint8_t  results[512];
+            uint32_t results_len = sizeof(results);
+
+            build_gss_integ_call(&msg, 0x47535351, handle, 1, 1, 1, 1);
+
+            /* Split inside the databody, past the RPC header: the header
+             * checksum then sits wholly in the first fragment while the
+             * databody and its checksum straddle the boundary, so the server
+             * has to gather each of them across two buffers -- and the
+             * checksum's gather begins beyond the end of the first. */
+            evpl_test_abort_if(msg.len < 60, "integrity call unexpectedly short");
+            outcome = gss_exchange_split(evpl, fd, &msg, msg.len - 40,
+                                         results, &results_len);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+            return check_integ_reply(results, results_len, 1, 1)
+                   ? EXP_SUCCESS : ACT_MALFORMED;
+        }
+
+        case DEF_GSSINTEGREPLYMICFAILS:
+        case DEF_GSSINTEGREPLYMICOVERSIZE:
+        {
+            uint8_t  results[512];
+            uint32_t results_len = sizeof(results);
+
+            /* The call itself is impeccable; only the server's own signature
+             * over the results cannot be produced.  A reply that comes back
+             * anyway is therefore an unsigned reply on a channel the client
+             * asked to have signed, which is what the outcome comparison
+             * catches -- and check_integ_reply confirms it really is
+             * unwrapped rather than wrapped in some other way. */
+            build_gss_integ_call(&msg, 0x47535352, handle, 1, 1, 1, 1);
+            outcome = gss_exchange(evpl, fd, &msg, results, &results_len);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+            return check_integ_reply(results, results_len, 1, 1)
+                   ? ACT_MALFORMED : EXP_SUCCESS;
+        }
+
+        case DEF_GSSINTEGCHECKSUMWRONG:
+            build_gss_integ_call(&msg, 0x47535347, handle, 1, 1, 0, 1);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSINTEGSEQMISMATCH:
+            /* The checksum is computed over the tampered databody, so the
+             * databody itself verifies and the seq consistency check is the
+             * only thing left that can reject the call. */
+            build_gss_integ_call(&msg, 0x47535348, handle, 1, 2, 1, 1);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSINTEGFRAMINGBAD:
+            build_gss_integ_bad_call(&msg, 0x47535353, handle, 1,
+                                     (int) c->param);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSSEQWINDOWJUMP:
+            /* A jump far clear of the window: the window cannot slide to
+             * cover it and has to be reset outright.  Both calls must be
+             * answered -- the second proves the reset left a usable window
+             * behind rather than a wedged one. */
+            build_gss_data_call(&msg, 0x47535354, handle, 1, GSS_SVC_NONE, 1, 1);
+            outcome = gss_exchange(evpl, fd, &msg, NULL, NULL);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+            build_gss_data_call(&msg, 0x47535355, handle, 5000, GSS_SVC_NONE,
+                                1, 1);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSSEQOUTOFORDER:
+            /* Inside the window, unseen, and not the next number: the case
+             * the window exists for. */
+            build_gss_data_call(&msg, 0x47535356, handle, 10, GSS_SVC_NONE,
+                                1, 1);
+            outcome = gss_exchange(evpl, fd, &msg, NULL, NULL);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+            build_gss_data_call(&msg, 0x47535357, handle, 5, GSS_SVC_NONE,
+                                1, 1);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        case DEF_GSSSEQTOOOLD:
+            /* Move the window well past the sequence number we then present,
+             * so it has fallen out of the bottom rather than merely being a
+             * repeat. */
+            build_gss_data_call(&msg, 0x47535358, handle, 200, GSS_SVC_NONE,
+                                1, 1);
+            outcome = gss_exchange(evpl, fd, &msg, NULL, NULL);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+            build_gss_data_call(&msg, 0x47535359, handle, 1, GSS_SVC_NONE,
+                                1, 1);
+            outcome = gss_exchange(evpl, fd, &msg, NULL, NULL);
+            return gss_classify_silence(evpl, fd, outcome, handle, 201);
+
+        case DEF_GSSSEQABOVEMAX:
+            /* Above MAXSEQ.  Nothing about the context is wrong, so a server
+             * that discards this instead of answering leaves the client with
+             * no way to learn it must refresh. */
+            build_gss_data_call(&msg, 0x4753535a, handle, 0x80000001,
+                                GSS_SVC_NONE, 1, 1);
+            outcome = gss_exchange(evpl, fd, &msg, NULL, NULL);
+            return gss_classify_silence(evpl, fd, outcome, handle, 5);
+
+        case DEF_GSSDESTROYCONTEXT:
+            build_gss_destroy_call(&msg, 0x47535349, handle, 1, 1);
+            outcome = gss_exchange(evpl, fd, &msg, NULL, NULL);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+            /* An acknowledged DESTROY that left the context usable would pass
+             * on the reply alone, so make the context prove it is gone. */
+            build_gss_data_call(&msg, 0x4753534a, handle, 2, GSS_SVC_NONE, 1, 1);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL) == EXP_AUTHERROR
+                   ? EXP_SUCCESS : ACT_MALFORMED;
+
+        case DEF_GSSDESTROYUNAUTHENTICATED:
+            build_gss_destroy_call(&msg, 0x4753534b, handle, 1, 0);
+            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+
+        default:  /* DEF_GSSSEQREPLAYED */
+            /* Use a sequence number, then use it again.  The first call must
+             * succeed; the replay must be met with silence. */
+            build_gss_data_call(&msg, 0x47535343, handle, 7, GSS_SVC_NONE, 1, 1);
+            outcome = gss_exchange(evpl, fd, &msg, NULL, NULL);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+
+            build_gss_data_call(&msg, 0x47535344, handle, 7, GSS_SVC_NONE, 1, 1);
+            outcome = gss_exchange(evpl, fd, &msg, NULL, NULL);
+            (void) lo;
+            (void) hi;
+            return gss_classify_silence(evpl, fd, outcome, handle, 8);
+    } /* switch */
+} /* run_gss_case */
+
+static void
+run_defect_case(
+    struct evpl                   *evpl,
+    const struct conf_defect_case *c)
+{
+    struct wirebuf args, msg, cred;
+    uint32_t       prog = CONF_PROG, vers = CONF_VERS, rpcvers = 2;
+    uint32_t       proc = target_proc(c->target);
+    uint32_t       cred_flavor = 0, cred_len = 0;
+    uint32_t       lo = 0, hi = 0;
+    uint32_t       mark_override = 0;
+    int            fd, actual, use_mark_override = 0, fragments = 1;
+    int            truncate_by = 0, trailing = 0, reasm_flood = 0;
+
+    if (!defect_applies(c->defect, c->target)) {
+        g_results.defect_skipped++;
+        return;
+    }
+
+    /* Framing is refused before any argument encoding is examined, so running
+     * this against all four targets would be the same test four times over
+     * with a different unread payload.  Same rule as the RPCSEC_GSS cases,
+     * and for the same reason -- see defect_case_first_time. */
+    if (c->defect == DEF_REASSEMBLYCAPEXCEEDED &&
+        !defect_case_first_time(c->defect, c->param)) {
+        g_results.defect_skipped++;
+        return;
+    }
+
+    if (defect_is_gss(c->defect)) {
+        if (!defect_case_first_time(c->defect, c->param)) {
+            g_results.defect_skipped++;
+            return;
+        }
+
+        fd = connect_raw();
+        if (fd < 0) {
+            evpl_test_error("defect case %s: connect failed", defect_name(c->defect));
+            g_results.defect_unknown++;
+            return;
+        }
+        g_results.defect_run++;
+        actual = run_gss_case(evpl, c, fd);
+        close(fd);
+        record_outcome(c, actual, 0, 0);
+        return;
+    }
+
+    build_args(&args, c->target);
+    cred.len = 0;
+
+    /* Apply the defect. */
+    switch (c->defect) {
+        case DEF_NODEFECT:
+            break;
+        case DEF_RPCVERSWRONG:
+            rpcvers = (uint32_t) c->param;
+            break;
+        case DEF_PROGRAMUNKNOWN:
+            prog = 0x5eadbeef;
+            break;
+        case DEF_VERSIONUNSUPPORTED:
+            vers = (uint32_t) c->param;
+            break;
+        case DEF_PROCEDUREUNKNOWN:
+            proc     = (uint32_t) c->param;
+            args.len = 0;
+            break;
+        case DEF_PROCEDURENULL:
+            proc     = 0;
+            args.len = 0;
+            break;
+        case DEF_AUTHFLAVORUNSUPPORTED:
+            cred_flavor = (uint32_t) c->param;
+            break;
+        case DEF_CREDBODYOVERLONG:
+            /* A credential whose declared body length runs past the message. */
+            cred_flavor = 1;   /* AUTH_SYS */
+            cred_len    = 0x0fffffff;
+            break;
+        case DEF_AUTHSYSVALID:
+            cred_flavor = 1;   /* AUTH_SYS */
+            build_authsys_cred(&cred);
+            cred_len = cred.len;
+            break;
+        case DEF_ARGSTRUNCATED:
+            truncate_by = (int) c->param;
+            break;
+        case DEF_ARGSTRAILINGGARBAGE:
+            trailing = (int) c->param;
+            break;
+        case DEF_STRINGLENOVERFLOW:
+            poke32(&args, BYTES_OFF_STRING_LEN, 0xffffffff);
+            break;
+        case DEF_STRINGLENBEYONDMESSAGE:
+            poke32(&args, BYTES_OFF_STRING_LEN, 0x1000);
+            break;
+        case DEF_STRINGEXCEEDSBOUND:
+            build_bytes_over_bound(&args, BOUNDED_MAX + 1, 4);
+            break;
+        case DEF_OPAQUEEXCEEDSBOUND:
+            build_bytes_over_bound(&args, 4, BOUNDED_MAX + 1);
+            break;
+        case DEF_ARRAYCOUNTEXCEEDSBOUND:
+            build_arrays_over_bound(&args, BOUNDED_MAX + 1);
+            break;
+        case DEF_ARRAYCOUNTHUGE:
+            poke32(&args, ARRAYS_OFF_VAR_COUNT, 0x40000000);
+            break;
+        case DEF_DISCRIMINANTUNMATCHED:
+            poke32(&args, STRICT_OFF_DISCRIM, 99);
+            break;
+        case DEF_BOOLNOTZEROORONE:
+            poke32(&args, SCALARS_OFF_BOOL, 2);
+            break;
+        case DEF_ENUMNOTDECLARED:
+            poke32(&args, SCALARS_OFF_ENUM, 99);
+            break;
+        case DEF_RECORDMARKHUGE:
+            use_mark_override = 1;
+            mark_override     = 0x7fffffff;
+            break;
+        case DEF_RECORDMARKZEROLENGTH:
+            use_mark_override = 1;
+            mark_override     = 0;
+            break;
+        case DEF_CALLSPLITACROSSFRAGMENTS:
+            fragments = (int) c->param;
+            break;
+        /* Swap in the large payload and ask for more fragments than the
+         * receiver's payload iovec ceiling, so it has to flatten the
+         * reassembled message rather than pass the iovecs straight through. */
+        case DEF_CALLSPLITPATHOLOGICAL:
+            build_args_large_bytes(&args);
+            fragments = PATHOLOGICAL_FRAGMENTS;
+            break;
+        /* Legal fragments, illegal total: the record is never terminated and
+         * is walked past the receiver's per-message cap. */
+        case DEF_REASSEMBLYCAPEXCEEDED:
+            reasm_flood = 1;
+            break;
+        default:
+            break;
+    } /* switch */
+
+    /* Assemble the RPC call message (without the record mark). */
+    msg.len = 0;
+    put32(&msg, 0x436f6e66);      /* xid */
+    put32(&msg, 0);               /* CALL */
+    put32(&msg, rpcvers);
+    put32(&msg, prog);
+    put32(&msg, vers);
+    put32(&msg, proc);
+    put32(&msg, cred_flavor);
+    put32(&msg, cred_len);
+    if (cred.len) {
+        evpl_test_abort_if(msg.len + cred.len > sizeof(msg.data),
+                           "message buffer overflow");
+        memcpy(msg.data + msg.len, cred.data, cred.len);
+        msg.len += cred.len;
+    }
+    put32(&msg, 0);               /* verf flavor AUTH_NONE */
+    put32(&msg, 0);               /* verf length           */
+
+    if (truncate_by > 0 && (uint32_t) truncate_by <= args.len) {
+        args.len -= truncate_by;
+    }
+    if (args.len) {
+        evpl_test_abort_if(msg.len + args.len > sizeof(msg.data),
+                           "message buffer overflow");
+        memcpy(msg.data + msg.len, args.data, args.len);
+        msg.len += args.len;
+    }
+    if (trailing > 0) {
+        evpl_test_abort_if(msg.len + trailing > (int) sizeof(msg.data),
+                           "message buffer overflow");
+        memset(msg.data + msg.len, 0xa5, trailing);
+        msg.len += trailing;
+    }
+
+    fd = connect_raw();
+    if (fd < 0) {
+        evpl_test_error("defect case %s: connect failed", defect_name(c->defect));
+        g_results.defect_unknown++;
+        return;
+    }
+
+    g_results.defect_run++;
+
+    if (use_mark_override) {
+        uint8_t  hdr[4];
+        uint32_t m = 0x80000000u | mark_override;
+
+        hdr[0] = (uint8_t) (m >> 24);
+        hdr[1] = (uint8_t) (m >> 16);
+        hdr[2] = (uint8_t) (m >> 8);
+        hdr[3] = (uint8_t) m;
+        send_all(evpl, fd, hdr, 4);
+        /* For the huge mark, send a token body so the server has something to
+         * buffer while it waits for the rest that will never arrive. */
+        if (mark_override) {
+            send_all(evpl, fd, msg.data, msg.len);
+        }
+    } else if (reasm_flood) {
+        uint32_t total = 0;
+        int      i;
+
+        /*
+         * The leading fragment is the real, well-formed call, so what the
+         * receiver is asked to hold is a genuine partial message rather than
+         * noise; everything after it is filler, because the point is that the
+         * record must be refused on its accumulated length alone, before any
+         * of it is parsed.  No fragment carries the terminal bit: the record
+         * is never completed, and a receiver that does not bound reassembly
+         * will hold every byte of it for as long as the peer keeps talking.
+         */
+        if (!send_fragment(evpl, fd, msg.data, msg.len, 0)) {
+            total = msg.len;
+
+            for (i = 0;
+                 i < REASM_FLOOD_FRAGS && total <= CONF_MAX_MESSAGE_SIZE;
+                 i++) {
+                if (send_fragment(evpl, fd, g_reasm_filler,
+                                  REASM_FLOOD_FRAG_LEN, 0)) {
+                    /* The receiver dropped the connection mid-flood, which is
+                     * the outcome under test; read_outcome confirms it. */
+                    break;
+                }
+                total += REASM_FLOOD_FRAG_LEN;
+            }
+        }
+    } else if (fragments > 1) {
+        uint32_t chunk = msg.len / fragments;
+        uint32_t sent  = 0;
+        int      i;
+
+        if (chunk < 4) {
+            chunk = 4;
+        }
+        for (i = 0; i < fragments && sent < msg.len; i++) {
+            uint32_t this_len = (i == fragments - 1) ? msg.len - sent : chunk;
+
+            if (sent + this_len > msg.len) {
+                this_len = msg.len - sent;
+            }
+            send_fragment(evpl, fd, msg.data + sent, this_len,
+                          sent + this_len >= msg.len);
+            sent += this_len;
+        }
+    } else {
+        send_fragment(evpl, fd, msg.data, msg.len, 1);
+    }
+
+    actual = read_outcome(evpl, fd, &lo, &hi);
+    close(fd);
+
+    record_outcome(c, actual, lo, hi);
+} /* run_defect_case */
+
+
+/*
+ * The defect phase needs the server serviced while the driver does blocking
+ * socket I/O, so here the server gets its own thread and the main thread
+ * speaks raw TCP -- the multifrag topology.  The value phase has fully torn
+ * its event loop down by this point.
+ */
+static void
+run_defect_phase(struct evpl *evpl)
+{
+    unsigned int i;
+
+    for (i = 0; i < CONF_NUM_DEFECT_CASES; i++) {
+        run_defect_case(evpl, &conf_defect_cases[i]);
+    }
+} /* run_defect_phase */
+
+/* ------------------------------------------------------------------ *
+* main
+* ------------------------------------------------------------------ */
+
+static void
+usage(const char *prog)
+{
+    fprintf(stderr, "Usage: %s [-r protocol] [-p port]\n", prog);
+    exit(1);
+} /* usage */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct server_ctx          ctx;
+    struct evpl               *evpl;
+    struct evpl_rpc2_server   *server;
+    struct evpl_rpc2_conn     *conn;
+    struct evpl_endpoint      *endpoint;
+    struct evpl_rpc2_program  *programs[1];
+    struct evpl_thread_config *tcfg;
+    uint64_t                   drain_deadline;
+    int                        opt, rc, failed;
+
+    conformance_evpl_config();
+
+    while ((opt = getopt(argc, argv, "r:p:")) != -1) {
+        switch (opt) {
+            case 'r':
+                rc = evpl_protocol_lookup(&proto, optarg);
+                if (rc) {
+                    fprintf(stderr, "Invalid protocol '%s'\n", optarg);
+                    return 1;
+                }
+                break;
+            case 'p':
+                port = atoi(optarg);
+                break;
+            default:
+                usage(argv[0]);
+        } /* switch */
+    }
+
+    pattern_init();
+
+    /*
+     * Server and client share one event loop and one thread.  The raw-socket
+     * phase therefore never blocks on the socket: it pumps evpl_continue
+     * between non-blocking reads, since the server that owes it a reply is
+     * running on this same thread.  Exactly one evpl is created for the whole
+     * run -- a second create/destroy cycle wedges process exit.
+     */
+    memset(&ctx, 0, sizeof(ctx));
+
+    /*
+     * A bounded wait is required, not merely nice: the default (-1) parks
+     * evpl_continue in the poller until something happens, and the defect
+     * cases that expect no reply at all would never come back to check their
+     * deadline.
+     *
+     * evpl_create() takes ownership of the config and releases it itself.
+     */
+    tcfg = evpl_thread_config_init();
+    evpl_thread_config_set_wait_ms(tcfg, 1);
+    evpl = evpl_create(tcfg);
+
+    conformance_program_init(&ctx);
+    programs[0] = &ctx.prog.rpc2;
+
+    server = evpl_rpc2_server_init(programs, 1);
+    /* A name-addressed transport (AF_UNIX, inproc) has no wildcard bind and no
+     * port, so the address is resolved once here.  test_address() derives a
+     * per-pid socket name under the build tree, which is what makes these runs
+     * safe to execute concurrently without a network namespace or a port
+     * lock -- the name is what has to be unique, not the port. */
+    g_address = test_address(proto, "0.0.0.0", argv[0]);
+    endpoint  = evpl_endpoint_create(g_address, port);
+    evpl_rpc2_server_start(server, proto, endpoint);
+
+    /* Two distinct private-data values, so that a notification reporting the
+     * wrong one is visible rather than indistinguishable -- see
+     * conformance_notify, which asserts which notification carries which. */
+    g_server_private = &ctx;
+    g_thread_private = &g_notify;
+
+    g_thread = evpl_rpc2_thread_init(evpl, programs, 1, conformance_notify,
+                                     g_thread_private);
+
+    /* Register the deterministic GSS provider so the RPCSEC_GSS cases have a
+     * mechanism to talk to.  Without one, libevpl rejects flavor-6 calls with
+     * AUTH_REJECTEDCRED before reaching any of the framing under test. */
+    evpl_rpc2_set_gss_provider(g_thread, gss_stub_provider(), NULL);
+
+    evpl_rpc2_server_attach(g_thread, server, g_server_private);
+
+    conn = evpl_rpc2_client_connect(g_thread, proto, endpoint, NULL, 0, NULL);
+    evpl_test_abort_if(!conn, "failed to connect RPC2 client");
+    g_connections_opened++;
+
+    evpl_test_info("running %u value cases", (unsigned int) CONF_NUM_VALUE_CASES);
+    run_value_phase(evpl, &ctx.prog, conn);
+
+    /* Needs a peer that writes its own transport header, so it runs outside
+     * the rpc2 client -- see the comment on the function. */
+    check_rdma_version_mismatch(evpl, endpoint, proto, conn->rdma);
+
+    /* The raw-socket phase needs a stream transport it can open a socket of
+     * its own onto: TCP or AF_UNIX.  RDMA carries no record marks, so the
+     * framing defects are not expressible there, and inproc has no descriptor
+     * to write to at all. */
+    if (proto == EVPL_STREAM_SOCKET_TCP || evpl_protocol_is_local(proto)) {
+        evpl_test_info("running %u defect cases",
+                       (unsigned int) CONF_NUM_DEFECT_CASES);
+        run_defect_phase(evpl);
+    } else {
+        evpl_test_info(
+            "skipping defect phase (needs a stream transport with a socket)");
+    }
+
+    /*
+     * The defect phase leaves behind connections in every state the server
+     * knows how to reach -- half-open, mid-reassembly, closed by the peer.
+     * Give the loop a chance to retire them before tearing it down.
+     */
+    drain_deadline = now_ms() + 200;
+    while (now_ms() < drain_deadline) {
+        evpl_continue(evpl);
+    }
+
+    evpl_rpc2_server_stop(server);
+    evpl_rpc2_client_disconnect(g_thread, conn);
+    evpl_rpc2_server_detach(g_thread, server);
+    evpl_rpc2_thread_destroy(g_thread);
+
+    /* Only now can no further notification arrive: thread_destroy closes what
+     * the run left behind and pumps until rpc2 has retired all of it. */
+    check_notifications();
+
+    /* The client connection the driver holds must be the one the notification
+     * path identified as unaccepted -- if those two disagree, the pointer the
+     * callback reported is not the connection the caller was handed, and
+     * everything the callback said about it was about something else. */
+    notify_check(g_notify.client_conn == conn,
+                 "the connection reported as this process's client is %p, "
+                 "but evpl_rpc2_client_connect returned %p",
+                 (void *) g_notify.client_conn, (void *) conn);
+
+    evpl_rpc2_server_destroy(server);
+    evpl_destroy(evpl);
+
+    printf("value cases:  %d run, %d failed (%d requesting chunks, placed %s)\n",
+           g_results.value_run, g_results.value_failed, g_results.value_chunked,
+           g_results.rdma_capable ? "by RDMA" : "inline -- transport reports no RDMA");
+    if (g_results.rdma_error_checks) {
+        printf("rdma error:   %d assertions (ERR_CHUNK refusal, connection survives, ERR_VERS range)\n",
+               g_results.rdma_error_checks);
+    }
+    printf("defect cases: %d run, %d matched spec, %d known divergences, "
+           "%d unexpected, %d not applicable\n",
+           g_results.defect_run, g_results.defect_matched,
+           g_results.defect_known, g_results.defect_unknown,
+           g_results.defect_skipped);
+    printf("notifications: %d accepted, %d connected, %d disconnected, "
+           "%d incoherent\n",
+           g_notify.accepted, g_notify.connected, g_notify.disconnected,
+           g_notify.errors);
+
+    failed = g_results.value_failed || g_results.defect_unknown ||
+        g_notify.errors;
+
+    printf("Test %s\n", failed ? "FAILED" : "PASSED");
+    return failed ? 1 : 0;
+} /* main */

--- a/src/rpc2/tests/conformance.x
+++ b/src/rpc2/tests/conformance.x
@@ -1,0 +1,197 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Ben Jarvis
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * XDR/RPC2 conformance test program.
+ *
+ * This .x exists purely to exercise xdrzcc's code generator and libevpl's
+ * RPC2 layer.  It aims to instantiate every XDR construct xdrzcc supports,
+ * in every container shape, so that the generated marshall/unmarshall paths
+ * are all reachable from a single RPC program.
+ *
+ * Every procedure is an ECHO: the server returns its argument unchanged (or,
+ * where echoing hostile input would be unsafe, a probe result describing what
+ * it decoded).  That makes the happy path self-checking without an oracle,
+ * and leaves the model to drive value permutations and wire-level defects.
+ *
+ * Deliberately ABSENT, because xdrzcc does not support them (each is a
+ * separate finding for the compiler's own test suite, not something this
+ * file can exercise):
+ *
+ *   - hyper / unsigned hyper / quadruple / bare "unsigned": no lexer token.
+ *   - negative constants: the lexer has no '-' rule; "const X = -1;" warns
+ *     and then silently parses as 1.
+ *   - "case 1:": case labels must be identifiers, not numbers.
+ *   - string inside an array or vector ("string s<>"): the string branch is
+ *     tested before the vector branch in codegen, so the shape is dropped.
+ *   - a typedef re-decorated at the use site ("mytype m<>;"): the modifier is
+ *     silently discarded, changing the wire format.  See the workaround note
+ *     in chimera's nfs4.x.
+ *   - mutual recursion (A refers to B refers to A): the header emission loop
+ *     does not terminate.
+ *
+ * Declared bounds on string<N>, opaque<N> and T<N> are all enforced at decode
+ * time, and the bound-exceeding cases in the model check each of them.
+ */
+
+const FIXED_OPAQUE_LEN = 16;
+const FIXED_ARRAY_LEN  = 4;
+const BOUNDED_MAX      = 8;
+
+/* ------------------------------------------------------------------ *
+ * Scalars: every numeric width and format xdrzcc can emit.
+ * ------------------------------------------------------------------ */
+
+enum color {
+    RED   = 0,
+    GREEN = 1,
+    BLUE  = 2
+};
+
+struct scalars {
+    int32_t  s32;
+    uint32_t u32;
+    int64_t  s64;
+    uint64_t u64;
+    float    f32;
+    double   f64;
+    bool     b;
+    color    c;
+};
+
+/* ------------------------------------------------------------------ *
+ * Byte strings: the four distinct representations, each with its own
+ * decode path (in-place aliasing, dbuf copy, fixed memcpy, zero-copy).
+ * ------------------------------------------------------------------ */
+
+struct bytes {
+    string   s;
+    string   bounded_s<BOUNDED_MAX>;
+    opaque   v<>;
+    opaque   bounded<BOUNDED_MAX>;
+    opaque   f[FIXED_OPAQUE_LEN];
+};
+
+/* zcopaque gets its own procedure: it is the only field type that never
+ * copies, so a failure here is a refcount/iovec bug rather than a codec bug
+ * and is worth isolating. */
+struct zbytes {
+    uint32_t head;
+    zcopaque z<>;
+    uint32_t tail;
+};
+
+/* ------------------------------------------------------------------ *
+ * Arrays: fixed and variable, over both a builtin and a struct element.
+ * ------------------------------------------------------------------ */
+
+struct point {
+    int32_t x;
+    int32_t y;
+};
+
+struct arrays {
+    uint32_t fixed_u32[FIXED_ARRAY_LEN];
+    uint32_t var_u32<>;
+    uint32_t bounded_u32<BOUNDED_MAX>;
+    point    fixed_pt[2];
+    point    var_pt<>;
+};
+
+/* ------------------------------------------------------------------ *
+ * Unions.  "tagged" has a default arm and a void arm; "strict" has
+ * neither, so an unmatched discriminant reaches the no-arm path that
+ * RFC 4506 requires to be treated as invalid.
+ * ------------------------------------------------------------------ */
+
+enum kind {
+    K_NONE = 0,
+    K_INT  = 1,
+    K_STR  = 2,
+    K_PT   = 3
+};
+
+union tagged switch (kind k) {
+case K_NONE:
+    void;
+case K_INT:
+    int32_t i;
+case K_STR:
+    string s;
+case K_PT:
+    point p;
+default:
+    void;
+};
+
+union strict switch (kind k) {
+case K_INT:
+    int32_t i;
+case K_PT:
+    point p;
+};
+
+/* Echoing a "strict" union decoded from an unmatched discriminant would
+ * re-marshall an uninitialized arm, so the server reports what it decoded
+ * instead of echoing it. */
+struct probe_result {
+    uint32_t seen_k;
+    int32_t  seen_i;
+};
+
+/* ------------------------------------------------------------------ *
+ * Optional pointer followed by a trailing field: regression shape for
+ * length accounting in the contig decoder (cf. xdrzcc tests/optional.x).
+ * ------------------------------------------------------------------ */
+
+struct opt_msg {
+    uint32_t head;
+    point   *opt;
+    uint32_t tail;
+};
+
+/* ------------------------------------------------------------------ *
+ * Linked list.  A member named "next*" that is optional turns the
+ * containing struct into a list encoded as repeated <1, elem> ... 0.
+ * ------------------------------------------------------------------ */
+
+struct lnode {
+    uint32_t value;
+    lnode   *nextnode;
+};
+
+struct list_msg {
+    lnode   *head;
+    uint32_t trailer;
+};
+
+/* ------------------------------------------------------------------ *
+ * Nesting and self-recursion.  "chain" is a self-recursive optional, so
+ * the generated codec for rec cannot be force-inlined.
+ * ------------------------------------------------------------------ */
+
+struct rec {
+    uint32_t depth;
+    rec     *chain;
+};
+
+struct nested {
+    point   inner_pt;
+    scalars inner_scalars;
+    rec    *chain;
+    uint32_t tail;
+};
+
+program CONFORMANCE_PROGRAM {
+    version CONFORMANCE_V1 {
+        scalars      ECHO_SCALARS(scalars)   = 1;
+        bytes        ECHO_BYTES(bytes)       = 2;
+        zbytes       ECHO_ZBYTES(zbytes)     = 3;
+        arrays       ECHO_ARRAYS(arrays)     = 4;
+        tagged       ECHO_UNION(tagged)      = 5;
+        probe_result PROBE_STRICT(strict)    = 6;
+        opt_msg      ECHO_OPTIONAL(opt_msg)  = 7;
+        list_msg     ECHO_LIST(list_msg)     = 8;
+        nested       ECHO_NESTED(nested)     = 9;
+    } = 1;
+} = 44;

--- a/src/rpc2/tests/conformance_client.c
+++ b/src/rpc2/tests/conformance_client.c
@@ -1,0 +1,1473 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Ben Jarvis
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Model-based conformance test for the RPC2 *client*.
+ *
+ * conformance.c drives libevpl's server with malformed calls.  This is its
+ * mirror image, and it exists because inverting the harness is the only way to
+ * reach the client's inbound path: a real server never produces a reply for an
+ * xid nobody sent, a truncated result, or a MSG_DENIED with a decodable body
+ * bolted on, so nothing that talks to a real server can test what the client
+ * does with one.
+ *
+ * The harness is a hostile server: a raw TCP listener that a genuine libevpl
+ * rpc2 client connects to.  For each case it reads the client's CALL, takes
+ * the xid, and writes back exactly the bytes the model asked for.  The oracle
+ * is the client's own reply callback -- its status argument, or its failure to
+ * fire at all.
+ *
+ * Cases come from quint/client.qnt via a build step (client_cases.h).  Each
+ * carries two predictions:
+ *
+ *   - the required callback outcome (success / decode error / some failure /
+ *     no callback for this reply);
+ *   - whether the connection must survive, checked by completing an ordinary
+ *     call on it afterwards.  That probe is also what distinguishes "the
+ *     client correctly ignored this reply" from "the client is wedged".
+ *
+ * The model encodes the SPECIFICATION, so a mismatch is a candidate bug in
+ * libevpl rather than a broken test.  Reviewed, consciously deferred
+ * divergences go in known_divergences[] with a note; anything else fails.
+ *
+ * TCP-only by construction: the whole point is hand-built record-marked bytes,
+ * which do not exist on the RDMA transports.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <time.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_rpc2.h"
+
+#include "core/test_log.h"
+#include "test_common.h"
+
+#include "conformance_client_xdr.h"
+#include "client_cases.h"
+
+static int port = 8000;
+
+/* RPC envelope constants (RFC 5531 section 9), spelled out here rather than
+ * pulled from the generated rpc2 header: this file must be able to encode
+ * values the enums do not name. */
+#define RPC_CALL            0
+#define RPC_REPLY           1
+#define RPC_MSG_ACCEPTED    0
+#define RPC_MSG_DENIED      1
+#define RPC_SUCCESS         0
+#define RPC_RPC_MISMATCH    0
+#define RPC_AUTH_ERROR      1
+#define RPC_AUTH_BADCRED    1
+#define RPC_AUTH_NONE       0
+#define RPC_AUTH_SYS        1
+
+/* hello_world.x, which this test reuses unmodified. */
+#define HELLO_PROG          42
+#define HELLO_VERS          1
+#define HELLO_PROC_GREET    1
+
+#define CALL_ID             42
+#define CALL_GREETING       "Hello from client!"
+#define REPLY_ID            100
+#define REPLY_GREETING      "Hello from the hostile server!"
+
+/*
+ * Outcomes the driver can observe that the model has no name for.  CEXP_*
+ * codes come from the model; these extend the same space so a divergence can
+ * be reported as one pair of names.
+ */
+#define ACT_NO_CALLBACK     100    /* deadline passed, connection still up   */
+#define ACT_CONN_LOST       101    /* connection died, callback never fired  */
+#define ACT_WRONG_VALUE     102    /* status 0 but the results did not match */
+#define ACT_DOUBLE_CALLBACK 103    /* one call completed more than once      */
+
+/*
+ * Wall-clock budget for one exchange.  Loopback replies land in microseconds,
+ * so anything approaching this is a client that has stopped making progress.
+ * Kept small because the CbDropped cases are expected to hit it.
+ */
+#define REPLY_TIMEOUT_MS    300
+
+/* Budget for the connect/accept handshake, which involves no RPC at all. */
+#define ACCEPT_TIMEOUT_MS   2000
+
+/* ------------------------------------------------------------------ *
+* Known divergences from the specification
+*
+* Each entry records a case where libevpl's behaviour differs from what the
+* model requires, so the suite can stay green while the gap remains visible.
+* Removing an entry turns the corresponding case back into a hard failure,
+* which is what should happen once the underlying issue is fixed.
+* ------------------------------------------------------------------ */
+
+struct known_divergence {
+    int         defect;   /* CDEF_* */
+    int         expect;   /* CEXP_*, what the model requires */
+    int         actual;   /* CEXP_ or ACT_ code: what libevpl does today */
+    const char *note;
+};
+
+/* Empty: the two bugs this harness found on its first run -- the client
+ * ignoring reply_stat/accept_stat, and disconnect freeing pending calls
+ * without firing their callbacks -- are both fixed in rpc2.c, so every case
+ * now has to match the model on its own merits.
+ */
+static const struct known_divergence known_divergences[] = {
+    { -1, -1, -1, NULL },
+};
+
+static int
+is_known_divergence(
+    int defect,
+    int expect,
+    int actual)
+{
+    unsigned int i;
+
+    for (i = 0; i < sizeof(known_divergences) / sizeof(known_divergences[0]); i++) {
+        if (known_divergences[i].defect == defect &&
+            known_divergences[i].expect == expect &&
+            known_divergences[i].actual == actual) {
+            return 1;
+        }
+    }
+    return 0;
+} /* is_known_divergence */
+
+static const char *
+defect_name(int d)
+{
+    switch (d) {
+        case CDEF_REPLYWELLFORMED:           return "ReplyWellFormed";
+        case CDEF_REPLYVERFAUTHSYS:          return "ReplyVerfAuthSys";
+        case CDEF_REPLYSPLITACROSSFRAGMENTS: return "ReplySplitAcrossFragments";
+        case CDEF_REPLYUNKNOWNXID:           return "ReplyUnknownXid";
+        case CDEF_REPLYDUPLICATED:           return "ReplyDuplicated";
+        case CDEF_REPLYISACALL:              return "ReplyIsACall";
+        case CDEF_REPLYHEADERTRUNCATED:      return "ReplyHeaderTruncated";
+        case CDEF_REPLYMTYPEUNDEFINED:       return "ReplyMtypeUndefined";
+        case CDEF_REPLYVERFBODYOVERLONG:     return "ReplyVerfBodyOverlong";
+        case CDEF_PEERCLOSESWITHOUTREPLY:    return "PeerClosesWithoutReply";
+        case CDEF_REPLYREJECTEDAUTH:         return "ReplyRejectedAuth";
+        case CDEF_REPLYREJECTEDRPCMISMATCH:  return "ReplyRejectedRpcMismatch";
+        case CDEF_REPLYACCEPTSTAT:           return "ReplyAcceptStat";
+        case CDEF_REPLYDENIEDWITHBODY:       return "ReplyDeniedWithBody";
+        case CDEF_REPLYACCEPTSTATWITHBODY:   return "ReplyAcceptStatWithBody";
+        case CDEF_REPLYSTATUNDEFINED:        return "ReplyStatUndefined";
+        case CDEF_REPLYEMPTYBODY:            return "ReplyEmptyBody";
+        case CDEF_REPLYTRUNCATEDBODY:        return "ReplyTruncatedBody";
+        case CDEF_REPLYTRAILINGGARBAGE:      return "ReplyTrailingGarbage";
+        case CDEF_REPLYGARBAGEBODY:          return "ReplyGarbageBody";
+        case CDEF_REPLYSTRINGLENOVERFLOW:    return "ReplyStringLenOverflow";
+        case CDEF_REPLYSTRINGLENBEYONDMESSAGE: return "ReplyStringLenBeyondMessage";
+        default:                             return "?";
+    } /* switch */
+} /* defect_name */
+
+static const char *
+outcome_name(int o)
+{
+    switch (o) {
+        case CEXP_CBSUCCESS:     return "CALLBACK_OK";
+        case CEXP_CBDECODEERROR: return "CALLBACK_DECODE_ERROR";
+        case CEXP_CBFAILED:      return "CALLBACK_FAILED";
+        case CEXP_CBDROPPED:     return "REPLY_DROPPED";
+        case ACT_NO_CALLBACK:    return "NO_CALLBACK";
+        case ACT_CONN_LOST:      return "CONN_LOST_CALLBACK_LOST";
+        case ACT_WRONG_VALUE:    return "WRONG_VALUE";
+        case ACT_DOUBLE_CALLBACK: return "DOUBLE_CALLBACK";
+        default:                 return "?";
+    } /* switch */
+} /* outcome_name */
+
+static const char *
+delivery_name(int d)
+{
+    switch (d) {
+        case CDLV_ONEWRITE:  return "one-write";
+        case CDLV_TWOWRITES: return "two-writes";
+        case CDLV_DRIBBLE:   return "dribble";
+        default:             return "?";
+    } /* switch */
+} /* delivery_name */
+
+/* ------------------------------------------------------------------ *
+* Shared state
+* ------------------------------------------------------------------ */
+
+struct results {
+    int run;
+    int matched;
+    int known;
+    int unknown;
+    /* Matches broken down by the outcome the model asked for.  A run that
+     * "passed" without ever reaching a callback would look identical to a
+     * healthy one in the totals alone; this is what makes the positive
+     * coverage visible in the output. */
+    int matched_by_expect[4];
+};
+
+static struct results g_results;
+
+/* Deterministic filler for the garbage-body cases. */
+#define MAX_PAYLOAD 256
+static uint8_t        g_pattern[MAX_PAYLOAD];
+
+static void
+pattern_init(void)
+{
+    unsigned int i;
+
+    for (i = 0; i < MAX_PAYLOAD; i++) {
+        g_pattern[i] = (uint8_t) (i * 7 + 13);
+    }
+} /* pattern_init */
+
+static uint64_t
+now_ms(void)
+{
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+} /* now_ms */
+
+/* ------------------------------------------------------------------ *
+* The client under test
+* ------------------------------------------------------------------ */
+
+/* What one outstanding call observed.  A call may only ever complete once, so
+ * `fired` is a count and not a flag: a second completion is itself a defect
+ * this harness is in a position to see. */
+struct call_state {
+    int      fired;
+    int      status;
+    int      matched;
+    /* Copied out for the failure message: a value that came back wrong is far
+     * more useful reported than counted. */
+    uint32_t got_id;
+    char     got_greeting[80];
+};
+
+/*
+ * Call state outlives the call that owns it.
+ *
+ * A case whose reply the client is required to ignore leaves its call
+ * outstanding on purpose, and libevpl completes every still-pending call when
+ * the connection goes down -- which can be several cases later.  So the state a
+ * callback writes into cannot live on the stack frame of the case that started
+ * the call: by the time the completion arrives that frame is gone, and the
+ * address has been reused by a later case's state.  Allocate it instead, and
+ * keep every allocation on a list to be released at the end of the run so the
+ * ASan build stays quiet.
+ */
+static struct call_state *g_call_states[512];
+static int                g_num_call_states;
+
+static struct call_state *
+call_state_alloc(void)
+{
+    struct call_state *cs = calloc(1, sizeof(*cs));
+
+    evpl_test_abort_if(!cs, "out of memory allocating call state");
+    evpl_test_abort_if(g_num_call_states >= (int) (sizeof(g_call_states) / sizeof(g_call_states[0])),
+                       "call state table exhausted; raise g_call_states[]");
+
+    g_call_states[g_num_call_states++] = cs;
+    return cs;
+} /* call_state_alloc */
+
+static void
+call_states_release(void)
+{
+    int i;
+
+    for (i = 0; i < g_num_call_states; i++) {
+        free(g_call_states[i]);
+    }
+    g_num_call_states = 0;
+} /* call_states_release */
+
+static void
+client_reply_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct Hello                *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct call_state *cs = private_data;
+
+    cs->fired++;
+    cs->status = status;
+
+    /* The contract is that a non-zero status means the reply argument is not
+     * to be touched, so this deliberately checks status first -- a client that
+     * hands back a half-decoded value with a failure status would be caught by
+     * the value comparison never running rather than by a crash here. */
+    if (status == 0 && reply && reply->greeting.str) {
+        cs->got_id = reply->id;
+        snprintf(cs->got_greeting, sizeof(cs->got_greeting), "%.*s",
+                 (int) reply->greeting.len, reply->greeting.str);
+
+        cs->matched = (reply->id == REPLY_ID) &&
+            strcmp(cs->got_greeting, REPLY_GREETING) == 0;
+    }
+} /* client_reply_cb */
+
+static struct HELLO_V1        g_prog;
+static struct evpl_rpc2_conn *g_conn;
+static int                    g_conn_alive;
+
+/*
+ * The connection's liveness is not observable from the conn pointer -- rpc2
+ * frees it on disconnect -- so it is tracked from the notify callback.  Every
+ * subsequent use of g_conn is gated on this, which is also what turns "the
+ * client hung up" into an observation rather than a use-after-free.
+ */
+static void
+client_notify_cb(
+    struct evpl_rpc2_thread *thread,
+    struct evpl_rpc2_conn   *conn,
+    struct evpl_rpc2_notify *notify,
+    void                    *private_data)
+{
+    if (notify->notify_type == EVPL_RPC2_NOTIFY_DISCONNECTED &&
+        conn == g_conn) {
+        g_conn_alive = 0;
+    }
+} /* client_notify_cb */
+
+static void
+issue_call_cred(
+    struct evpl                 *evpl,
+    struct call_state           *cs,
+    const struct evpl_rpc2_cred *cred)
+{
+    struct Hello request;
+
+    memset(cs, 0, sizeof(*cs));
+    memset(&request, 0, sizeof(request));
+
+    request.id = CALL_ID;
+    xdr_set_str_static(&request, greeting, CALL_GREETING,
+                       strlen(CALL_GREETING));
+
+    g_prog.send_call_GREET(&g_prog.rpc2, evpl, g_conn, cred, &request,
+                           0, 0, NULL, 0, 0, client_reply_cb, cs);
+} /* issue_call_cred */
+
+static void
+issue_call(
+    struct evpl       *evpl,
+    struct call_state *cs)
+{
+    issue_call_cred(evpl, cs, NULL);
+} /* issue_call */
+
+/* ------------------------------------------------------------------ *
+* Wire byte assembly, borrowed wholesale from conformance.c
+* ------------------------------------------------------------------ */
+
+struct wirebuf {
+    uint8_t  data[2048];
+    uint32_t len;
+};
+
+static void
+put32(
+    struct wirebuf *b,
+    uint32_t        v)
+{
+    evpl_test_abort_if(b->len + 4 > sizeof(b->data), "wire buffer overflow");
+    b->data[b->len++] = (uint8_t) (v >> 24);
+    b->data[b->len++] = (uint8_t) (v >> 16);
+    b->data[b->len++] = (uint8_t) (v >> 8);
+    b->data[b->len++] = (uint8_t) v;
+} /* put32 */
+
+static void
+put_bytes(
+    struct wirebuf *b,
+    const void     *src,
+    uint32_t        n)
+{
+    uint32_t pad = (4 - (n & 3)) & 3;
+
+    evpl_test_abort_if(b->len + n + pad > sizeof(b->data), "wire buffer overflow");
+    memcpy(b->data + b->len, src, n);
+    b->len += n;
+    memset(b->data + b->len, 0, pad);
+    b->len += pad;
+} /* put_bytes */
+
+static uint32_t
+get32(const uint8_t *p)
+{
+    return ((uint32_t) p[0] << 24) | ((uint32_t) p[1] << 16) |
+           ((uint32_t) p[2] << 8) | (uint32_t) p[3];
+} /* get32 */
+
+/* struct Hello { unsigned int id; string greeting; } */
+static void
+put_hello(struct wirebuf *b)
+{
+    put32(b, REPLY_ID);
+    put32(b, (uint32_t) strlen(REPLY_GREETING));
+    put_bytes(b, REPLY_GREETING, (uint32_t) strlen(REPLY_GREETING));
+} /* put_hello */
+
+/* xid, REPLY, MSG_ACCEPTED, AUTH_NONE verifier, SUCCESS. */
+static void
+put_accepted_header(
+    struct wirebuf *b,
+    uint32_t        xid)
+{
+    put32(b, xid);
+    put32(b, RPC_REPLY);
+    put32(b, RPC_MSG_ACCEPTED);
+    put32(b, RPC_AUTH_NONE);
+    put32(b, 0);
+    put32(b, RPC_SUCCESS);
+} /* put_accepted_header */
+
+/* xid, REPLY, MSG_ACCEPTED, AUTH_NONE verifier, <stat> (+ range for
+ * PROG_MISMATCH, which is the one accept_stat carrying a body of its own). */
+static void
+put_accepted_error_header(
+    struct wirebuf *b,
+    uint32_t        xid,
+    uint32_t        stat)
+{
+    put32(b, xid);
+    put32(b, RPC_REPLY);
+    put32(b, RPC_MSG_ACCEPTED);
+    put32(b, RPC_AUTH_NONE);
+    put32(b, 0);
+    put32(b, stat);
+
+    if (stat == 2) {  /* PROG_MISMATCH carries mismatch_info */
+        put32(b, HELLO_VERS);
+        put32(b, HELLO_VERS);
+    }
+} /* put_accepted_error_header */
+
+static void
+put_denied_auth_header(
+    struct wirebuf *b,
+    uint32_t        xid)
+{
+    put32(b, xid);
+    put32(b, RPC_REPLY);
+    put32(b, RPC_MSG_DENIED);
+    put32(b, RPC_AUTH_ERROR);
+    put32(b, RPC_AUTH_BADCRED);
+} /* put_denied_auth_header */
+
+/*
+ * Assemble the reply message (no record mark) for one case.
+ *
+ * `xid` is the one the client actually chose for the outstanding call, read
+ * back off the wire -- the client owns xid allocation, so guessing it is not
+ * an option and the unknown-xid case is built by perturbing it.
+ */
+static void
+build_reply(
+    struct wirebuf           *b,
+    const struct client_case *c,
+    uint32_t                  xid)
+{
+    uint32_t body_start;
+
+    b->len = 0;
+
+    switch (c->defect) {
+        case CDEF_REPLYWELLFORMED:
+        case CDEF_REPLYDUPLICATED:
+        case CDEF_REPLYSPLITACROSSFRAGMENTS:
+            put_accepted_header(b, xid);
+            put_hello(b);
+            break;
+
+        case CDEF_REPLYVERFAUTHSYS:
+            /* A reply verifier that is not AUTH_NONE is legal and must decode:
+             * flavor, body length, then authsys_parms (stamp, machinename,
+             * uid, gid, gids<16>) -- 24 bytes with a one-character name. */
+            put32(b, xid);
+            put32(b, RPC_REPLY);
+            put32(b, RPC_MSG_ACCEPTED);
+            put32(b, RPC_AUTH_SYS);
+            put32(b, 24);
+            put32(b, 1);              /* stamp                   */
+            put32(b, 1);              /* machinename.len         */
+            put_bytes(b, "h", 1);
+            put32(b, 0);              /* uid                     */
+            put32(b, 0);              /* gid                     */
+            put32(b, 0);              /* gids.len                */
+            put32(b, RPC_SUCCESS);
+            put_hello(b);
+            break;
+
+        case CDEF_REPLYUNKNOWNXID:
+            /* Perturbed rather than fixed: it must miss every xid the client
+             * has ever issued on this connection, and the client counts up
+             * from 1. */
+            put_accepted_header(b, xid ^ 0x5a5a5a5au);
+            put_hello(b);
+            break;
+
+        case CDEF_REPLYISACALL:
+            put32(b, xid ^ 0x5a5a5a5au);
+            put32(b, RPC_CALL);
+            put32(b, 2);              /* rpcvers                 */
+            put32(b, HELLO_PROG);
+            put32(b, HELLO_VERS);
+            put32(b, 0);              /* proc: NULL              */
+            put32(b, RPC_AUTH_NONE);
+            put32(b, 0);
+            put32(b, RPC_AUTH_NONE);
+            put32(b, 0);
+            break;
+
+        case CDEF_REPLYHEADERTRUNCATED:
+            put_accepted_header(b, xid);
+            put_hello(b);
+            b->len = (uint32_t) c->param;
+            break;
+
+        case CDEF_REPLYMTYPEUNDEFINED:
+            put32(b, xid);
+            put32(b, (uint32_t) c->param);
+            put_hello(b);
+            break;
+
+        case CDEF_REPLYVERFBODYOVERLONG:
+            put32(b, xid);
+            put32(b, RPC_REPLY);
+            put32(b, RPC_MSG_ACCEPTED);
+            put32(b, RPC_AUTH_NONE);
+            put32(b, 8);              /* claims 8 bytes AUTH_NONE cannot have */
+            put32(b, 0xdeadbeefu);
+            put32(b, 0xcafebabeu);
+            put32(b, RPC_SUCCESS);
+            put_hello(b);
+            break;
+
+        case CDEF_PEERCLOSESWITHOUTREPLY:
+            /* No bytes at all; the caller closes the socket instead. */
+            break;
+
+        case CDEF_REPLYREJECTEDAUTH:
+            put_denied_auth_header(b, xid);
+            break;
+
+        case CDEF_REPLYREJECTEDRPCMISMATCH:
+            put32(b, xid);
+            put32(b, RPC_REPLY);
+            put32(b, RPC_MSG_DENIED);
+            put32(b, RPC_RPC_MISMATCH);
+            put32(b, 2);              /* low                     */
+            put32(b, 2);              /* high                    */
+            break;
+
+        case CDEF_REPLYACCEPTSTAT:
+            put_accepted_error_header(b, xid, (uint32_t) c->param);
+            break;
+
+        case CDEF_REPLYDENIEDWITHBODY:
+            put_denied_auth_header(b, xid);
+            put_hello(b);
+            break;
+
+        case CDEF_REPLYACCEPTSTATWITHBODY:
+            put_accepted_error_header(b, xid, (uint32_t) c->param);
+            put_hello(b);
+            break;
+
+        case CDEF_REPLYSTATUNDEFINED:
+            put32(b, xid);
+            put32(b, RPC_REPLY);
+            put32(b, (uint32_t) c->param);
+            put_hello(b);
+            break;
+
+        case CDEF_REPLYEMPTYBODY:
+            put_accepted_header(b, xid);
+            break;
+
+        case CDEF_REPLYTRUNCATEDBODY:
+            put_accepted_header(b, xid);
+            body_start = b->len;
+            put_hello(b);
+            b->len = body_start + (uint32_t) c->param;
+            break;
+
+        case CDEF_REPLYTRAILINGGARBAGE:
+            put_accepted_header(b, xid);
+            put_hello(b);
+            put_bytes(b, g_pattern, (uint32_t) c->param);
+            break;
+
+        case CDEF_REPLYGARBAGEBODY:
+            put_accepted_header(b, xid);
+            put_bytes(b, g_pattern, 16);
+            break;
+
+        case CDEF_REPLYSTRINGLENOVERFLOW:
+            put_accepted_header(b, xid);
+            put32(b, REPLY_ID);
+            put32(b, 0xffffffffu);
+            break;
+
+        case CDEF_REPLYSTRINGLENBEYONDMESSAGE:
+            put_accepted_header(b, xid);
+            put32(b, REPLY_ID);
+            put32(b, 4096);           /* claims far more than follows */
+            put_bytes(b, g_pattern, 4);
+            break;
+
+        default:
+            evpl_test_abort("unhandled defect %u; the model gained a variant "
+                            "the driver has no arm for", c->defect);
+    } /* switch */
+} /* build_reply */
+
+/* ------------------------------------------------------------------ *
+* The hostile server: a raw TCP listener
+* ------------------------------------------------------------------ */
+
+static int g_listen_fd = -1;
+static int g_peer_fd   = -1;
+
+static int
+listen_raw(int listen_port)
+{
+    struct sockaddr_in addr;
+    int                fd, flag = 1;
+
+    fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    if (fd < 0) {
+        return -1;
+    }
+
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag));
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family      = AF_INET;
+    addr.sin_port        = htons(listen_port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    if (bind(fd, (struct sockaddr *) &addr, sizeof(addr)) < 0 ||
+        listen(fd, 8) < 0) {
+        close(fd);
+        return -1;
+    }
+
+    return fd;
+} /* listen_raw */
+
+/*
+ * Everything below shares one event loop with the client under test, so it may
+ * never block on the socket: the peer that owes it bytes is running on this
+ * same thread and only runs while evpl_continue is being pumped.
+ */
+static int
+accept_peer(struct evpl *evpl)
+{
+    uint64_t deadline = now_ms() + ACCEPT_TIMEOUT_MS;
+    int      fd, flag = 1;
+
+    for (;;) {
+        fd = accept(g_listen_fd, NULL, NULL);
+        if (fd >= 0) {
+            fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
+            setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+            return fd;
+        }
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            return -1;
+        }
+        evpl_continue(evpl);
+        if (now_ms() > deadline) {
+            return -1;
+        }
+    }
+} /* accept_peer */
+
+static int
+send_all(
+    struct evpl *evpl,
+    const void  *buf,
+    size_t       len)
+{
+    const uint8_t *p        = buf;
+    uint64_t       deadline = now_ms() + REPLY_TIMEOUT_MS;
+    ssize_t        n;
+
+    while (len) {
+        n = send(g_peer_fd, p, len, MSG_NOSIGNAL);
+        if (n > 0) {
+            p   += n;
+            len -= n;
+            continue;
+        }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            evpl_continue(evpl);
+            if (now_ms() > deadline) {
+                return -1;
+            }
+            continue;
+        }
+        return -1;
+    }
+    return 0;
+} /* send_all */
+
+#define READ_OK      0
+#define READ_TIMEOUT (-1)
+#define READ_EOF     (-2)
+
+static int
+read_exact(
+    struct evpl *evpl,
+    uint8_t     *buf,
+    uint32_t     want,
+    uint64_t     deadline)
+{
+    uint32_t off = 0;
+    ssize_t  n;
+
+    while (off < want) {
+        n = recv(g_peer_fd, buf + off, want - off, 0);
+        if (n == 0) {
+            return READ_EOF;
+        }
+        if (n < 0) {
+            if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                return READ_EOF;
+            }
+            evpl_continue(evpl);
+            if (now_ms() > deadline) {
+                return READ_TIMEOUT;
+            }
+            continue;
+        }
+        off += n;
+    }
+    return READ_OK;
+} /* read_exact */
+
+/*
+ * Read one record-marked message the client sent, returning only CALLs.
+ *
+ * The ReplyIsACall case provokes the client into answering with a REPLY of its
+ * own (PROG_UNAVAIL: a client connection exports no programs).  Those replies
+ * share the socket with the calls this harness is waiting for, so they are
+ * skipped here rather than being mistaken for the next call and desyncing
+ * every case that follows.
+ */
+static int
+read_call(
+    struct evpl *evpl,
+    uint8_t     *buf,
+    uint32_t     bufsz,
+    uint32_t    *out_len,
+    uint32_t    *out_xid)
+{
+    uint8_t  mark[4];
+    uint32_t len;
+    uint64_t deadline = now_ms() + REPLY_TIMEOUT_MS;
+    int      rc;
+
+    for (;;) {
+        rc = read_exact(evpl, mark, 4, deadline);
+        if (rc != READ_OK) {
+            return rc;
+        }
+
+        len = get32(mark) & 0x7fffffffu;
+        if (len > bufsz) {
+            return READ_EOF;
+        }
+
+        rc = read_exact(evpl, buf, len, deadline);
+        if (rc != READ_OK) {
+            return rc;
+        }
+
+        if (len >= 8 && get32(buf + 4) == RPC_CALL) {
+            *out_len = len;
+            *out_xid = get32(buf);
+            return READ_OK;
+        }
+    }
+} /* read_call */
+
+/*
+ * Put one assembled message on the wire.
+ *
+ * The delivery mode is part of the case: a defect that is only detected
+ * because the whole record arrived in a single read is not really detected,
+ * and the client's record-mark framing is precisely the code that has to cope
+ * with byte-at-a-time arrival.
+ */
+static int
+deliver(
+    struct evpl              *evpl,
+    const struct client_case *c,
+    const struct wirebuf     *msg)
+{
+    uint8_t  rec[sizeof(msg->data) + 4];
+    uint32_t total, half, i;
+
+    rec[0] = (uint8_t) (0x80 | ((msg->len >> 24) & 0x7f));
+    rec[1] = (uint8_t) (msg->len >> 16);
+    rec[2] = (uint8_t) (msg->len >> 8);
+    rec[3] = (uint8_t) msg->len;
+    memcpy(rec + 4, msg->data, msg->len);
+    total = msg->len + 4;
+
+    switch (c->delivery) {
+        case CDLV_ONEWRITE:
+            return send_all(evpl, rec, total);
+
+        case CDLV_TWOWRITES:
+            half = total / 2;
+            if (half == 0) {
+                half = total;
+            }
+            if (send_all(evpl, rec, half)) {
+                return -1;
+            }
+            /* Let the client observe the partial record before the rest
+             * arrives; without this the kernel usually coalesces the two
+             * writes and the split never happens. */
+            evpl_continue(evpl);
+            evpl_continue(evpl);
+            return send_all(evpl, rec + half, total - half);
+
+        case CDLV_DRIBBLE:
+            for (i = 0; i < total; i++) {
+                if (send_all(evpl, rec + i, 1)) {
+                    return -1;
+                }
+                evpl_continue(evpl);
+            }
+            return 0;
+
+        default:
+            evpl_test_abort("unhandled delivery %u", c->delivery);
+    } /* switch */
+
+    return -1;
+} /* deliver */
+
+/*
+ * Deliver one message as `n` record-mark fragments (RFC 5531 section 11).
+ * Only the last carries the terminal bit, so this exercises the client's
+ * inbound reassembly accumulator rather than its fast path.
+ */
+static int
+deliver_fragmented(
+    struct evpl          *evpl,
+    const struct wirebuf *msg,
+    uint32_t              nfrag)
+{
+    uint8_t  hdr[4];
+    uint32_t off = 0, i, this_len, remaining;
+
+    if (nfrag == 0 || nfrag > msg->len) {
+        nfrag = msg->len ? msg->len : 1;
+    }
+
+    for (i = 0; i < nfrag; i++) {
+        remaining = msg->len - off;
+        this_len  = (i + 1 == nfrag) ? remaining : remaining / (nfrag - i);
+        if (this_len == 0) {
+            this_len = 1;
+        }
+
+        hdr[0] = (uint8_t) ((i + 1 == nfrag ? 0x80 : 0x00) |
+                            ((this_len >> 24) & 0x7f));
+        hdr[1] = (uint8_t) (this_len >> 16);
+        hdr[2] = (uint8_t) (this_len >> 8);
+        hdr[3] = (uint8_t) this_len;
+
+        if (send_all(evpl, hdr, 4) ||
+            send_all(evpl, msg->data + off, this_len)) {
+            return -1;
+        }
+
+        evpl_continue(evpl);
+        off += this_len;
+    }
+
+    return 0;
+} /* deliver_fragmented */
+
+/* ------------------------------------------------------------------ *
+* Case execution
+* ------------------------------------------------------------------ */
+
+static struct evpl_rpc2_thread *g_thread;
+static struct evpl_endpoint    *g_endpoint;
+
+static int
+ensure_conn(struct evpl *evpl)
+{
+    if (g_conn_alive) {
+        return 0;
+    }
+
+    if (g_peer_fd >= 0) {
+        close(g_peer_fd);
+        g_peer_fd = -1;
+    }
+
+    g_conn = evpl_rpc2_client_connect(g_thread, EVPL_STREAM_SOCKET_TCP,
+                                      g_endpoint, NULL, 0, NULL);
+    if (!g_conn) {
+        return -1;
+    }
+    g_conn_alive = 1;
+
+    g_peer_fd = accept_peer(evpl);
+    if (g_peer_fd < 0) {
+        return -1;
+    }
+
+    return 0;
+} /* ensure_conn */
+
+/* Pump until the call completes, the connection dies, or the budget runs
+ * out.  The deadline is what separates "the client correctly ignored this
+ * reply" from "the client is stuck", and it is the only reason this loop is
+ * bounded at all -- a dropped reply produces no event to wait on. */
+static void
+pump_until_fired(
+    struct evpl       *evpl,
+    struct call_state *cs)
+{
+    uint64_t deadline = now_ms() + REPLY_TIMEOUT_MS;
+
+    while (!cs->fired && g_conn_alive && now_ms() < deadline) {
+        evpl_continue(evpl);
+    }
+} /* pump_until_fired */
+
+/* Complete an ordinary call on the connection.  Returns 1 if it round-tripped.
+ * This is the evidence for "the connection is still usable", which is the
+ * other half of every case whose reply the client is required to ignore. */
+static int
+probe_connection(struct evpl *evpl)
+{
+    struct call_state *cs = call_state_alloc();
+    struct wirebuf     msg;
+    uint8_t            buf[2048];
+    uint32_t           len, xid;
+
+    struct client_case one = { 0, CDLV_ONEWRITE, 0, 0, -1 };
+
+    if (!g_conn_alive || g_peer_fd < 0) {
+        return 0;
+    }
+
+    issue_call(evpl, cs);
+
+    if (read_call(evpl, buf, sizeof(buf), &len, &xid) != READ_OK) {
+        return 0;
+    }
+
+    msg.len = 0;
+    put_accepted_header(&msg, xid);
+    put_hello(&msg);
+
+    if (deliver(evpl, &one, &msg)) {
+        return 0;
+    }
+
+    pump_until_fired(evpl, cs);
+
+    return cs->fired == 1 && cs->status == 0 && cs->matched;
+} /* probe_connection */
+
+/* ------------------------------------------------------------------ *
+* Outbound AUTH_SYS credentials (RFC 5531 Appendix A)
+*
+* The reply cases above all send AUTH_NONE, which leaves the client's other
+* credential flavor -- the one every real NFS client uses -- entirely
+* unexercised.  This checks the encode direction, and it belongs in this
+* harness rather than in conformance.c because only a hostile server sees the
+* bytes: handing the credential to a real libevpl server and asking it what it
+* decoded would test the encoder and the decoder against each other, and a
+* pair of mutually consistent bugs would pass.  Here the oracle is the RFC's
+* own layout, read off the wire.
+*
+*     struct authsys_parms {
+*        unsigned int stamp;
+*        string machinename<255>;
+*        unsigned int uid;
+*        unsigned int gid;
+*        unsigned int gids<16>;
+*     };
+*
+* carried in the call's credential as flavor AUTH_SYS with that structure as
+* the opaque body (RFC 5531 section 9: opaque_auth is a flavor and a counted
+* body, and the body is XDR).
+* ------------------------------------------------------------------ */
+
+struct cred_case {
+    const char *machinename;
+    uint32_t    uid;
+    uint32_t    gid;
+    uint32_t    num_gids;
+    uint32_t    gids[EVPL_RPC2_AUTH_SYS_MAX_GIDS];
+};
+
+/*
+ * Machine names of length 4n, 4n+1, 4n+2 and 4n+3 between them cover every
+ * XDR residue, so all four padding cases are encoded and checked; the group
+ * lists cover the empty list and the declared <16> bound, which is where a
+ * counted field is most likely to be got wrong.
+ */
+static const struct cred_case cred_cases[] = {
+    { "conformance-client", 4711,                      815,                       3,
+        { 0,                    1,                         0xffffffffu } },
+    { "h",                  0,                         0,                         0,
+        { 0     } },
+    { "abc",                1,                         2,                         1,
+        { 65534 } },
+    { "node",               0xffffffffu,               0xffffffffu,               EVPL_RPC2_AUTH_SYS_MAX_GIDS,
+        { 100,                  101,                       102,                       103,
+        104, 105, 106, 107,
+        108, 109, 110, 111, 112, 113, 114, 115 } },
+};
+
+static int                    g_cred_run;
+static int                    g_cred_failed;
+
+#define cred_check(cond, ...)               \
+        do {                                    \
+            if (!(cond)) {                      \
+                evpl_test_error(__VA_ARGS__);   \
+                g_cred_failed++;                \
+                return;                         \
+            }                                   \
+        } while (0)
+
+static void
+check_authsys_call(
+    struct evpl            *evpl,
+    const struct cred_case *cc)
+{
+    struct call_state    *cs = call_state_alloc();
+    struct evpl_rpc2_cred cred;
+    struct wirebuf        msg;
+    struct client_case    one = { 0, CDLV_ONEWRITE, 0, 0, -1 };
+    static uint32_t       gids[EVPL_RPC2_AUTH_SYS_MAX_GIDS];
+    uint8_t               buf[2048];
+    const uint8_t        *body;
+    uint32_t              len, xid, cred_len, name_len, name_pad, want_len;
+    uint32_t              off, p, ngids, i;
+    int                   rc;
+
+    evpl_test_abort_if(ensure_conn(evpl),
+                       "failed to (re)connect the client under test");
+
+    name_len = (uint32_t) strlen(cc->machinename);
+    name_pad = (4 - (name_len & 3)) & 3;
+
+    memcpy(gids, cc->gids, sizeof(gids));
+
+    memset(&cred, 0, sizeof(cred));
+    cred.flavor                  = EVPL_RPC2_AUTH_SYS;
+    cred.authsys.uid             = cc->uid;
+    cred.authsys.gid             = cc->gid;
+    cred.authsys.num_gids        = cc->num_gids;
+    cred.authsys.gids            = gids;
+    cred.authsys.machinename     = cc->machinename;
+    cred.authsys.machinename_len = (int) name_len;
+
+    g_cred_run++;
+
+    issue_call_cred(evpl, cs, &cred);
+
+    rc = read_call(evpl, buf, sizeof(buf), &len, &xid);
+    evpl_test_abort_if(rc != READ_OK,
+                       "credential case '%s': never saw the client's CALL "
+                       "(rc %d)", cc->machinename, rc);
+
+    /* xid, mtype, rpcvers, prog, vers, proc, then the credential. */
+    off = 24;
+    cred_check(len >= off + 8, "credential case '%s': call is %u bytes, too "
+               "short to hold a credential at all", cc->machinename, len);
+
+    cred_check(get32(buf + off) == RPC_AUTH_SYS,
+               "credential case '%s': call carried auth flavor %u, expected "
+               "AUTH_SYS (%u)", cc->machinename, get32(buf + off),
+               RPC_AUTH_SYS);
+    off += 4;
+
+    cred_len = get32(buf + off);
+    off     += 4;
+
+    /* stamp + counted machinename (padded) + uid + gid + counted gids. */
+    want_len = 4 + 4 + name_len + name_pad + 4 + 4 + 4 + 4 * cc->num_gids;
+
+    cred_check(cred_len == want_len,
+               "credential case '%s': credential body is %u bytes, expected "
+               "%u", cc->machinename, cred_len, want_len);
+
+    /* The body is itself padded to a multiple of four inside the message. */
+    cred_check(off + ((cred_len + 3) & ~3u) + 8 <= len,
+               "credential case '%s': credential body runs past the end of "
+               "the call", cc->machinename);
+
+    body = buf + off;
+
+    /* struct evpl_rpc2_cred has no stamp, so libevpl always sends 0.  RFC 5531
+     * Appendix A calls it "an arbitrary ID which the caller machine may
+     * generate", so a constant is conformant -- asserted to pin down which
+     * constant, since a field nobody checks is a field that can quietly start
+     * carrying uninitialized stack. */
+    cred_check(get32(body) == 0,
+               "credential case '%s': stamp is %u, expected 0",
+               cc->machinename, get32(body));
+
+    cred_check(get32(body + 4) == name_len,
+               "credential case '%s': machinename length is %u, expected %u",
+               cc->machinename, get32(body + 4), name_len);
+
+    cred_check(memcmp(body + 8, cc->machinename, name_len) == 0,
+               "credential case '%s': machinename bytes did not survive",
+               cc->machinename);
+
+    for (i = 0; i < name_pad; i++) {
+        cred_check(body[8 + name_len + i] == 0,
+                   "credential case '%s': machinename pad byte %u is 0x%02x, "
+                   "and RFC 4506 section 4.11 requires zero",
+                   cc->machinename, i, body[8 + name_len + i]);
+    }
+
+    p = 8 + name_len + name_pad;
+
+    cred_check(get32(body + p) == cc->uid,
+               "credential case '%s': uid is %u, expected %u",
+               cc->machinename, get32(body + p), cc->uid);
+
+    cred_check(get32(body + p + 4) == cc->gid,
+               "credential case '%s': gid is %u, expected %u",
+               cc->machinename, get32(body + p + 4), cc->gid);
+
+    ngids = get32(body + p + 8);
+    cred_check(ngids == cc->num_gids,
+               "credential case '%s': gids count is %u, expected %u",
+               cc->machinename, ngids, cc->num_gids);
+
+    for (i = 0; i < ngids; i++) {
+        cred_check(get32(body + p + 12 + 4 * i) == cc->gids[i],
+                   "credential case '%s': gids[%u] is %u, expected %u",
+                   cc->machinename, i, get32(body + p + 12 + 4 * i),
+                   cc->gids[i]);
+    }
+
+    /* The verifier is unaffected by the credential flavor: an AUTH_SYS call
+     * still carries AUTH_NONE there (RFC 5531 Appendix A -- system
+     * authentication has no verifier of its own). */
+    off += (cred_len + 3) & ~3u;
+    cred_check(get32(buf + off) == RPC_AUTH_NONE && get32(buf + off + 4) == 0,
+               "credential case '%s': verifier is flavor %u length %u, "
+               "expected AUTH_NONE with an empty body",
+               cc->machinename, get32(buf + off), get32(buf + off + 4));
+    off += 8;
+
+    /* And the arguments still follow it, unshifted -- a credential encoded at
+     * the wrong length would leave the call decodable only by accident. */
+    cred_check(off + 8 + strlen(CALL_GREETING) <= len,
+               "credential case '%s': no room left for the arguments",
+               cc->machinename);
+    cred_check(get32(buf + off) == CALL_ID &&
+               get32(buf + off + 4) == strlen(CALL_GREETING) &&
+               memcmp(buf + off + 8, CALL_GREETING,
+                      strlen(CALL_GREETING)) == 0,
+               "credential case '%s': the arguments did not survive the "
+               "credential", cc->machinename);
+
+    /* Answer it, so the call completes and nothing is left outstanding for a
+     * later case to trip over. */
+    msg.len = 0;
+    put_accepted_header(&msg, xid);
+    put_hello(&msg);
+
+    cred_check(deliver(evpl, &one, &msg) == 0,
+               "credential case '%s': failed to write the reply",
+               cc->machinename);
+
+    pump_until_fired(evpl, cs);
+
+    cred_check(cs->fired == 1 && cs->status == 0 && cs->matched,
+               "credential case '%s': the call did not complete (fired %d, "
+               "status %d, matched %d)", cc->machinename, cs->fired,
+               cs->status, cs->matched);
+} /* check_authsys_call */
+
+static void
+run_case(
+    struct evpl              *evpl,
+    const struct client_case *c)
+{
+    struct call_state *cs = call_state_alloc();
+    struct wirebuf     msg;
+    uint8_t            buf[2048];
+    uint32_t           len, xid;
+    int                actual, probe_ok, rc;
+
+    if (ensure_conn(evpl)) {
+        evpl_test_abort("failed to (re)connect the client under test");
+    }
+
+    g_results.run++;
+
+    issue_call(evpl, cs);
+
+    rc = read_call(evpl, buf, sizeof(buf), &len, &xid);
+    evpl_test_abort_if(rc != READ_OK,
+                       "case %s/%s: never saw the client's CALL (rc %d)",
+                       defect_name(c->defect), delivery_name(c->delivery), rc);
+
+    build_reply(&msg, c, xid);
+
+    if (c->defect == CDEF_PEERCLOSESWITHOUTREPLY) {
+        close(g_peer_fd);
+        g_peer_fd = -1;
+    } else if (c->defect == CDEF_REPLYSPLITACROSSFRAGMENTS) {
+        rc = deliver_fragmented(evpl, &msg, (uint32_t) c->param);
+        evpl_test_abort_if(rc, "case %s: failed to write the fragments",
+                           defect_name(c->defect));
+    } else {
+        rc = deliver(evpl, c, &msg);
+        evpl_test_abort_if(rc, "case %s/%s: failed to write the reply",
+                           defect_name(c->defect), delivery_name(c->delivery));
+    }
+
+    pump_until_fired(evpl, cs);
+
+    /* The second copy goes out only once the first has been consumed, so that
+     * what it collides with is a completed call and not a race. */
+    if (c->defect == CDEF_REPLYDUPLICATED && g_conn_alive) {
+        rc = deliver(evpl, c, &msg);
+        evpl_test_abort_if(rc, "case %s: failed to write the duplicate",
+                           defect_name(c->defect));
+        evpl_continue(evpl);
+        evpl_continue(evpl);
+    }
+
+    /* Classify what the client did.  Note the ordering: a second completion
+     * outranks whatever the first one said, because no status can make
+     * double-completing a call correct. */
+    if (cs->fired > 1) {
+        actual = ACT_DOUBLE_CALLBACK;
+    } else if (cs->fired == 1) {
+        if (cs->status == 0) {
+            actual = cs->matched ? CEXP_CBSUCCESS : ACT_WRONG_VALUE;
+        } else if (cs->status == EVPL_RPC2_REPLY_DECODE_ERROR) {
+            actual = CEXP_CBDECODEERROR;
+        } else {
+            actual = CEXP_CBFAILED;
+        }
+    } else if (!g_conn_alive) {
+        actual = ACT_CONN_LOST;
+    } else {
+        actual = ACT_NO_CALLBACK;
+    }
+
+    probe_ok = probe_connection(evpl);
+
+    /* CbFailed is deliberately satisfied by a decode error: the model does not
+     * pin down which non-zero status a refusal produces, only that the call
+     * completes and completes as a failure. */
+    if (c->expect == CEXP_CBFAILED &&
+        (actual == CEXP_CBDECODEERROR || actual == CEXP_CBFAILED)) {
+        actual = CEXP_CBFAILED;
+    }
+
+    /* A reply the client must ignore leaves no trace of its own, so the only
+     * proof it was ignored *correctly* -- rather than because the client
+     * stopped working -- is a subsequent ordinary call on the same
+     * connection. */
+    if (c->expect == CEXP_CBDROPPED && actual == ACT_NO_CALLBACK && probe_ok) {
+        actual = CEXP_CBDROPPED;
+    }
+
+    if (actual == c->expect &&
+        (c->survive != CSRV_CONNUP || probe_ok)) {
+        g_results.matched++;
+        g_results.matched_by_expect[c->expect]++;
+        return;
+    }
+
+    if (is_known_divergence(c->defect, c->expect, actual)) {
+        g_results.known++;
+        evpl_test_info("known divergence: %s(%lld)/%s expected %s, got %s",
+                       defect_name(c->defect), (long long) c->param,
+                       delivery_name(c->delivery),
+                       outcome_name(c->expect), outcome_name(actual));
+        return;
+    }
+
+    g_results.unknown++;
+    evpl_test_error(
+        "DIVERGENCE: %s(%lld)/%s expected %s, got %s (status %d, fired %d, "
+        "conn %s, probe %s, results id=%u greeting='%s')",
+        defect_name(c->defect), (long long) c->param,
+        delivery_name(c->delivery),
+        outcome_name(c->expect), outcome_name(actual),
+        cs->status, cs->fired,
+        g_conn_alive ? "up" : "down",
+        probe_ok ? "ok" : "failed",
+        cs->got_id, cs->got_greeting);
+} /* run_case */
+
+static void
+usage(const char *prog)
+{
+    fprintf(stderr, "Usage: %s [-r protocol] [-p port]\n", prog);
+    exit(1);
+} /* usage */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct evpl               *evpl;
+    struct evpl_rpc2_program  *programs[1];
+    struct evpl_thread_config *tcfg;
+    enum evpl_protocol_id      proto = EVPL_STREAM_SOCKET_TCP;
+    unsigned int               i;
+    int                        opt, rc, failed;
+
+    test_evpl_config();
+
+    while ((opt = getopt(argc, argv, "r:p:")) != -1) {
+        switch (opt) {
+            case 'r':
+                rc = evpl_protocol_lookup(&proto, optarg);
+                if (rc) {
+                    fprintf(stderr, "Invalid protocol '%s'\n", optarg);
+                    return 1;
+                }
+                break;
+            case 'p':
+                port = atoi(optarg);
+                break;
+            default:
+                usage(argv[0]);
+        } /* switch */
+    }
+
+    /* The harness is hand-built record-marked bytes, which is a stream-only
+     * concept; there is no way to express these defects over RDMA. */
+    if (proto != EVPL_STREAM_SOCKET_TCP) {
+        printf("skipping: raw record marking requires a stream transport\n");
+        printf("Test PASSED\n");
+        return 0;
+    }
+
+    pattern_init();
+
+    /*
+     * A bounded wait is required, not merely nice: the default (-1) parks
+     * evpl_continue in the poller until something happens, and the cases that
+     * expect no callback at all would never come back to check their deadline.
+     *
+     * evpl_create() takes ownership of the config and releases it itself.
+     * Exactly one evpl is created for the whole run -- a second create/destroy
+     * cycle wedges process exit.
+     */
+    tcfg = evpl_thread_config_init();
+    evpl_thread_config_set_wait_ms(tcfg, 1);
+    evpl = evpl_create(tcfg);
+
+    HELLO_V1_init(&g_prog);
+    programs[0] = &g_prog.rpc2;
+
+    g_listen_fd = listen_raw(port);
+    evpl_test_abort_if(g_listen_fd < 0, "failed to listen on port %d", port);
+
+    g_thread = evpl_rpc2_thread_init(evpl, programs, 1, client_notify_cb,
+                                     NULL);
+    g_endpoint = evpl_endpoint_create("127.0.0.1", port);
+
+    /* Before the reply matrix, and on a connection nothing has abused yet:
+     * these check what the client puts on the wire, so they need a case-free
+     * connection more than they need a particular one. */
+    evpl_test_info("running %u outbound credential cases",
+                   (unsigned int) (sizeof(cred_cases) / sizeof(cred_cases[0])));
+
+    for (i = 0; i < sizeof(cred_cases) / sizeof(cred_cases[0]); i++) {
+        check_authsys_call(evpl, &cred_cases[i]);
+    }
+
+    evpl_test_info("running %u client reply cases",
+                   (unsigned int) CLIENT_NUM_CASES);
+
+    for (i = 0; i < CLIENT_NUM_CASES; i++) {
+        run_case(evpl, &client_cases[i]);
+    }
+
+    if (g_conn_alive) {
+        evpl_rpc2_client_disconnect(g_thread, g_conn);
+    }
+
+    if (g_peer_fd >= 0) {
+        close(g_peer_fd);
+    }
+    close(g_listen_fd);
+
+    /* Let the loop retire the connections the run left in every state the
+     * client knows how to reach before tearing it down. */
+    {
+        uint64_t drain_deadline = now_ms() + 200;
+
+        while (now_ms() < drain_deadline) {
+            evpl_continue(evpl);
+        }
+    }
+
+    evpl_rpc2_thread_destroy(g_thread);
+    evpl_destroy(evpl);
+
+    /* Only now, once no callback can run again, is the call state unreachable. */
+    call_states_release();
+
+    printf("outbound credential cases: %d run, %d failed\n",
+           g_cred_run, g_cred_failed);
+    printf("client reply cases: %d run, %d matched spec, %d known divergences, "
+           "%d unexpected\n",
+           g_results.run, g_results.matched, g_results.known,
+           g_results.unknown);
+    printf("  matched by required outcome: %d callback-ok, %d decode-error, "
+           "%d failed, %d dropped\n",
+           g_results.matched_by_expect[CEXP_CBSUCCESS],
+           g_results.matched_by_expect[CEXP_CBDECODEERROR],
+           g_results.matched_by_expect[CEXP_CBFAILED],
+           g_results.matched_by_expect[CEXP_CBDROPPED]);
+
+    failed = g_results.unknown != 0 || g_cred_failed != 0;
+
+    printf("Test %s\n", failed ? "FAILED" : "PASSED");
+    return failed ? 1 : 0;
+} /* main */

--- a/src/rpc2/tests/gss_stub.c
+++ b/src/rpc2/tests/gss_stub.c
@@ -1,0 +1,247 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Ben Jarvis
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Deterministic RPCSEC_GSS provider for the conformance test.  See gss_stub.h
+ * for why this exists in place of a real mechanism.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_rpc2_gss.h"
+
+#include "gss_stub.h"
+
+static int gss_stub_accept_mode = GSS_STUB_ACCEPT_COMPLETE;
+static int gss_stub_verify_mode = GSS_STUB_VERIFY_HONEST;
+static int gss_stub_mic_mode    = GSS_STUB_MIC_HONEST;
+
+void
+gss_stub_set_behaviour(
+    int accept_mode,
+    int verify_mode,
+    int mic_mode)
+{
+    gss_stub_accept_mode = accept_mode;
+    gss_stub_verify_mode = verify_mode;
+    gss_stub_mic_mode    = mic_mode;
+} /* gss_stub_set_behaviour */
+
+/*
+ * FNV-1a over the message, emitted big-endian.  The point is not
+ * cryptographic strength -- it is that the driver can compute the identical
+ * value and so present a verifier the server will accept, which is what makes
+ * the success paths reachable rather than only the rejections.
+ */
+void
+gss_stub_mic(
+    const void *msg,
+    size_t      msg_len,
+    uint8_t     out[GSS_STUB_MIC_LEN])
+{
+    const uint8_t *p = msg;
+    uint64_t       h = 1469598103934665603ULL;
+    size_t         i;
+
+    for (i = 0; i < msg_len; i++) {
+        h ^= p[i];
+        h *= 1099511628211ULL;
+    }
+
+    for (i = 0; i < GSS_STUB_MIC_LEN; i++) {
+        out[i] = (uint8_t) (h >> (56 - 8 * i));
+    }
+} /* gss_stub_mic */
+
+/* Per-context cookie.  Only its existence matters to libevpl, which treats it
+ * as opaque; the stub keeps a marker so destroy() can assert it owns it. */
+struct gss_stub_ctx {
+    uint32_t magic;
+    int      legs;
+};
+
+#define GSS_STUB_MAGIC 0x5f475353u
+
+static int
+gss_stub_accept(
+    void       *provider_arg,
+    void      **gss_ctx,
+    const void *in_token,
+    size_t      in_len,
+    void      **out_token,
+    size_t     *out_len,
+    int        *complete,
+    char       *principal,
+    size_t      principal_sz)
+{
+    struct gss_stub_ctx *ctx = *gss_ctx;
+    uint8_t             *tok;
+
+    if (!ctx) {
+        ctx = calloc(1, sizeof(*ctx));
+        if (!ctx) {
+            return -1;
+        }
+        ctx->magic = GSS_STUB_MAGIC;
+        *gss_ctx   = ctx;
+    }
+
+    ctx->legs++;
+
+    if (gss_stub_accept_mode == GSS_STUB_ACCEPT_FAIL) {
+        return -1;
+    }
+
+    /* Every leg returns a token to relay, which is what a real mechanism does
+     * and what keeps the reply-construction path exercised.  Its length is
+     * deliberately not a multiple of four: GSS tokens are arbitrary octet
+     * strings, so the server has to pad the opaque it marshals them into, and
+     * an aligned token would leave that padding untested. */
+    tok = malloc(GSS_STUB_TOKEN_LEN);
+    if (!tok) {
+        return -1;
+    }
+    memcpy(tok, "STUB!", GSS_STUB_TOKEN_LEN);
+    *out_token = tok;
+    *out_len   = GSS_STUB_TOKEN_LEN;
+
+    /* A failure that still emits a token: the server must not send it, and
+     * must not leak it either. */
+    if (gss_stub_accept_mode == GSS_STUB_ACCEPT_FAIL_TOK) {
+        return -1;
+    }
+
+    if (gss_stub_accept_mode == GSS_STUB_ACCEPT_CONTINUE && ctx->legs < 2) {
+        *complete = 0;
+        return 0;
+    }
+
+    *complete = 1;
+    snprintf(principal, principal_sz, "stub@LIBEVPL.TEST");
+    return 0;
+} /* gss_stub_accept */
+
+static int
+gss_stub_get_mic(
+    void       *provider_arg,
+    void       *gss_ctx,
+    const void *msg,
+    size_t      msg_len,
+    void      **mic,
+    size_t     *mic_len)
+{
+    uint8_t *out;
+
+    /* Only the integrity databody is signed with anything other than a
+     * four-byte message; see gss_stub.h. */
+    if (msg_len != sizeof(uint32_t)) {
+        if (gss_stub_mic_mode == GSS_STUB_MIC_FAIL_BODY) {
+            return -1;
+        }
+        if (gss_stub_mic_mode == GSS_STUB_MIC_HUGE_BODY) {
+            out = malloc(GSS_STUB_MIC_HUGE_LEN);
+            if (!out) {
+                return -1;
+            }
+            memset(out, 0xa5, GSS_STUB_MIC_HUGE_LEN);
+            *mic     = out;
+            *mic_len = GSS_STUB_MIC_HUGE_LEN;
+            return 0;
+        }
+    }
+
+    out = malloc(GSS_STUB_MIC_LEN);
+
+    if (!out) {
+        return -1;
+    }
+
+    gss_stub_mic(msg, msg_len, out);
+    *mic     = out;
+    *mic_len = GSS_STUB_MIC_LEN;
+    return 0;
+} /* gss_stub_get_mic */
+
+static int
+gss_stub_verify_mic(
+    void       *provider_arg,
+    void       *gss_ctx,
+    const void *msg,
+    size_t      msg_len,
+    const void *mic,
+    size_t      mic_len)
+{
+    uint8_t expect[GSS_STUB_MIC_LEN];
+
+    if (gss_stub_verify_mode == GSS_STUB_VERIFY_REJECT) {
+        return -1;
+    }
+
+    if (mic_len != GSS_STUB_MIC_LEN) {
+        return -1;
+    }
+
+    gss_stub_mic(msg, msg_len, expect);
+    return memcmp(expect, mic, GSS_STUB_MIC_LEN) == 0 ? 0 : -1;
+} /* gss_stub_verify_mic */
+
+/*
+ * Privacy (krb5p) is not implemented by rpc2.c, which rejects the service with
+ * AUTH_TOOWEAK before ever reaching a provider.  These exist to complete the
+ * vtable and to fail loudly if that ever changes without the stub keeping up.
+ */
+static int
+gss_stub_wrap(
+    void       *provider_arg,
+    void       *gss_ctx,
+    const void *in,
+    size_t      in_len,
+    void      **out,
+    size_t     *out_len)
+{
+    return -1;
+} /* gss_stub_wrap */
+
+static int
+gss_stub_unwrap(
+    void       *provider_arg,
+    void       *gss_ctx,
+    const void *in,
+    size_t      in_len,
+    void      **out,
+    size_t     *out_len)
+{
+    return -1;
+} /* gss_stub_unwrap */
+
+static void
+gss_stub_destroy(
+    void *provider_arg,
+    void *gss_ctx)
+{
+    struct gss_stub_ctx *ctx = gss_ctx;
+
+    if (ctx && ctx->magic == GSS_STUB_MAGIC) {
+        ctx->magic = 0;
+        free(ctx);
+    }
+} /* gss_stub_destroy */
+
+static const struct evpl_rpc2_gss_provider gss_stub_vtable = {
+    .accept     = gss_stub_accept,
+    .get_mic    = gss_stub_get_mic,
+    .verify_mic = gss_stub_verify_mic,
+    .wrap       = gss_stub_wrap,
+    .unwrap     = gss_stub_unwrap,
+    .destroy    = gss_stub_destroy,
+};
+
+const struct evpl_rpc2_gss_provider *
+gss_stub_provider(void)
+{
+    return &gss_stub_vtable;
+} /* gss_stub_provider */

--- a/src/rpc2/tests/gss_stub.h
+++ b/src/rpc2/tests/gss_stub.h
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Ben Jarvis
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * A deterministic RPCSEC_GSS provider for testing.
+ *
+ * libevpl implements the RPCSEC_GSS wire framing and state machine but
+ * deliberately links no GSS mechanism (see evpl_rpc2_gss.h).  Exercising that
+ * machinery therefore needs a provider, and a real Kerberos one would be both
+ * heavyweight and -- more importantly -- untestable: the interesting cases are
+ * the failures, and a real mechanism cannot be told to fail on demand.
+ *
+ * This stub is instead fully deterministic and externally controllable.  Its
+ * MIC is a plain FNV-1a hash of the message, so a test driver can compute a
+ * valid verifier for itself, and its accept/verify behaviour is selected per
+ * case through gss_stub_set_behaviour().  That turns the mechanism into
+ * another dimension the model can drive rather than an opaque dependency.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+struct evpl_rpc2_gss_provider;
+
+/* What the next accept() should do. */
+#define GSS_STUB_ACCEPT_COMPLETE 0   /* establish the context immediately   */
+#define GSS_STUB_ACCEPT_CONTINUE 1   /* one more leg required               */
+#define GSS_STUB_ACCEPT_FAIL     2   /* mechanism-level failure             */
+/* A mechanism-level failure that still hands back a token for the server to
+ * relay -- the normal shape of a rejection a real mechanism wants the peer to
+ * see, and the only way to reach the server's "free the token we were given
+ * but will never send" path. */
+#define GSS_STUB_ACCEPT_FAIL_TOK 3
+
+/* Whether verify_mic() should honour the checksum or reject regardless. */
+#define GSS_STUB_VERIFY_HONEST   0
+#define GSS_STUB_VERIFY_REJECT   1
+
+/*
+ * What get_mic() should do when asked to sign a message that is NOT four bytes
+ * long.  The four-byte MICs are the RPC-level verifiers (a checksum over a
+ * seq_num or over the seq_window); anything longer is the integrity service's
+ * databody.  Keying on the length lets a case break the *reply* signing that
+ * RFC 2203 sec 5.3.3.4.1 governs without also breaking the context handshake
+ * that has to succeed first.
+ */
+#define GSS_STUB_MIC_HONEST      0
+#define GSS_STUB_MIC_FAIL_BODY   1   /* refuse to sign the databody         */
+#define GSS_STUB_MIC_HUGE_BODY   2   /* sign it, but with an outsized MIC   */
+
+/* Bigger than the 512-byte checksum headroom rpc2.c reserves in an integrity
+ * reply, so a MIC this size is one it cannot emit. */
+#define GSS_STUB_MIC_HUGE_LEN    600
+
+void
+gss_stub_set_behaviour(
+    int accept_mode,
+    int verify_mode,
+    int mic_mode);
+
+/* The MIC the stub computes, and which a driver can therefore reproduce to
+* build a verifier the stub will accept.  Always GSS_STUB_MIC_LEN bytes. */
+#define GSS_STUB_MIC_LEN   8
+
+/* Length of the token every accept() leg hands back.  Deliberately not a
+ * multiple of four -- see gss_stub_accept(). */
+#define GSS_STUB_TOKEN_LEN 5
+
+void
+gss_stub_mic(
+    const void *msg,
+    size_t      msg_len,
+    uint8_t     out[GSS_STUB_MIC_LEN]);
+
+const struct evpl_rpc2_gss_provider *
+gss_stub_provider(
+    void);

--- a/src/rpc2/tests/quint/check_models.sh
+++ b/src/rpc2/tests/quint/check_models.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Ben Jarvis
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# check_models.sh - run the Quint models' own scenario tests and invariants
+#
+# Usage: check_models.sh QUINT SRC_DIR
+#
+# Registered as a ctest so that a broken specification surfaces as a failing
+# test rather than as a failing build or, worse, as a quietly wrong case table.
+# This is the model checking the model; the conformance test that consumes its
+# output is what checks the implementation.
+
+set -euo pipefail
+
+QUINT="${1:?usage: check_models.sh QUINT SRC_DIR}"
+SRC_DIR="${2:?}"
+
+"${QUINT}" test "${SRC_DIR}/values.qnt"
+"${QUINT}" test "${SRC_DIR}/defects.qnt"
+
+# Random simulation against the invariants: the value model must only ever
+# emit legal input, and every defect must carry a specified outcome.
+"${QUINT}" run "${SRC_DIR}/values.qnt" \
+    --invariant=wellFormed --max-samples=500 --max-steps=50
+"${QUINT}" run "${SRC_DIR}/defects.qnt" \
+    --invariant=safety --max-samples=500 --max-steps=50

--- a/src/rpc2/tests/quint/client.qnt
+++ b/src/rpc2/tests/quint/client.qnt
@@ -1,0 +1,357 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+/**
+ * client.qnt -- the reply-defect taxonomy for the RPC2 *client*.
+ *
+ * defects.qnt drives libevpl's server with malformed CALLs.  This model is its
+ * mirror image: each state is one deliberately defective REPLY delivered to a
+ * real libevpl client by a hostile server, plus what the client is required to
+ * do with it.
+ *
+ * IMPORTANT: this model encodes the SPECIFICATION, not libevpl's current
+ * behaviour.  Where the two disagree the driver records a divergence, which is
+ * reviewed as a candidate bug.  Encoding current behaviour instead would
+ * freeze today's defects into the spec and guarantee they are never found.
+ *
+ * The two requirements that carry most of the weight here, because both are
+ * easy to violate and neither is visible from a well-behaved peer:
+ *
+ *   1. No call may be abandoned in silence.  A client that issued a call owes
+ *      its caller exactly one completion, whatever the peer does -- including
+ *      hanging up.  Anything else is a caller blocked forever.
+ *
+ *   2. A reply the peer refused is not a result.  MSG_DENIED and any
+ *      accept_stat other than SUCCESS mean there is no result to deliver, so
+ *      whatever bytes follow must never reach the caller as a success.
+ *
+ * The defect kinds are SYMBOLIC; the driver owns the byte-level mis-encoding.
+ * Quint's job is to enumerate the taxonomy and state the required outcome.
+ *
+ *   quint test client.qnt
+ *   quint run client.qnt --invariant=safety
+ */
+module rpc2_client {
+
+    /// Mirrors hello_world.x and the RPC2 reply envelope (RFC 5531 section 9).
+    pure val PROG = 42
+    pure val VERS = 1
+    pure val PROC_GREET = 1
+    pure val RPC_VERS = 2
+
+    type Defect =
+        /* --- baseline: proves the hostile server can build a VALID reply -- */
+        | ReplyWellFormed
+        /* A reply verifier need not be AUTH_NONE; any legal opaque_auth must
+         * decode.  Positive coverage for the header decoder. */
+        | ReplyVerfAuthSys
+        /* Legal record marking (RFC 5531 section 11) on the inbound path. */
+        | ReplySplitAcrossFragments(int)
+
+        /* --- replies that are not ours ---------------------------------- */
+        | ReplyUnknownXid
+        | ReplyDuplicated             /* the same reply delivered twice      */
+        | ReplyIsACall                /* mtype == CALL on a client connection */
+
+        /* --- envelope the client cannot parse ---------------------------- */
+        | ReplyHeaderTruncated(int)   /* record shorter than an RPC header    */
+        | ReplyMtypeUndefined(int)    /* mtype neither CALL nor REPLY         */
+        | ReplyVerfBodyOverlong       /* verf length disagrees with its body  */
+        | PeerClosesWithoutReply      /* connection dropped mid-call          */
+
+        /* --- results the peer refused to produce ------------------------- */
+        | ReplyRejectedAuth           /* MSG_DENIED / AUTH_ERROR              */
+        | ReplyRejectedRpcMismatch    /* MSG_DENIED / RPC_MISMATCH            */
+        | ReplyAcceptStat(int)        /* MSG_ACCEPTED, accept_stat != SUCCESS */
+        /* The same refusals, but with a perfectly well-formed result encoded
+         * after them.  A client that ignores the status and decodes whatever
+         * follows reports success for a call the peer declined -- so these
+         * separate "does not look at the status" from "happens to fail to
+         * decode the empty body that a refusal leaves behind". */
+        | ReplyDeniedWithBody
+        | ReplyAcceptStatWithBody(int)
+        | ReplyStatUndefined(int)     /* reply_stat neither ACCEPTED nor DENIED */
+
+        /* --- undecodable results (RFC 4506) ------------------------------ */
+        | ReplyEmptyBody
+        | ReplyTruncatedBody(int)
+        | ReplyTrailingGarbage(int)
+        | ReplyGarbageBody
+        | ReplyStringLenOverflow
+        | ReplyStringLenBeyondMessage
+
+    /// What the client must do with the reply.
+    type Outcome =
+        /* The callback fires with status 0 and the value the peer encoded. */
+        | CbSuccess
+        /* The callback fires with EVPL_RPC2_REPLY_DECODE_ERROR: the results
+         * were present but not decodable as the procedure's return type. */
+        | CbDecodeError
+        /* The callback fires with some non-zero status.  Which one is left
+         * open: libevpl's reply callback carries a single int, so requiring a
+         * distinct code for each refusal would be requiring an API change
+         * rather than stating a protocol obligation.  What is NOT open is that
+         * the call completes, and completes as a failure. */
+        | CbFailed
+        /* This reply is not an answer to the outstanding call and must be
+         * discarded without completing it. */
+        | CbDropped
+
+    /// Whether the connection must survive the defect.  ConnAny is for the
+    /// defects that destroy the framing or the transport itself, where
+    /// dropping the connection is a legitimate response; the callback
+    /// obligation above still holds in that case.
+    type Survival =
+        | ConnUp
+        | ConnAny
+
+    /// How the hostile server puts the bytes on the wire.  A defect that is
+    /// only detected because the whole record arrived in one read is not
+    /// really detected, so every payload defect is also delivered split.
+    type Delivery =
+        | OneWrite
+        | TwoWrites
+        | Dribble        /* one byte per write, pumping the loop between */
+
+    type Case = { defect: Defect, delivery: Delivery }
+
+    var current: Case
+
+    /// The response the specification requires for `current`.  State
+    /// variables rather than derived expressions so that they are carried in
+    /// the generated ITF trace: the trace, not the model, is what the C driver
+    /// consumes, so the prediction has to travel with the case.
+    var expected: Outcome
+    var survives: Survival
+
+    // ------------------------------------------------------------------
+    // The specification: defect -> required client behaviour
+    // ------------------------------------------------------------------
+
+    pure def required(d: Defect): Outcome = match d {
+        | ReplyWellFormed => CbSuccess
+        | ReplyVerfAuthSys => CbSuccess
+
+        /* RFC 5531 section 11: a record split across fragments is one
+         * message.  Reassembling it is not optional. */
+        | ReplySplitAcrossFragments(_) => CbSuccess
+
+        /* The first copy completes the call; the taxonomy entry is about the
+         * copy that follows it, which by then matches no outstanding xid.  The
+         * driver additionally requires that the callback fired exactly once --
+         * a second delivery must not double-complete. */
+        | ReplyDuplicated => CbSuccess
+
+        /* A reply matching no outstanding call is late, duplicate, or for a
+         * call already reaped.  ONC RPC has no way to acknowledge a reply, so
+         * the only correct action is to drop it -- and, because every record
+         * is framed independently, to keep the connection. */
+        | ReplyUnknownXid => CbDropped
+
+        /* A CALL arriving on a connection where no program is exported is not
+         * an answer to anything.  It must not be matched against a pending
+         * xid, and it must not take the connection down. */
+        | ReplyIsACall => CbDropped
+
+        /* Nothing about a garbled record identifies which call it answers, so
+         * the connection may go.  What may not go is the caller's completion:
+         * the client knows exactly which calls it had outstanding on that
+         * connection and owes each of them an answer. */
+        | ReplyHeaderTruncated(_) => CbFailed
+        | ReplyMtypeUndefined(_) => CbFailed
+        | ReplyVerfBodyOverlong => CbFailed
+        | PeerClosesWithoutReply => CbFailed
+
+        /* A refusal is a completed call with no result.  Reporting it as a
+         * failure is required; reporting the bytes that follow it as a result
+         * is the bug these cases exist to catch. */
+        | ReplyRejectedAuth => CbFailed
+        | ReplyRejectedRpcMismatch => CbFailed
+        | ReplyAcceptStat(_) => CbFailed
+        | ReplyDeniedWithBody => CbFailed
+        | ReplyAcceptStatWithBody(_) => CbFailed
+        | ReplyStatUndefined(_) => CbFailed
+
+        /* Results that are present but not decodable as the procedure's
+         * return type.  RFC 4506: too short, too long, or internally
+         * inconsistent are all invalid, and the caller must be told the call
+         * failed rather than handed a partially decoded value. */
+        | ReplyEmptyBody => CbDecodeError
+        | ReplyTruncatedBody(_) => CbDecodeError
+        | ReplyTrailingGarbage(_) => CbDecodeError
+        | ReplyGarbageBody => CbDecodeError
+        | ReplyStringLenOverflow => CbDecodeError
+        | ReplyStringLenBeyondMessage => CbDecodeError
+    }
+
+    /// A defect that leaves the record framing intact gives the client no
+    /// reason to hang up: one bad reply does not desync a record-marked
+    /// stream, and closing would fail every other call in flight.
+    pure def survival(d: Defect): Survival = match d {
+        | ReplyHeaderTruncated(_) => ConnAny
+        | ReplyMtypeUndefined(_) => ConnAny
+        | ReplyVerfBodyOverlong => ConnAny
+        | PeerClosesWithoutReply => ConnAny
+        | _ => ConnUp
+    }
+
+    // ------------------------------------------------------------------
+    // Case generation
+    // ------------------------------------------------------------------
+
+    pure val DELIVERIES = Set(OneWrite, TwoWrites, Dribble)
+
+    /// Defect instances.  Where a defect carries a number, a few
+    /// representative values are enumerated rather than the whole domain: the
+    /// driver's encoding is identical for all of them, so extra values buy no
+    /// new code paths.
+    pure val DEFECTS = Set(
+        ReplyWellFormed,
+        ReplyVerfAuthSys,
+        ReplySplitAcrossFragments(2), ReplySplitAcrossFragments(3),
+        ReplySplitAcrossFragments(16),
+        ReplyUnknownXid,
+        ReplyDuplicated,
+        ReplyIsACall,
+        ReplyHeaderTruncated(0), ReplyHeaderTruncated(4), ReplyHeaderTruncated(9),
+        ReplyMtypeUndefined(2), ReplyMtypeUndefined(4294967295),
+        ReplyVerfBodyOverlong,
+        PeerClosesWithoutReply,
+        ReplyRejectedAuth,
+        ReplyRejectedRpcMismatch,
+        /* 1 PROG_UNAVAIL, 2 PROG_MISMATCH, 3 PROC_UNAVAIL, 4 GARBAGE_ARGS,
+         * 5 SYSTEM_ERR -- PROG_MISMATCH is the one that carries a body of its
+         * own, so it is kept in both the with- and without-results forms. */
+        ReplyAcceptStat(1), ReplyAcceptStat(2), ReplyAcceptStat(4),
+        ReplyAcceptStat(5),
+        ReplyDeniedWithBody,
+        ReplyAcceptStatWithBody(2), ReplyAcceptStatWithBody(4),
+        ReplyStatUndefined(2), ReplyStatUndefined(4294967295),
+        ReplyEmptyBody,
+        ReplyTruncatedBody(1), ReplyTruncatedBody(4), ReplyTruncatedBody(8),
+        ReplyTrailingGarbage(4), ReplyTrailingGarbage(64),
+        ReplyGarbageBody,
+        ReplyStringLenOverflow,
+        ReplyStringLenBeyondMessage
+    )
+
+    /// Apply one specific case, recording the required behaviour alongside it.
+    action use(d: Defect, v: Delivery): bool = all {
+        current' = { defect: d, delivery: v },
+        expected' = required(d),
+        survives' = survival(d)
+    }
+
+    action pick = {
+        nondet d = DEFECTS.oneOf()
+        nondet v = DELIVERIES.oneOf()
+        use(d, v)
+    }
+
+    action init = use(ReplyWellFormed, OneWrite)
+    action step = pick
+
+    // ------------------------------------------------------------------
+    // Invariants
+    // ------------------------------------------------------------------
+
+    /// Totality check on `required`.  Quint's match is exhaustive, so a new
+    /// Defect variant without a rule fails to typecheck rather than silently
+    /// defaulting -- this catches the reverse mistake, an Outcome the C driver
+    /// would have no arm for.
+    val outcomeIsSpecified = match expected {
+        | CbSuccess => true
+        | CbDecodeError => true
+        | CbFailed => true
+        | CbDropped => true
+    }
+
+    /// Requirement 1.  Only a reply that is not an answer to the outstanding
+    /// call may leave it uncompleted; everything else -- including the peer
+    /// hanging up -- must complete it.  This is the property that catches
+    /// "frees the pending request without invoking its callback".
+    val noCallIsLostInSilence =
+        match current.defect {
+            | ReplyUnknownXid => expected == CbDropped
+            | ReplyIsACall => expected == CbDropped
+            | _ => expected != CbDropped
+        }
+
+    /// Requirement 2.  A refusal may never be reported as a success, whatever
+    /// bytes the peer appended to it.
+    val refusalIsNeverSuccess =
+        match current.defect {
+            | ReplyRejectedAuth => expected == CbFailed
+            | ReplyRejectedRpcMismatch => expected == CbFailed
+            | ReplyAcceptStat(_) => expected == CbFailed
+            | ReplyDeniedWithBody => expected == CbFailed
+            | ReplyAcceptStatWithBody(_) => expected == CbFailed
+            | ReplyStatUndefined(_) => expected == CbFailed
+            | _ => true
+        }
+
+    /// A reply the client is required to ignore is not a reason to hang up:
+    /// dropping the connection would fail every other call in flight.
+    val droppedRepliesKeepTheConnection =
+        (expected != CbDropped) or (survives == ConnUp)
+
+    val safety =
+        outcomeIsSpecified and noCallIsLostInSilence and
+        refusalIsNeverSuccess and droppedRepliesKeepTheConnection
+
+    // ------------------------------------------------------------------
+    // Scenario tests: the outcomes most likely to be got wrong
+    // ------------------------------------------------------------------
+
+    /// A stray reply is dropped, not fatal -- and dropping it must leave the
+    /// connection able to carry the next call.
+    run strayReplyIsDroppedTest =
+        init
+            .then(use(ReplyUnknownXid, OneWrite))
+            .expect(expected == CbDropped and survives == ConnUp)
+            .then(use(ReplyIsACall, OneWrite))
+            .expect(expected == CbDropped and survives == ConnUp)
+
+    /// The distinction that separates "cannot decode the results" from "the
+    /// peer declined to produce results": both fail, and a refusal carrying a
+    /// decodable body still fails.
+    run refusalIsNotAResultTest =
+        init
+            .then(use(ReplyRejectedAuth, OneWrite))
+            .expect(expected == CbFailed)
+            .then(use(ReplyDeniedWithBody, OneWrite))
+            .expect(expected == CbFailed)
+            .then(use(ReplyAcceptStatWithBody(4), OneWrite))
+            .expect(expected == CbFailed)
+            .then(use(ReplyStatUndefined(2), OneWrite))
+            .expect(expected == CbFailed)
+
+    /// Losing the transport is still a completion.
+    run transportLossCompletesTheCallTest =
+        init
+            .then(use(PeerClosesWithoutReply, OneWrite))
+            .expect(expected == CbFailed and survives == ConnAny)
+            .then(use(ReplyMtypeUndefined(2), OneWrite))
+            .expect(expected == CbFailed)
+
+    /// Undecodable results are reported as such, not as a zero-filled value.
+    run undecodableResultsAreReportedTest =
+        init
+            .then(use(ReplyTruncatedBody(4), Dribble))
+            .expect(expected == CbDecodeError)
+            .then(use(ReplyTrailingGarbage(4), OneWrite))
+            .expect(expected == CbDecodeError)
+            .then(use(ReplyStringLenOverflow, TwoWrites))
+            .expect(expected == CbDecodeError)
+
+    /// Legal framing must still work when it arrives the hard way.
+    run legalFramingSucceedsTest =
+        init
+            .then(use(ReplySplitAcrossFragments(16), OneWrite))
+            .expect(expected == CbSuccess)
+            .then(use(ReplyWellFormed, Dribble))
+            .expect(expected == CbSuccess)
+            .then(use(ReplyVerfAuthSys, TwoWrites))
+            .expect(expected == CbSuccess)
+}

--- a/src/rpc2/tests/quint/defects.qnt
+++ b/src/rpc2/tests/quint/defects.qnt
@@ -1,0 +1,676 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+/**
+ * defects.qnt -- the negative half of the conformance matrix.
+ *
+ * Each state is one deliberately defective RPC call plus the response RFC
+ * 5531 (ONC RPC) and RFC 4506 (XDR) require the server to produce.
+ *
+ * IMPORTANT: this model encodes the SPECIFICATION, not libevpl's current
+ * behaviour.  Where the two disagree the replay driver records a divergence
+ * rather than failing outright, and the divergence list is reviewed as a set
+ * of candidate bugs.  Encoding current behaviour instead would freeze
+ * today's defects into the spec and guarantee they are never found.
+ *
+ * The defect kinds are SYMBOLIC; the driver owns the byte-level mis-encoding.
+ * Quint's job is to enumerate the taxonomy and state the required outcome,
+ * which is exactly the part that is easy to get wrong by hand and easy to
+ * forget to update.
+ *
+ *   quint test defects.qnt
+ *   quint run defects.qnt --invariant=outcomeIsSpecified
+ */
+module rpc2_defects {
+
+    /// Mirrors of conformance.x / the RPC2 envelope.
+    pure val PROG = 44
+    pure val VERS_LOW = 1
+    pure val VERS_HIGH = 1
+    pure val MAX_PROC = 9
+    pure val RPC_VERS = 2
+    pure val BOUNDED_MAX = 8
+
+    /// The procedures whose arguments the raw-socket driver can hand-build.
+    /// Payload defects target one of these; envelope defects ignore it.
+    type Target =
+        | TScalars      /* proc 1: fixed-size, no counted fields  */
+        | TBytes        /* proc 2: string, opaque<>, opaque<8>    */
+        | TArrays       /* proc 4: counted arrays, one bounded    */
+        | TStrict       /* proc 6: union with no default arm      */
+
+    type Defect =
+        /* --- baseline: proves the driver can build a VALID call ------- */
+        | NoDefect
+        /* --- RPC envelope (RFC 5531 section 9) ------------------------ */
+        | RpcVersWrong(int)
+        | ProgramUnknown
+        | VersionUnsupported(int)
+        | ProcedureUnknown(int)
+        | ProcedureNull
+        | AuthFlavorUnsupported(int)
+        | CredBodyOverlong
+        | AuthSysValid                /* a well-formed AUTH_SYS credential */
+        /* --- XDR payload (RFC 4506) ----------------------------------- */
+        | ArgsTruncated(int)
+        | ArgsTrailingGarbage(int)
+        | StringLenOverflow
+        | StringLenBeyondMessage
+        | StringExceedsBound
+        | OpaqueExceedsBound
+        | ArrayCountExceedsBound
+        | ArrayCountHuge
+        | DiscriminantUnmatched
+        | BoolNotZeroOrOne
+        | EnumNotDeclared
+        /* --- TCP record marking (RFC 5531 section 11) ----------------- */
+        | RecordMarkHuge
+        | RecordMarkZeroLength
+        | CallSplitAcrossFragments(int)
+        /* One call split into more fragments than the receiver's payload
+         * iovec ceiling, which forces it to flatten the message into a
+         * bounded contiguous copy.  Still legal framing -- RFC 5531 section
+         * 11 sets no limit on fragment count -- so it must succeed like any
+         * other split.  Deliberately a variant of its own rather than another
+         * CallSplitAcrossFragments value: it needs a payload large enough to
+         * divide that many ways, and it is meant to run as one scenario
+         * rather than across the whole target matrix. */
+        | CallSplitPathological
+        /* One call split into fragments that are each individually legal --
+         * every record mark is small, and none on its own is refusable --
+         * but whose running total exceeds what the receiver is willing to
+         * hold for one message.  RFC 5531 section 11 bounds a *fragment* at
+         * 2**31-1 bytes and says nothing at all about a record's total
+         * length, so a receiver that only checks fragments will buffer
+         * without limit on an unauthenticated peer's say-so.  Distinct from
+         * RecordMarkHuge, which is one oversized mark refused on sight. */
+        | ReassemblyCapExceeded
+        /* --- RPCSEC_GSS (RFC 2203) ------------------------------------ */
+        | GssInitEstablishes          /* handshake completes in one leg    */
+        | GssInitContinues            /* handshake needs a second leg      */
+        | GssInitMechFails            /* provider rejects the token        */
+        | GssDataValid                /* established context, good MIC     */
+        | GssCredVersionWrong(int)
+        | GssProcUnknown(int)
+        | GssServicePrivacy           /* krb5p: not implemented            */
+        | GssHandleUnknown            /* DATA against a handle we never got */
+        | GssVerifierNotGss           /* DATA whose verf is not flavor 6   */
+        | GssMicWrong                 /* DATA carrying a bad header MIC    */
+        | GssSeqReplayed              /* a sequence number already used    */
+        | GssIntegDataValid           /* krb5i: well-formed integ_data     */
+        | GssIntegChecksumWrong       /* krb5i: databody checksum is bad   */
+        | GssIntegSeqMismatch         /* krb5i: databody seq != cred seq   */
+        | GssDestroyContext           /* DESTROY of a context we hold      */
+        | GssDestroyUnauthenticated   /* DESTROY with no valid header MIC  */
+        /* --- RPCSEC_GSS replay window (RFC 2203 section 5.3.3.1) ------- */
+        | GssSeqAboveMax              /* seq_num above MAXSEQ (0x80000000) */
+        | GssSeqWindowJump            /* seq_num jumps clear of the window */
+        | GssSeqTooOld                /* seq_num below the window          */
+        | GssSeqOutOfOrder            /* in-window, unseen, not the next   */
+        /* --- RPCSEC_GSS credential framing (RFC 2203 section 5) -------- */
+        | GssCredTruncated            /* credential body ends mid-field    */
+        | GssCredHandleOverruns       /* handle<> runs past the credential */
+        /* --- RPCSEC_GSS context creation (RFC 2203 section 5.2) -------- */
+        | GssNoMechanism(int)         /* flavor 6 at a server with no GSS  */
+        | GssContinueInitUnknownHandle /* CONTINUE_INIT naming no context  */
+        | GssInitTokenMalformed(int)  /* rpc_gss_init_arg is undecodable   */
+        | GssContinueInitTokenMalformed
+        | GssInitMechFailsWithToken   /* accept() fails but emits a token  */
+        /* --- RPCSEC_GSS integrity framing (RFC 2203 section 5.3.2.2) --- */
+        | GssIntegFramingBad(int)     /* rpc_gss_integ_data is undecodable */
+        | GssIntegEmptyArgs           /* krb5i call with no arguments      */
+        | GssIntegSplitAcrossFragments
+        | GssIntegReplyMicFails       /* cannot sign the results           */
+        | GssIntegReplyMicOversize    /* signature too big to emit         */
+
+    /// What the server must do.  Closed means "no reply is possible, the
+    /// connection must be dropped" -- used where the defect destroys the
+    /// xid, so there is nothing to address a reply to.  A server that
+    /// instead hangs or buffers without bound fails this expectation; the
+    /// driver reports that distinctly as Stalled.
+    type Outcome =
+        | Success
+        | ProgUnavail
+        | ProgMismatch({ lo: int, hi: int })
+        | ProcUnavail
+        | GarbageArgs
+        | RpcMismatch({ lo: int, hi: int })
+        | AuthError
+        | Closed
+        /* Accepted, understood, and deliberately answered with silence: RFC
+         * 2203 requires a replayed RPCSEC_GSS sequence number to be discarded
+         * without a reply, while the connection stays up.  Distinct from
+         * Closed (no connection) and from a stalled server (no decision). */
+        | NoReply
+
+    type Case = { defect: Defect, target: Target }
+
+    var current: Case
+
+    /// The response the specification requires for `current`.  This is a
+    /// state variable rather than a derived expression so that it is carried
+    /// in the generated ITF trace: the trace, not the model, is what the C
+    /// driver consumes, so the prediction has to travel with the case.
+    var expected: Outcome
+
+    // ------------------------------------------------------------------
+    // The specification: defect -> required response
+    // ------------------------------------------------------------------
+
+    /**
+     * RFC 5531 section 9 fixes both the outcomes and the order of the checks
+     * that produce them: the RPC version is validated before the program,
+     * the program before the version, and the version before the procedure.
+     * Argument decoding happens last, so a call that is defective in two
+     * ways reports the earlier defect.  The driver only ever injects one
+     * defect at a time, so that ordering is not exercised here -- but it is
+     * why each case below can name a single outcome.
+     */
+    pure def required(d: Defect): Outcome = match d {
+        | NoDefect => Success
+
+        /* An unrecognised RPC protocol version is denied outright, with the
+         * range of versions the server speaks.  RFC 5531 section 9. */
+        | RpcVersWrong(_) => RpcMismatch({ lo: RPC_VERS, hi: RPC_VERS })
+
+        /* A program the server does not export is PROG_UNAVAIL -- NOT
+         * PROG_MISMATCH, which is reserved for a program that exists at
+         * other versions.  Clients use the distinction to decide whether to
+         * downgrade or give up. */
+        | ProgramUnknown => ProgUnavail
+
+        /* An exported program at an unsupported version reports the range
+         * actually supported, so the client can retry within it. */
+        | VersionUnsupported(_) => ProgMismatch({ lo: VERS_LOW, hi: VERS_HIGH })
+
+        | ProcedureUnknown(_) => ProcUnavail
+
+        /* RFC 5531 section 11.1: every program must implement procedure 0,
+         * taking no arguments and returning no results. */
+        | ProcedureNull => Success
+
+        /* An authentication flavor the server does not support is denied.
+         * RFC 5531 leaves the specific auth_stat open (AUTH_BADCRED and
+         * AUTH_TOOWEAK are both defensible), so the model requires only
+         * AUTH_ERROR and the driver does not compare the sub-status. */
+        | AuthFlavorUnsupported(_) => AuthError
+        | CredBodyOverlong => AuthError
+
+        /* Not a defect: AUTH_SYS is one of the two flavors RFC 5531 defines,
+         * and a call carrying a well-formed one is an ordinary call.  Present
+         * so that the flavor's accepted path is asserted, not just the
+         * rejection of a malformed credential above. */
+        | AuthSysValid => Success
+
+        /* Anything that makes the argument stream undecodable -- too short,
+         * too long, or internally inconsistent -- is GARBAGE_ARGS.  The
+         * connection stays up: the xid is known, so a reply is possible and
+         * required. */
+        | ArgsTruncated(_) => GarbageArgs
+        | ArgsTrailingGarbage(_) => GarbageArgs
+        | StringLenOverflow => GarbageArgs
+        | StringLenBeyondMessage => GarbageArgs
+
+        /* RFC 4506: a counted field declared with a bound may not exceed it,
+         * and the decoder is required to treat an over-bound count as
+         * invalid rather than trusting it. */
+        | StringExceedsBound => GarbageArgs
+        | OpaqueExceedsBound => GarbageArgs
+        | ArrayCountExceedsBound => GarbageArgs
+        | ArrayCountHuge => GarbageArgs
+
+        /* RFC 4506: a discriminated union whose discriminant matches no arm
+         * and which declares no default is invalid. */
+        | DiscriminantUnmatched => GarbageArgs
+
+        /* RFC 4506: bool is an enum over {0,1}; an enum may only carry a
+         * declared value.  Anything else is invalid. */
+        | BoolNotZeroOrOne => GarbageArgs
+        | EnumNotDeclared => GarbageArgs
+
+        /* Record marking defects destroy the message framing itself, so no
+         * xid is recoverable and no reply can be addressed.  The server must
+         * drop the connection.  Critically it must NOT wait indefinitely for
+         * bytes that a hostile length claims are coming. */
+        | RecordMarkHuge => Closed
+        | RecordMarkZeroLength => Closed
+
+        /* Same conclusion by a different route.  The framing here is never
+         * malformed -- it is simply unbounded -- so the receiver has to stop
+         * of its own accord.  Once it does, the partial record is discarded
+         * and the message it belonged to never existed, so there is no xid
+         * to address a reply to and the connection must go.  The failure
+         * this catches is the one that costs memory rather than correctness:
+         * accumulating fragments until the process dies. */
+        | ReassemblyCapExceeded => Closed
+
+        /* RPCSEC_GSS.  The handshake rides on the program's NULL procedure
+         * and establishes a context; a DATA call against an established
+         * context with a good verifier is an ordinary successful call. */
+        | GssInitEstablishes => Success
+        | GssInitContinues => Success
+        | GssDataValid => Success
+
+        /* A mechanism-level failure during context establishment leaves no
+         * context to talk to. */
+        | GssInitMechFails => AuthError
+
+        /* RFC 2203 section 5: the credential names a version and a procedure;
+         * anything outside the defined set is a bad credential. */
+        | GssCredVersionWrong(_) => AuthError
+        | GssProcUnknown(_) => AuthError
+
+        /* Privacy is a defined service that this implementation does not
+         * provide, which RFC 5531 answers by rejecting the credential as too
+         * weak rather than by pretending to honour it. */
+        | GssServicePrivacy => AuthError
+
+        /* No usable security context: either it never existed, or the caller
+         * cannot prove it holds it. */
+        | GssHandleUnknown => AuthError
+        | GssVerifierNotGss => AuthError
+        | GssMicWrong => AuthError
+
+        /* RFC 2203 section 5.3.3.1: a request whose sequence number falls
+         * outside the window, or repeats one already seen, is discarded in
+         * silence -- answering it would itself be an oracle for an attacker
+         * replaying traffic. */
+        | GssSeqReplayed => NoReply
+
+        /* RFC 2203 section 5.3.2.2: under the integrity service the call
+         * arguments travel as rpc_gss_integ_data, whose databody is
+         * seq_num || args and whose checksum is a MIC over that databody.  A
+         * well-formed one is an ordinary call, and the results come back
+         * wrapped the same way (section 5.3.3.2). */
+        | GssIntegDataValid => Success
+
+        /* RFC 2203 section 5.3.3.4.2: "When GSS_VerifyMIC() is called to
+         * verify the call arguments (service is rpc_gss_svc_integrity), a
+         * failure results in an RPC response with a reply status of
+         * MSG_ACCEPTED, and an acceptance status of GARBAGE_ARGS."  Note the
+         * deliberate contrast with the *header* verifier failing, which is
+         * MSG_DENIED / AUTH_ERROR: an argument the server cannot authenticate
+         * is an undecodable argument, not an unauthenticated caller. */
+        | GssIntegChecksumWrong => GarbageArgs
+
+        /* RFC 2203 section 5.3.2.2 requires the seq_num embedded in the
+         * databody to equal the one in the credential.  A databody that
+         * violates that is not a well-formed rpc_gss_data_t, so it fails
+         * argument decoding -- the same GARBAGE_ARGS outcome section 5.3.3.4.2
+         * gives every argument-level integrity failure. */
+        | GssIntegSeqMismatch => GarbageArgs
+
+        /* RFC 2203 section 5.4: the client retires a context with a control
+         * message carrying gss_proc RPCSEC_GSS_DESTROY over NULLPROC and no
+         * arguments; "the server sends a response as it would to a data
+         * request". */
+        | GssDestroyContext => Success
+
+        /* RFC 2203 section 5.4: "The sequence number in the request must be
+         * valid, and the header checksum in the verifier must be valid, for
+         * the server to accept the message."  DESTROY is authenticated like
+         * any other request -- otherwise anyone who can guess a handle can
+         * retire someone else's context.  An unverifiable one is denied, per
+         * section 5.3.3.4.2. */
+        | GssDestroyUnauthenticated => AuthError
+
+        /* RFC 2203 section 5.3.3.3: "When the client's sequence number
+         * exceeds the maximum the server will allow, the server will reject
+         * the request with the reason RPCSEC_GSS_CTXPROBLEM."  A rejection,
+         * not a silent drop: the client is told to refresh the context and
+         * retry, which it cannot infer from silence.  This is the one place
+         * in the sequence-number rules where the answer is an error rather
+         * than nothing, and it is the easy one to collapse into the general
+         * "bad seq_num, discard" case. */
+        | GssSeqAboveMax => AuthError
+
+        /* RFC 2203 section 5.3.3.1: "If a sequence number higher than the
+         * last number seen is received ... the window is moved forward to the
+         * new sequence number", and "a consequence of the silent discard is
+         * that clients may increment the seq_num by more than one".  A jump
+         * clear of the window is therefore ordinary traffic, not an attack:
+         * it just resets the window rather than sliding it. */
+        | GssSeqWindowJump => Success
+
+        /* RFC 2203 section 5.3.3.1: "If the sequence number received falls
+         * below this range, it is silently discarded" -- the same silence a
+         * replay gets, and for the same reason (section 5.3.3.1: the server
+         * cannot tell a reordering from an attack, and answering would tell
+         * an attacker which it was). */
+        | GssSeqTooOld => NoReply
+
+        /* RFC 2203 section 5.3.3.1: "If the sequence number is within this
+         * range, and the server has not seen it, the request is accepted."
+         * The window exists precisely so that requests may arrive out of
+         * order -- section 5.2.3.1 advertises seq_window as the number of
+         * requests that "may be out of order" -- so an unseen in-window
+         * number is an ordinary request, not a stale one. */
+        | GssSeqOutOfOrder => Success
+
+        /* RFC 2203 section 5.3.3.3: "If there is a problem with the
+         * credential, such a bad length, illegal control procedure, or an
+         * illegal service, the appropriate auth_stat status is AUTH_BADCRED."
+         * A credential that stops mid-field, or whose handle<> claims more
+         * bytes than the credential contains, is exactly a bad length. */
+        | GssCredTruncated => AuthError
+        | GssCredHandleOverruns => AuthError
+
+        /* A CONTINUE_INIT whose handle names no context the server holds is a
+         * problem with the credential (RFC 2203 section 5.3.3.3), so the call
+         * is denied.  Note that section 5.2.3.2 forbids the two RPCSEC_GSS
+         * auth_stat values on a context-creation response, which is why the
+         * model requires only AUTH_ERROR and the driver does not compare the
+         * sub-status. */
+        /* RFC 2203 section 5.2.3.2: "MSG_DENIED could be returned because the
+         * server's RPC implementation does not recognize the RPCSEC_GSS
+         * security flavor.  RFC 1831 does not specify the appropriate reply
+         * status in this instance, but common implementation practice appears
+         * to be to return a rejection status of AUTH_ERROR with an auth_stat
+         * of AUTH_REJECTEDCRED."  A server with no mechanism configured must
+         * therefore say so, both to a context-creation request and to a data
+         * request -- the two entry points, and the reason this defect is
+         * parameterised.  Answering either one as though the flavor were
+         * understood would leave the client waiting for a context it will
+         * never get. */
+        | GssNoMechanism(_) => AuthError
+
+        | GssContinueInitUnknownHandle => AuthError
+
+        /* The GSS token travels in the call ARGUMENTS (rpc_gss_init_arg,
+         * RFC 2203 section 5.2.2), not in the credential, so a token that
+         * cannot be decoded is an argument-decoding failure: GARBAGE_ARGS per
+         * RFC 5531 section 9.  Section 5.2.3.2 explicitly contemplates this
+         * ("An MSG_ACCEPTED reply (to a creation request) with an acceptance
+         * status of other than SUCCESS ... is formulated as usual") and just
+         * as explicitly rules out the alternative libevpl reaches for:
+         * "neither of these two [RPCSEC_GSS_CREDPROBLEM and
+         * RPCSEC_GSS_CTXPROBLEM] can be returned in responses to context
+         * creation requests."  Same split the model already draws for the
+         * integrity service: a bad credential is an unauthenticated caller,
+         * a bad argument is an undecodable argument. */
+        | GssInitTokenMalformed(_) => GarbageArgs
+        | GssContinueInitTokenMalformed => GarbageArgs
+
+        /* A mechanism-level failure, modelled the same way as
+         * GssInitMechFails above whether or not the mechanism also produced a
+         * token: the token is the mechanism's business, and a context that
+         * failed to establish leaves nothing to talk to either way. */
+        | GssInitMechFailsWithToken => AuthError
+
+        /* RFC 2203 section 5.3.2.2 fixes the shape of the integrity call
+         * arguments; anything that does not decode as an rpc_gss_integ_data
+         * is undecodable arguments, which section 5.3.3.4.2 and RFC 5531
+         * section 9 both answer with GARBAGE_ARGS. */
+        | GssIntegFramingBad(_) => GarbageArgs
+
+        /* A procedure that takes no arguments is still a procedure: under
+         * integrity its databody is just the seq_num (RFC 2203 section
+         * 5.3.2.2), and the reply comes back wrapped the same way. */
+        | GssIntegEmptyArgs => Success
+
+        /* Record marking (RFC 5531 section 10) is independent of the security
+         * flavor, so an integrity call delivered in pieces must be treated
+         * exactly like one delivered whole. */
+        | GssIntegSplitAcrossFragments => Success
+
+        /* RFC 2203 section 5.3.3.4.1: "When GSS_GetMIC() is called to sign
+         * the call results (service is rpc_gss_svc_integrity), a failure
+         * results in no RPC response being sent."  Silence is the specified
+         * behaviour: a reply the server could not sign is worse than no
+         * reply, because a client that accepted it would have taken
+         * unauthenticated results on an authenticated channel. */
+        | GssIntegReplyMicFails => NoReply
+        | GssIntegReplyMicOversize => NoReply
+
+        /* Not a defect: a correctly framed call split across several
+         * fragments is legal and must succeed.  Included here so the
+         * framing path gets positive coverage from the same harness. */
+        | CallSplitAcrossFragments(_) => Success
+
+        /* Also not a defect: an extreme fragment count is still legal
+         * framing, and the flattening it forces must be transparent. */
+        | CallSplitPathological => Success
+    }
+
+    // ------------------------------------------------------------------
+    // Case generation
+    // ------------------------------------------------------------------
+
+    pure val TARGETS = Set(TScalars, TBytes, TArrays, TStrict)
+
+    /// Defect instances.  Where a defect carries a number, a few
+    /// representative values are enumerated rather than the whole domain:
+    /// the driver's encoding is identical for all of them, so extra values
+    /// buy no new code paths.
+    pure val DEFECTS = Set(
+        NoDefect,
+        RpcVersWrong(0), RpcVersWrong(1), RpcVersWrong(3), RpcVersWrong(4294967295),
+        ProgramUnknown,
+        VersionUnsupported(0), VersionUnsupported(2), VersionUnsupported(4294967295),
+        ProcedureUnknown(10), ProcedureUnknown(4294967295),
+        ProcedureNull,
+        AuthFlavorUnsupported(2), AuthFlavorUnsupported(42),
+        CredBodyOverlong,
+        AuthSysValid,
+        GssInitEstablishes, GssInitContinues, GssInitMechFails,
+        GssDataValid,
+        GssCredVersionWrong(0), GssCredVersionWrong(2),
+        GssProcUnknown(4), GssProcUnknown(99),
+        GssServicePrivacy, GssHandleUnknown, GssVerifierNotGss,
+        GssMicWrong, GssSeqReplayed,
+        GssIntegDataValid, GssIntegChecksumWrong, GssIntegSeqMismatch,
+        GssDestroyContext, GssDestroyUnauthenticated,
+        GssSeqAboveMax, GssSeqWindowJump, GssSeqTooOld, GssSeqOutOfOrder,
+        GssCredTruncated, GssCredHandleOverruns,
+        GssNoMechanism(0), GssNoMechanism(1),
+        GssContinueInitUnknownHandle,
+        GssInitTokenMalformed(0), GssInitTokenMalformed(1),
+        GssContinueInitTokenMalformed,
+        GssInitMechFailsWithToken,
+        GssIntegFramingBad(0), GssIntegFramingBad(1), GssIntegFramingBad(2),
+        GssIntegFramingBad(3), GssIntegFramingBad(4),
+        GssIntegEmptyArgs, GssIntegSplitAcrossFragments,
+        GssIntegReplyMicFails, GssIntegReplyMicOversize,
+        ArgsTruncated(1), ArgsTruncated(4), ArgsTruncated(8),
+        ArgsTrailingGarbage(4), ArgsTrailingGarbage(64),
+        StringLenOverflow,
+        StringLenBeyondMessage,
+        StringExceedsBound,
+        OpaqueExceedsBound,
+        ArrayCountExceedsBound,
+        ArrayCountHuge,
+        DiscriminantUnmatched,
+        BoolNotZeroOrOne,
+        EnumNotDeclared,
+        RecordMarkHuge,
+        RecordMarkZeroLength,
+        CallSplitAcrossFragments(2), CallSplitAcrossFragments(3),
+        CallSplitAcrossFragments(16),
+        CallSplitPathological,
+        ReassemblyCapExceeded
+    )
+
+    /// Apply one specific case, recording the required outcome alongside it.
+    action use(d: Defect, t: Target): bool = all {
+        current' = { defect: d, target: t },
+        expected' = required(d)
+    }
+
+    action pick = {
+        nondet d = DEFECTS.oneOf()
+        nondet t = TARGETS.oneOf()
+        use(d, t)
+    }
+
+    action init = use(NoDefect, TScalars)
+    action step = pick
+
+    // ------------------------------------------------------------------
+    // Invariants
+    // ------------------------------------------------------------------
+
+    /// Every defect in the taxonomy has a required outcome.  This is a
+    /// totality check on `required`: Quint's match is exhaustive, so a new
+    /// variant added to Defect without a corresponding rule fails to
+    /// typecheck rather than silently defaulting.
+    val outcomeIsSpecified = match expected {
+        | Success => true
+        | ProgUnavail => true
+        | ProgMismatch(r) => r.lo <= r.hi
+        | ProcUnavail => true
+        | GarbageArgs => true
+        | RpcMismatch(r) => r.lo <= r.hi
+        | AuthError => true
+        | Closed => true
+        | NoReply => true
+    }
+
+    /// A defect that destroys the framing cannot be answered, and every
+    /// defect that preserves it must be: an RPC server may not silently
+    /// drop a call it was able to parse the header of.  This is the
+    /// property that catches "closes the connection instead of replying".
+    val answerableDefectsAreAnswered =
+        match current.defect {
+            | RecordMarkHuge => expected == Closed
+            | RecordMarkZeroLength => expected == Closed
+            /* Silence here is a decision, not a missing answer: RFC 2203
+             * names each of these as a case the server answers by sending
+             * nothing at all. */
+            | ReassemblyCapExceeded => expected == Closed
+            /* Silence here is a decision, not a missing answer. */
+            | GssSeqReplayed => expected == NoReply
+            | GssSeqTooOld => expected == NoReply
+            | GssIntegReplyMicFails => expected == NoReply
+            | GssIntegReplyMicOversize => expected == NoReply
+            | _ => expected != Closed
+        }
+
+    val safety = outcomeIsSpecified and answerableDefectsAreAnswered
+
+    // ------------------------------------------------------------------
+    // Scenario tests: the outcomes most likely to be got wrong
+    // ------------------------------------------------------------------
+
+    /// The distinction clients rely on to negotiate versions.
+    run programVsVersionTest =
+        init
+            .then(use(ProgramUnknown, TScalars))
+            .expect(expected == ProgUnavail)
+            .then(use(VersionUnsupported(2), TScalars))
+            .expect(expected == ProgMismatch({ lo: 1, hi: 1 }))
+
+    run nullProcedureIsAlwaysAvailableTest =
+        init
+            .then(use(ProcedureNull, TScalars))
+            .expect(expected == Success)
+
+    /// Decodable-but-invalid payloads must be answered, not dropped.
+    run payloadDefectsAreAnsweredTest =
+        init
+            .then(use(StringLenOverflow, TBytes))
+            .expect(expected == GarbageArgs)
+            .then(use(StringExceedsBound, TBytes))
+            .expect(expected == GarbageArgs)
+            .then(use(ArrayCountExceedsBound, TArrays))
+            .expect(expected == GarbageArgs)
+            .then(use(DiscriminantUnmatched, TStrict))
+            .expect(expected == GarbageArgs)
+
+    /// The two GSS outcomes most easily got wrong: an unimplemented service is
+    /// refused rather than silently downgraded, and a replay is answered with
+    /// silence rather than an error that would confirm the replay landed.
+    run gssOutcomesTest =
+        init
+            .then(use(GssServicePrivacy, TScalars))
+            .expect(expected == AuthError)
+            .then(use(GssSeqReplayed, TScalars))
+            .expect(expected == NoReply)
+            .then(use(GssDataValid, TScalars))
+            .expect(expected == Success)
+
+    /// The integrity service splits one failure into two different replies,
+    /// and getting them the same way round is the easy mistake: a bad *header*
+    /// verifier means the caller is not authenticated (MSG_DENIED), while a bad
+    /// *argument* checksum means the arguments did not survive (GARBAGE_ARGS).
+    run gssIntegrityOutcomesTest =
+        init
+            .then(use(GssIntegDataValid, TScalars))
+            .expect(expected == Success)
+            .then(use(GssIntegChecksumWrong, TScalars))
+            .expect(expected == GarbageArgs)
+            .then(use(GssMicWrong, TScalars))
+            .expect(expected == AuthError)
+
+    /// The replay window has three outcomes, not two, and which one applies
+    /// turns only on where the sequence number falls.  Getting this wrong in
+    /// the safe-looking direction -- discarding anything unexpected -- loses
+    /// the one case RFC 2203 requires an answer for, and getting it wrong in
+    /// the other direction turns the window into a replay oracle.
+    run gssSequenceWindowTest =
+        init
+            /* Ahead of the window: accepted, the window follows. */
+            .then(use(GssSeqWindowJump, TScalars))
+            .expect(expected == Success)
+            /* Inside the window and not yet seen: accepted, out of order. */
+            .then(use(GssSeqOutOfOrder, TScalars))
+            .expect(expected == Success)
+            /* Inside the window and already seen: silence. */
+            .then(use(GssSeqReplayed, TScalars))
+            .expect(expected == NoReply)
+            /* Below the window: silence. */
+            .then(use(GssSeqTooOld, TScalars))
+            .expect(expected == NoReply)
+            /* Above MAXSEQ: an error, and the only one of the five. */
+            .then(use(GssSeqAboveMax, TScalars))
+            .expect(expected == AuthError)
+
+    /// A reply the server cannot sign is not a reply.  The tempting
+    /// alternative -- ship the results unsigned -- is the one outcome the
+    /// integrity service exists to prevent.
+    run gssIntegrityReplySigningTest =
+        init
+            .then(use(GssIntegReplyMicFails, TScalars))
+            .expect(expected == NoReply)
+            .then(use(GssIntegReplyMicOversize, TScalars))
+            .expect(expected == NoReply)
+
+    /// Where the malformation sits decides the answer: a credential the server
+    /// cannot parse means it cannot identify the caller, while a token it
+    /// cannot parse is just an undecodable argument.
+    run gssContextCreationFramingTest =
+        init
+            .then(use(GssCredTruncated, TScalars))
+            .expect(expected == AuthError)
+            .then(use(GssInitTokenMalformed(1), TScalars))
+            .expect(expected == GarbageArgs)
+
+    /// Destroying a context is an authenticated operation, so an unverifiable
+    /// DESTROY must be refused rather than honoured.
+    run gssDestroyIsAuthenticatedTest =
+        init
+            .then(use(GssDestroyContext, TScalars))
+            .expect(expected == Success)
+            .then(use(GssDestroyUnauthenticated, TScalars))
+            .expect(expected == AuthError)
+
+    run framingDefectsCloseTest =
+        init
+            .then(use(RecordMarkHuge, TScalars))
+            .expect(expected == Closed)
+            .then(use(CallSplitAcrossFragments(16), TScalars))
+            .expect(expected == Success)
+
+    /// Fragmenting is legal without limit; accumulating is not.  The pair
+    /// that is easy to conflate: a legal split must succeed however many
+    /// pieces it arrives in, while a split whose pieces are individually
+    /// just as legal must still be cut off once their total passes what the
+    /// receiver will hold.  Getting this wrong in the permissive direction
+    /// is a memory-exhaustion hole reachable by any unauthenticated peer.
+    run reassemblyIsBoundedTest =
+        init
+            .then(use(CallSplitPathological, TBytes))
+            .expect(expected == Success)
+            .then(use(ReassemblyCapExceeded, TBytes))
+            .expect(expected == Closed)
+}

--- a/src/rpc2/tests/quint/generate_cases.sh
+++ b/src/rpc2/tests/quint/generate_cases.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Ben Jarvis
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# generate_cases.sh - turn the Quint models into the C case table
+#
+# Usage: generate_cases.sh QUINT PYTHON SRC_DIR WORK_DIR OUT_HEADER
+#
+# Driven by CMake as a build step, so everything it produces -- the ITF traces
+# as well as the header -- is a build artifact under WORK_DIR rather than
+# something checked in.  Run it by hand the same way if you want to inspect the
+# traces.
+#
+# Generation is deliberately lean: it does not re-check the models, because the
+# quint_model test does that and a build is the wrong place to discover a
+# broken specification.
+#
+# The seeds are fixed, so a given quint version always yields the same cases.
+# Different quint versions may sample differently; that is the tradeoff for
+# generating rather than checking in, and is why the devcontainer pins one.
+
+set -euo pipefail
+
+QUINT="${1:?usage: generate_cases.sh QUINT PYTHON SRC_DIR WORK_DIR OUT_HEADER}"
+PYTHON="${2:?}"
+SRC_DIR="${3:?}"
+WORK_DIR="${4:?}"
+OUT_HEADER="${5:?}"
+
+mkdir -p "${WORK_DIR}"
+
+# The value matrix is a wide cross-product, so it is sampled: several seeds,
+# long traces, de-duplicated by the converter.  The defect taxonomy is small
+# and enumerable, so its traces only need to be long enough to reach every
+# (defect, target) pair -- the case count printed at the end is the check on
+# that.
+VALUE_SEEDS=(0xa1 0xa2 0xa3 0xa4 0xa5 0xa6 0xa7 0xa8)
+DEFECT_SEEDS=(0xb1 0xb2 0xb3 0xb4)
+
+VALUE_TRACES=()
+for s in "${VALUE_SEEDS[@]}"; do
+    f="${WORK_DIR}/values-${s}.itf.json"
+    "${QUINT}" run "${SRC_DIR}/values.qnt" \
+        --seed="$s" --max-steps=200 --out-itf="$f" > /dev/null
+    VALUE_TRACES+=("$f")
+done
+
+DEFECT_TRACES=()
+for s in "${DEFECT_SEEDS[@]}"; do
+    f="${WORK_DIR}/defects-${s}.itf.json"
+    "${QUINT}" run "${SRC_DIR}/defects.qnt" \
+        --seed="$s" --max-steps=400 --out-itf="$f" > /dev/null
+    DEFECT_TRACES+=("$f")
+done
+
+"${PYTHON}" "${SRC_DIR}/itf_to_cases.py" "${OUT_HEADER}" \
+    --values "${VALUE_TRACES[@]}" \
+    --defects "${DEFECT_TRACES[@]}"

--- a/src/rpc2/tests/quint/generate_client_cases.sh
+++ b/src/rpc2/tests/quint/generate_client_cases.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Ben Jarvis
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# generate_client_cases.sh - turn client.qnt into the C case table
+#
+# Usage: generate_client_cases.sh QUINT PYTHON SRC_DIR WORK_DIR OUT_HEADER
+#
+# The client-side twin of generate_cases.sh.  Driven by CMake as a build step,
+# so everything it produces -- the ITF traces as well as the header -- is a
+# build artifact under WORK_DIR rather than something checked in.  Run it by
+# hand the same way if you want to inspect the traces.
+#
+# Generation is deliberately lean: it does not re-check the model, because the
+# quint_client_model test does that and a build is the wrong place to discover
+# a broken specification.
+#
+# The seeds are fixed, so a given quint version always yields the same cases.
+# Different quint versions may sample differently; that is the tradeoff for
+# generating rather than checking in, and is why the devcontainer pins one.
+
+set -euo pipefail
+
+QUINT="${1:?usage: generate_client_cases.sh QUINT PYTHON SRC_DIR WORK_DIR OUT_HEADER}"
+PYTHON="${2:?}"
+SRC_DIR="${3:?}"
+WORK_DIR="${4:?}"
+OUT_HEADER="${5:?}"
+
+mkdir -p "${WORK_DIR}"
+
+# The taxonomy is small and enumerable, so the traces only need to be long
+# enough to reach every (defect, delivery) pair.  The case count printed at the
+# end is the check on that: it must equal the size of the cross product the
+# model declares, minus the pairs the converter collapses.
+SEEDS=(0xc1 0xc2 0xc3 0xc4 0xc5 0xc6)
+
+TRACES=()
+for s in "${SEEDS[@]}"; do
+    f="${WORK_DIR}/client-${s}.itf.json"
+    "${QUINT}" run "${SRC_DIR}/client.qnt" \
+        --seed="$s" --max-steps=400 --out-itf="$f" > /dev/null
+    TRACES+=("$f")
+done
+
+"${PYTHON}" "${SRC_DIR}/itf_to_client_cases.py" "${OUT_HEADER}" "${TRACES[@]}"

--- a/src/rpc2/tests/quint/itf_to_cases.py
+++ b/src/rpc2/tests/quint/itf_to_cases.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Ben Jarvis
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+"""Convert Quint ITF traces into a C case table for conformance.c.
+
+The Quint models (values.qnt, defects.qnt) enumerate test cases symbolically.
+This script turns the resulting traces into a checked-in C header so the test
+binary carries its cases as static data -- no JSON parser, no Python, and no
+quint at build or run time.  Regenerate with regen_cases.sh after changing a
+model.
+
+Every tag the models can emit must appear in the tables below.  An unknown tag
+is a hard error rather than a silently skipped case: if a model gains a
+variant, the C driver needs a corresponding arm, and failing loudly here is
+what forces that.
+"""
+
+import json
+import sys
+
+# Tag orderings. These define the numeric values of the generated C enums, so
+# reordering a list renumbers the enum -- harmless (the header is regenerated
+# atomically with the tables) but avoid it for reviewable diffs.
+VALUE_FIELDS = {
+    "proc": ["EchoScalars", "EchoBytes", "EchoZbytes", "EchoArrays",
+             "EchoUnion", "EchoOptional", "EchoList", "EchoNested"],
+    "i": ["I32Min", "I32Neg1", "I32Zero", "I32One", "I32Max"],
+    "u": ["U32Zero", "U32One", "U32Max"],
+    "l": ["I64Min", "I64Neg1", "I64Zero", "I64Max"],
+    "ul": ["U64Zero", "U64One", "U64Max"],
+    "f": ["FZero", "FNegZero", "FOne", "FNegOne", "FLarge", "FNan"],
+    "b": ["BFalse", "BTrue"],
+    "col": ["ColRed", "ColGreen", "ColBlue"],
+    "strLen": ["LEmpty", "LOne", "LUnaligned", "LAligned", "LAtBound", "LLarge"],
+    "opaqueLen": ["LEmpty", "LOne", "LUnaligned", "LAligned", "LAtBound", "LLarge"],
+    "boundedLen": ["LEmpty", "LOne", "LUnaligned", "LAligned", "LAtBound", "LLarge"],
+    "arrLen": ["LEmpty", "LOne", "LUnaligned", "LAligned", "LAtBound", "LLarge"],
+    "optPresent": ["OptAbsent", "OptPresent"],
+    "arm": ["ArmNone", "ArmInt", "ArmStr", "ArmPt"],
+    "depth": ["LEmpty", "LOne", "LUnaligned", "LAligned", "LAtBound", "LLarge"],
+    "chunk": ["ChunkNone", "ChunkDdp", "ChunkReply", "ChunkReadInto",
+              "ChunkWriteAlloc", "ChunkWriteExact"],
+}
+
+# Field order in struct conf_value_case; also the C member names.
+VALUE_ORDER = ["proc", "i", "u", "l", "ul", "f", "b", "col", "strLen",
+               "opaqueLen", "boundedLen", "arrLen", "optPresent", "arm", "depth",
+               "chunk"]
+
+VALUE_MEMBER = {
+    "proc": "proc", "i": "i", "u": "u", "l": "l", "ul": "ul", "f": "f",
+    "b": "b", "col": "col", "strLen": "str_len", "opaqueLen": "opaque_len",
+    "boundedLen": "bounded_len", "arrLen": "arr_len",
+    "optPresent": "opt_present", "arm": "arm", "depth": "depth",
+    "chunk": "chunk",
+}
+
+# Which fields each procedure actually reads.  The model picks a class for
+# every field on every step, but a case for ECHO_SCALARS that differs only in
+# its (unused) list depth is not a distinct test -- it is the same RPC on the
+# wire.  De-duplicating on the relevant subset keeps the case count honest and
+# stops the table filling up with identical calls.  Irrelevant fields are
+# zeroed in the emitted row.
+VALUE_RELEVANT = {
+    "EchoScalars":  ["i", "u", "l", "ul", "f", "b", "col", "chunk"],
+    "EchoBytes":    ["strLen", "opaqueLen", "boundedLen", "chunk"],
+    "EchoZbytes":   ["u", "opaqueLen", "chunk"],
+    "EchoArrays":   ["u", "arrLen", "boundedLen", "chunk"],
+    "EchoUnion":    ["arm", "i", "strLen", "chunk"],
+    "EchoOptional": ["optPresent", "u", "i", "chunk"],
+    "EchoList":     ["u", "depth", "chunk"],
+    "EchoNested":   ["i", "u", "depth", "chunk"],
+}
+
+DEFECTS = [
+    "NoDefect",
+    "RpcVersWrong", "ProgramUnknown", "VersionUnsupported", "ProcedureUnknown",
+    "ProcedureNull", "AuthFlavorUnsupported", "CredBodyOverlong",
+    "ArgsTruncated", "ArgsTrailingGarbage", "StringLenOverflow",
+    "StringLenBeyondMessage", "StringExceedsBound", "OpaqueExceedsBound",
+    "ArrayCountExceedsBound",
+    "ArrayCountHuge", "DiscriminantUnmatched", "BoolNotZeroOrOne",
+    "EnumNotDeclared", "RecordMarkHuge", "RecordMarkZeroLength",
+    "CallSplitAcrossFragments", "CallSplitPathological",
+    "GssInitEstablishes", "GssInitContinues", "GssInitMechFails",
+    "GssDataValid", "GssCredVersionWrong", "GssProcUnknown",
+    "GssServicePrivacy", "GssHandleUnknown", "GssVerifierNotGss",
+    "GssMicWrong", "GssSeqReplayed",
+    "AuthSysValid",
+    "GssIntegDataValid", "GssIntegChecksumWrong", "GssIntegSeqMismatch",
+    "GssDestroyContext", "GssDestroyUnauthenticated",
+    "GssSeqAboveMax", "GssSeqWindowJump", "GssSeqTooOld", "GssSeqOutOfOrder",
+    "GssCredTruncated", "GssCredHandleOverruns",
+    "GssNoMechanism",
+    "GssContinueInitUnknownHandle", "GssInitTokenMalformed",
+    "GssContinueInitTokenMalformed", "GssInitMechFailsWithToken",
+    "GssIntegFramingBad", "GssIntegEmptyArgs", "GssIntegSplitAcrossFragments",
+    "GssIntegReplyMicFails", "GssIntegReplyMicOversize",
+    "ReassemblyCapExceeded",
+]
+
+TARGETS = ["TScalars", "TBytes", "TArrays", "TStrict"]
+
+OUTCOMES = ["Success", "ProgUnavail", "ProgMismatch", "ProcUnavail",
+            "GarbageArgs", "RpcMismatch", "AuthError", "Closed", "NoReply"]
+
+
+class TagError(Exception):
+    pass
+
+
+def tag_of(v):
+    if not isinstance(v, dict) or "tag" not in v:
+        raise TagError("expected a tagged variant, got %r" % (v,))
+    return v["tag"]
+
+
+def index_of(table, tag, what):
+    try:
+        return table.index(tag)
+    except ValueError:
+        raise TagError("unknown %s tag %r; add it to itf_to_cases.py and to "
+                       "the C driver" % (what, tag))
+
+
+def itf_int(v):
+    if isinstance(v, dict) and "#bigint" in v:
+        return int(v["#bigint"])
+    if isinstance(v, int):
+        return v
+    raise TagError("expected an integer, got %r" % (v,))
+
+
+def payload_int(variant):
+    """Integer payload of a variant, or -1 when it carries none."""
+    val = variant.get("value")
+    if isinstance(val, dict) and "#tup" in val:
+        return -1
+    return itf_int(val)
+
+
+def load_states(paths, var):
+    for path in paths:
+        with open(path) as f:
+            trace = json.load(f)
+        for state in trace["states"]:
+            yield state, path
+
+
+def collect_values(paths):
+    seen, cases = set(), []
+    for state, path in load_states(paths, "current"):
+        cur = state["current"]
+        proc_tag = tag_of(cur["proc"])
+        relevant = VALUE_RELEVANT.get(proc_tag)
+        if relevant is None:
+            raise TagError("no relevance entry for procedure %r; add one to "
+                           "itf_to_cases.py" % proc_tag)
+
+        row = []
+        for field in VALUE_ORDER:
+            if field != "proc" and field not in relevant:
+                row.append(0)
+                continue
+            row.append(index_of(VALUE_FIELDS[field], tag_of(cur[field]), field))
+
+        key = tuple(row)
+        if key not in seen:
+            seen.add(key)
+            cases.append(row)
+    return cases
+
+
+def collect_defects(paths):
+    seen, cases = set(), []
+    for state, path in load_states(paths, "current"):
+        cur = state["current"]
+        dv = cur["defect"]
+        defect = index_of(DEFECTS, tag_of(dv), "defect")
+        param = payload_int(dv)
+        target = index_of(TARGETS, tag_of(cur["target"]), "target")
+
+        ev = state["expected"]
+        outcome = index_of(OUTCOMES, tag_of(ev), "outcome")
+        lo = hi = -1
+        if tag_of(ev) in ("ProgMismatch", "RpcMismatch"):
+            rng = ev["value"]
+            lo, hi = itf_int(rng["lo"]), itf_int(rng["hi"])
+
+        key = (defect, param, target, outcome, lo, hi)
+        if key not in seen:
+            seen.add(key)
+            cases.append(key)
+    return cases
+
+
+def emit_enum(out, name, prefix, tags):
+    # De-duplicate while preserving order: several value fields share the
+    # LenCls tags, and they must map to one C enum, not several.
+    seen, uniq = set(), []
+    for t in tags:
+        if t not in seen:
+            seen.add(t)
+            uniq.append(t)
+    out.append("enum %s {" % name)
+    for i, t in enumerate(uniq):
+        out.append("    %s_%s = %d," % (prefix, t.upper(), i))
+    out.append("};")
+    out.append("")
+
+
+def main():
+    if len(sys.argv) < 4:
+        print("usage: %s <out.h> --values <traces...> --defects <traces...>"
+              % sys.argv[0], file=sys.stderr)
+        return 2
+
+    out_path = sys.argv[1]
+    args = sys.argv[2:]
+    value_paths, defect_paths, bucket = [], [], None
+    for a in args:
+        if a == "--values":
+            bucket = value_paths
+        elif a == "--defects":
+            bucket = defect_paths
+        elif bucket is None:
+            print("stray argument %r before --values/--defects" % a,
+                  file=sys.stderr)
+            return 2
+        else:
+            bucket.append(a)
+
+    values = collect_values(value_paths)
+    defects = collect_defects(defect_paths)
+
+    o = []
+    o.append("/* SPDX-FileCopyrightText: 2026 Ben Jarvis")
+    o.append(" *")
+    o.append(" * SPDX-License-Identifier: LGPL-2.1-only")
+    o.append(" *")
+    o.append(" * GENERATED FILE -- DO NOT EDIT.")
+    o.append(" *")
+    o.append(" * Produced by quint/regen_cases.sh from the Quint models in")
+    o.append(" * quint/values.qnt and quint/defects.qnt.  Each row is one test")
+    o.append(" * case; the C driver in conformance.c maps the symbolic classes")
+    o.append(" * to wire bytes and checks the predicted outcome.")
+    o.append(" */")
+    o.append("")
+    o.append("#pragma once")
+    o.append("")
+    o.append("#include <stdint.h>")
+    o.append("")
+
+    # One shared enum per distinct class family.
+    emit_enum(o, "conf_proc_cls", "CLS", VALUE_FIELDS["proc"])
+    emit_enum(o, "conf_int_cls", "CLS", VALUE_FIELDS["i"])
+    emit_enum(o, "conf_uint_cls", "CLS", VALUE_FIELDS["u"])
+    emit_enum(o, "conf_long_cls", "CLS", VALUE_FIELDS["l"])
+    emit_enum(o, "conf_ulong_cls", "CLS", VALUE_FIELDS["ul"])
+    emit_enum(o, "conf_float_cls", "CLS", VALUE_FIELDS["f"])
+    emit_enum(o, "conf_bool_cls", "CLS", VALUE_FIELDS["b"])
+    emit_enum(o, "conf_color_cls", "CLS", VALUE_FIELDS["col"])
+    emit_enum(o, "conf_len_cls", "CLS", VALUE_FIELDS["strLen"])
+    emit_enum(o, "conf_opt_cls", "CLS", VALUE_FIELDS["optPresent"])
+    emit_enum(o, "conf_arm_cls", "CLS", VALUE_FIELDS["arm"])
+    emit_enum(o, "conf_chunk_cls", "CLS", VALUE_FIELDS["chunk"])
+    emit_enum(o, "conf_defect", "DEF", DEFECTS)
+    emit_enum(o, "conf_target", "TGT", TARGETS)
+    emit_enum(o, "conf_outcome", "EXP", OUTCOMES)
+
+    o.append("struct conf_value_case {")
+    for field in VALUE_ORDER:
+        o.append("    uint8_t %s;" % VALUE_MEMBER[field])
+    o.append("};")
+    o.append("")
+    o.append("struct conf_defect_case {")
+    o.append("    uint8_t defect;")
+    o.append("    uint8_t target;")
+    o.append("    uint8_t expect;")
+    o.append("    int64_t param;     /* defect payload, -1 when it has none */")
+    o.append("    int32_t expect_lo; /* version range for the *MISMATCH outcomes */")
+    o.append("    int32_t expect_hi;")
+    o.append("};")
+    o.append("")
+
+    o.append("static const struct conf_value_case conf_value_cases[] = {")
+    for row in values:
+        o.append("    { %s }," % ", ".join(str(x) for x in row))
+    o.append("};")
+    o.append("")
+    o.append("static const struct conf_defect_case conf_defect_cases[] = {")
+    for d, param, t, outcome, lo, hi in defects:
+        o.append("    { %d, %d, %d, %d, %d, %d }," % (d, t, outcome, param, lo, hi))
+    o.append("};")
+    o.append("")
+    o.append("#define CONF_NUM_VALUE_CASES "
+             "(sizeof(conf_value_cases) / sizeof(conf_value_cases[0]))")
+    o.append("#define CONF_NUM_DEFECT_CASES "
+             "(sizeof(conf_defect_cases) / sizeof(conf_defect_cases[0]))")
+    o.append("")
+
+    with open(out_path, "w") as f:
+        f.write("\n".join(o))
+
+    print("%s: %d value cases, %d defect cases"
+          % (out_path, len(values), len(defects)))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except TagError as e:
+        print("error: %s" % e, file=sys.stderr)
+        sys.exit(1)

--- a/src/rpc2/tests/quint/itf_to_cases.py
+++ b/src/rpc2/tests/quint/itf_to_cases.py
@@ -236,9 +236,14 @@ def main():
     defects = collect_defects(defect_paths)
 
     o = []
+    # The header written into the GENERATED file.  Fenced off because reuse
+    # otherwise reads these string literals as this script's own license tags
+    # and fails to parse the trailing quote as part of the expression.
+    # REUSE-IgnoreStart
     o.append("/* SPDX-FileCopyrightText: 2026 Ben Jarvis")
     o.append(" *")
     o.append(" * SPDX-License-Identifier: LGPL-2.1-only")
+    # REUSE-IgnoreEnd
     o.append(" *")
     o.append(" * GENERATED FILE -- DO NOT EDIT.")
     o.append(" *")

--- a/src/rpc2/tests/quint/itf_to_client_cases.py
+++ b/src/rpc2/tests/quint/itf_to_client_cases.py
@@ -146,9 +146,14 @@ def main():
     cases = collect(sys.argv[2:])
 
     o = []
+    # The header written into the GENERATED file.  Fenced off because reuse
+    # otherwise reads these string literals as this script's own license tags
+    # and fails to parse the trailing quote as part of the expression.
+    # REUSE-IgnoreStart
     o.append("/* SPDX-FileCopyrightText: 2026 Ben Jarvis")
     o.append(" *")
     o.append(" * SPDX-License-Identifier: LGPL-2.1-only")
+    # REUSE-IgnoreEnd
     o.append(" *")
     o.append(" * GENERATED FILE -- DO NOT EDIT.")
     o.append(" *")

--- a/src/rpc2/tests/quint/itf_to_client_cases.py
+++ b/src/rpc2/tests/quint/itf_to_client_cases.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Ben Jarvis
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+"""Convert Quint ITF traces of client.qnt into a C case table.
+
+client.qnt enumerates reply defects symbolically.  This script turns the
+resulting traces into a C header that conformance_client.c compiles in, so the
+test binary carries its cases as static data -- no JSON parser, no Python, and
+no quint at run time.  CMake runs generate_client_cases.sh, which runs this;
+the header lives in the build tree so it can never drift from the model.
+
+Every tag the model can emit must appear in the tables below.  An unknown tag
+is a hard error rather than a silently skipped case: if the model gains a
+variant, the C driver needs a corresponding arm, and failing loudly here is
+what forces that.
+"""
+
+import json
+import sys
+
+# Tag orderings.  These define the numeric values of the generated C enums, so
+# reordering a list renumbers the enum -- harmless (the header is regenerated
+# atomically with the table) but avoid it for reviewable diffs.
+DEFECTS = [
+    "ReplyWellFormed",
+    "ReplyVerfAuthSys",
+    "ReplySplitAcrossFragments",
+    "ReplyUnknownXid",
+    "ReplyDuplicated",
+    "ReplyIsACall",
+    "ReplyHeaderTruncated",
+    "ReplyMtypeUndefined",
+    "ReplyVerfBodyOverlong",
+    "PeerClosesWithoutReply",
+    "ReplyRejectedAuth",
+    "ReplyRejectedRpcMismatch",
+    "ReplyAcceptStat",
+    "ReplyDeniedWithBody",
+    "ReplyAcceptStatWithBody",
+    "ReplyStatUndefined",
+    "ReplyEmptyBody",
+    "ReplyTruncatedBody",
+    "ReplyTrailingGarbage",
+    "ReplyGarbageBody",
+    "ReplyStringLenOverflow",
+    "ReplyStringLenBeyondMessage",
+]
+
+DELIVERIES = ["OneWrite", "TwoWrites", "Dribble"]
+
+OUTCOMES = ["CbSuccess", "CbDecodeError", "CbFailed", "CbDropped"]
+
+SURVIVALS = ["ConnUp", "ConnAny"]
+
+# Defects whose wire delivery is fixed by the defect itself, so varying the
+# delivery mode does not produce a distinct test -- it produces the same bytes
+# in the same order.  Collapsing them to OneWrite keeps the case count honest
+# instead of filling the table with triplicates.  Mirrors VALUE_RELEVANT in
+# itf_to_cases.py.
+DELIVERY_IRRELEVANT = {
+    # Nothing is written at all; the defect is the close.
+    "PeerClosesWithoutReply",
+    # The defect *is* a delivery pattern: it writes its own fragments.
+    "ReplySplitAcrossFragments",
+}
+
+
+class TagError(Exception):
+    pass
+
+
+def tag_of(v):
+    if not isinstance(v, dict) or "tag" not in v:
+        raise TagError("expected a tagged variant, got %r" % (v,))
+    return v["tag"]
+
+
+def index_of(table, tag, what):
+    try:
+        return table.index(tag)
+    except ValueError:
+        raise TagError("unknown %s tag %r; add it to itf_to_client_cases.py "
+                       "and to the C driver" % (what, tag))
+
+
+def itf_int(v):
+    if isinstance(v, dict) and "#bigint" in v:
+        return int(v["#bigint"])
+    if isinstance(v, int):
+        return v
+    raise TagError("expected an integer, got %r" % (v,))
+
+
+def payload_int(variant):
+    """Integer payload of a variant, or -1 when it carries none."""
+    val = variant.get("value")
+    if isinstance(val, dict) and "#tup" in val:
+        return -1
+    return itf_int(val)
+
+
+def collect(paths):
+    seen, cases = set(), []
+    for path in paths:
+        with open(path) as f:
+            trace = json.load(f)
+        for state in trace["states"]:
+            cur = state["current"]
+            dv = cur["defect"]
+            dtag = tag_of(dv)
+
+            defect = index_of(DEFECTS, dtag, "defect")
+            param = payload_int(dv)
+
+            dtag_delivery = ("OneWrite" if dtag in DELIVERY_IRRELEVANT
+                             else tag_of(cur["delivery"]))
+            delivery = index_of(DELIVERIES, dtag_delivery, "delivery")
+
+            expect = index_of(OUTCOMES, tag_of(state["expected"]), "outcome")
+            survive = index_of(SURVIVALS, tag_of(state["survives"]),
+                               "survival")
+
+            key = (defect, param, delivery, expect, survive)
+            if key not in seen:
+                seen.add(key)
+                cases.append(key)
+    return cases
+
+
+def emit_enum(out, name, prefix, tags):
+    out.append("enum %s {" % name)
+    for i, t in enumerate(tags):
+        out.append("    %s_%s = %d," % (prefix, t.upper(), i))
+    out.append("};")
+    out.append("")
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("usage: %s <out.h> <traces...>" % sys.argv[0], file=sys.stderr)
+        return 2
+
+    out_path = sys.argv[1]
+    cases = collect(sys.argv[2:])
+
+    o = []
+    o.append("/* SPDX-FileCopyrightText: 2026 Ben Jarvis")
+    o.append(" *")
+    o.append(" * SPDX-License-Identifier: LGPL-2.1-only")
+    o.append(" *")
+    o.append(" * GENERATED FILE -- DO NOT EDIT.")
+    o.append(" *")
+    o.append(" * Produced by quint/generate_client_cases.sh from the Quint")
+    o.append(" * model in quint/client.qnt.  Each row is one defective reply;")
+    o.append(" * the driver in conformance_client.c maps the symbolic defect to")
+    o.append(" * wire bytes and checks the client against the prediction.")
+    o.append(" */")
+    o.append("")
+    o.append("#pragma once")
+    o.append("")
+    o.append("#include <stdint.h>")
+    o.append("")
+
+    emit_enum(o, "client_defect", "CDEF", DEFECTS)
+    emit_enum(o, "client_delivery", "CDLV", DELIVERIES)
+    emit_enum(o, "client_outcome", "CEXP", OUTCOMES)
+    emit_enum(o, "client_survival", "CSRV", SURVIVALS)
+
+    o.append("struct client_case {")
+    o.append("    uint8_t defect;")
+    o.append("    uint8_t delivery;")
+    o.append("    uint8_t expect;   /* required callback outcome */")
+    o.append("    uint8_t survive;  /* whether the conn must stay usable */")
+    o.append("    int64_t param;    /* defect payload, -1 when it has none */")
+    o.append("};")
+    o.append("")
+
+    o.append("static const struct client_case client_cases[] = {")
+    for defect, param, delivery, expect, survive in cases:
+        o.append("    { %d, %d, %d, %d, %d }," %
+                 (defect, delivery, expect, survive, param))
+    o.append("};")
+    o.append("")
+    o.append("#define CLIENT_NUM_CASES "
+             "(sizeof(client_cases) / sizeof(client_cases[0]))")
+    o.append("")
+
+    with open(out_path, "w") as f:
+        f.write("\n".join(o))
+
+    print("%s: %d client reply cases" % (out_path, len(cases)))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except TagError as e:
+        print("error: %s" % e, file=sys.stderr)
+        sys.exit(1)

--- a/src/rpc2/tests/quint/values.qnt
+++ b/src/rpc2/tests/quint/values.qnt
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+/**
+ * values.qnt -- the positive half of the XDR conformance matrix.
+ *
+ * Each state picks one procedure of CONFORMANCE_PROGRAM (conformance.x) and
+ * one boundary-value class for each of that procedure's fields.  The expected
+ * result is always Echo: a well-formed call must come back byte-identical,
+ * because every handler in the test server echoes its argument.
+ *
+ * The classes are SYMBOLIC on purpose -- "U32Max", not 4294967295.  The C
+ * driver owns the mapping from class to bytes/values, so this model stays
+ * readable and stays out of the business of encoding XDR.
+ *
+ * The bounds declared here (BoundedMax, FixedOpaqueLen, FixedArrayLen) must
+ * match the consts in conformance.x.  defects.qnt derives its
+ * bound-exceeding cases from the same numbers, which is the main reason the
+ * positive and negative matrices live in one model rather than two ad-hoc
+ * lists.
+ *
+ *   quint test values.qnt
+ *   quint run values.qnt --invariant=wellFormed
+ *   ./regen_cases.sh      (in the parent directory)
+ */
+module xdr_values {
+
+    // Mirrors of the conformance.x consts.
+    pure val BoundedMax = 8
+    pure val FixedOpaqueLen = 16
+    pure val FixedArrayLen = 4
+
+    /// Procedures of CONFORMANCE_V1, by name.
+    type Proc =
+        | EchoScalars
+        | EchoBytes
+        | EchoZbytes
+        | EchoArrays
+        | EchoUnion
+        | EchoOptional
+        | EchoList
+        | EchoNested
+
+    /// Boundary classes for the numeric scalars.  Signed types carry their
+    /// min so the sign bit and two's-complement encoding are exercised;
+    /// floats carry a NaN, which the driver compares bitwise (a value
+    /// comparison would spuriously fail).
+    type IntCls = | I32Min | I32Neg1 | I32Zero | I32One | I32Max
+    type UintCls = | U32Zero | U32One | U32Max
+    type LongCls = | I64Min | I64Neg1 | I64Zero | I64Max
+    type UlongCls = | U64Zero | U64One | U64Max
+    type FloatCls = | FZero | FNegZero | FOne | FNegOne | FLarge | FNan
+    type BoolCls = | BFalse | BTrue
+    type ColorCls = | ColRed | ColGreen | ColBlue
+
+    /// Length classes for counted things.  Empty and one are the classic
+    /// off-by-one traps; Unaligned forces XDR's 4-byte padding; AtBound is
+    /// the largest value a bounded field may legally carry.
+    type LenCls =
+        | LEmpty
+        | LOne
+        | LUnaligned
+        | LAligned
+        | LAtBound
+        | LLarge
+
+    type OptCls = | OptAbsent | OptPresent
+    type ArmCls = | ArmNone | ArmInt | ArmStr | ArmPt
+
+    /// How the call negotiates RPC-over-RDMA data placement.  These map onto
+    /// the (ddp, max_rdma_write_chunk, write_chunk_iov, max_rdma_reply_chunk)
+    /// arguments every generated send_call_* takes and which the driver
+    /// previously always passed as zero -- leaving the whole chunk-negotiation
+    /// path in rpc2.c unexercised.
+    ///
+    /// They are inert on a stream transport (rpc2.c gates all of it on
+    /// conn->rdma), so the same case table is meaningful on both transports:
+    /// over TCP these degrade to the inline path, over RDMA-on-TCP they select
+    /// genuinely different code.
+    /// The last two are both RFC 8166 Write chunks -- storage the requester
+    /// offers for a DDP-eligible result -- and differ only in who owns the
+    /// buffer.  They are separate classes because that ownership split is
+    /// exactly what rpc2.c branches on, and getting it wrong is a leak on one
+    /// side and a double free on the other.
+    type ChunkCls =
+        | ChunkNone        /* inline: no direct placement at all         */
+        | ChunkDdp         /* direct placement on, sizes left to libevpl */
+        | ChunkReply       /* reply travels in a reply chunk             */
+        | ChunkReadInto    /* write chunk, caller-owned destination      */
+        | ChunkWriteAlloc  /* write chunk, destination allocated by libevpl */
+        | ChunkWriteExact  /* write chunk sized exactly to the result    */
+
+    /// One generated test case.  Only the fields relevant to `proc` are
+    /// meaningful; the driver ignores the rest.
+    type Case = {
+        proc: Proc,
+        i: IntCls,
+        u: UintCls,
+        l: LongCls,
+        ul: UlongCls,
+        f: FloatCls,
+        b: BoolCls,
+        col: ColorCls,
+        strLen: LenCls,
+        opaqueLen: LenCls,
+        boundedLen: LenCls,
+        arrLen: LenCls,
+        optPresent: OptCls,
+        arm: ArmCls,
+        depth: LenCls,
+        chunk: ChunkCls
+    }
+
+    pure val DEFAULT_CASE: Case = {
+        proc: EchoScalars,
+        i: I32Zero, u: U32Zero, l: I64Zero, ul: U64Zero,
+        f: FZero, b: BFalse, col: ColRed,
+        strLen: LEmpty, opaqueLen: LEmpty, boundedLen: LEmpty,
+        arrLen: LEmpty, optPresent: OptAbsent, arm: ArmNone, depth: LEmpty,
+        chunk: ChunkNone
+    }
+
+    var current: Case
+
+    // ------------------------------------------------------------------
+    // Case generation
+    // ------------------------------------------------------------------
+
+    pure val INT_CLASSES = Set(I32Min, I32Neg1, I32Zero, I32One, I32Max)
+    pure val UINT_CLASSES = Set(U32Zero, U32One, U32Max)
+    pure val LONG_CLASSES = Set(I64Min, I64Neg1, I64Zero, I64Max)
+    pure val ULONG_CLASSES = Set(U64Zero, U64One, U64Max)
+    pure val FLOAT_CLASSES = Set(FZero, FNegZero, FOne, FNegOne, FLarge, FNan)
+    pure val BOOL_CLASSES = Set(BFalse, BTrue)
+    pure val COLOR_CLASSES = Set(ColRed, ColGreen, ColBlue)
+    pure val ARM_CLASSES = Set(ArmNone, ArmInt, ArmStr, ArmPt)
+    pure val OPT_CLASSES = Set(OptAbsent, OptPresent)
+
+    /// Arming a destination buffer only means something when the reply
+    /// actually carries a zero-copy payload to place into it, which among
+    /// these procedures is ECHO_ZBYTES alone.  The others take the shapes that
+    /// apply to any reply.
+    pure val CHUNK_CLASSES = Set(ChunkNone, ChunkDdp, ChunkReply)
+
+    /// The write-chunk classes offer storage for the reply's DDP-eligible
+    /// result, so they only mean anything for a procedure whose reply has one
+    /// -- ECHO_ZBYTES alone here, which writeChunkOnlyWhereItApplies below
+    /// enforces.
+    ///
+    /// ChunkReadInto was held out of generation for a while because it failed
+    /// the echo oracle; the cause was the missing take_read_chunk call in the
+    /// test's own handler rather than anything in the transport, and with that
+    /// fixed it belongs in the matrix.
+    /// ChunkWriteExact is the at-bound length class for chunk sizing: the
+    /// chunk offered is exactly as large as the result placed in it, which is
+    /// the one case where a segment is consumed to its last byte rather than
+    /// capped short.  The others all offer more room than the result needs.
+    pure val WRITE_CHUNK_CLASSES = Set(ChunkReadInto, ChunkWriteAlloc,
+                                       ChunkWriteExact)
+
+    pure val CHUNK_CLASSES_ZEROCOPY = CHUNK_CLASSES.union(WRITE_CHUNK_CLASSES)
+
+    /// Unbounded counted fields may take any length class; LAtBound is only
+    /// meaningful for a field that actually declares a bound, but it is a
+    /// legal (and interesting) length for an unbounded one too.
+    pure val LEN_CLASSES = Set(LEmpty, LOne, LUnaligned, LAligned, LAtBound, LLarge)
+
+    /// Bounded fields (opaque<8>, uint32_t<8>) may not exceed the bound, so
+    /// LLarge is excluded here -- exceeding it is a defect, and lives in
+    /// defects.qnt rather than being silently generated as a "positive" case.
+    pure val BOUNDED_LEN_CLASSES = Set(LEmpty, LOne, LUnaligned, LAligned, LAtBound)
+
+    action pick = {
+        nondet p = Set(EchoScalars, EchoBytes, EchoZbytes, EchoArrays,
+                       EchoUnion, EchoOptional, EchoList, EchoNested).oneOf()
+        nondet vi = INT_CLASSES.oneOf()
+        nondet vu = UINT_CLASSES.oneOf()
+        nondet vl = LONG_CLASSES.oneOf()
+        nondet vul = ULONG_CLASSES.oneOf()
+        nondet vf = FLOAT_CLASSES.oneOf()
+        nondet vb = BOOL_CLASSES.oneOf()
+        nondet vcol = COLOR_CLASSES.oneOf()
+        nondet vstr = LEN_CLASSES.oneOf()
+        nondet vopq = LEN_CLASSES.oneOf()
+        nondet vbnd = BOUNDED_LEN_CLASSES.oneOf()
+        nondet varr = LEN_CLASSES.oneOf()
+        nondet vopt = OPT_CLASSES.oneOf()
+        nondet varm = ARM_CLASSES.oneOf()
+        nondet vdepth = LEN_CLASSES.oneOf()
+        nondet vchunk = (if (p == EchoZbytes) CHUNK_CLASSES_ZEROCOPY
+                         else CHUNK_CLASSES).oneOf()
+        current' = {
+            proc: p, i: vi, u: vu, l: vl, ul: vul, f: vf, b: vb, col: vcol,
+            strLen: vstr, opaqueLen: vopq, boundedLen: vbnd, arrLen: varr,
+            optPresent: vopt, arm: varm, depth: vdepth, chunk: vchunk
+        }
+    }
+
+    action init = all { current' = DEFAULT_CASE }
+    action step = pick
+
+    // ------------------------------------------------------------------
+    // Invariant: every generated case is legal input
+    // ------------------------------------------------------------------
+
+    /// A bounded field must never be asked to carry more than its bound --
+    /// otherwise this model would be emitting cases that RFC 4506 requires
+    /// the server to REJECT, while labelling them as expected-to-echo.
+    val boundedWithinBound =
+        BOUNDED_LEN_CLASSES.contains(current.boundedLen)
+
+    /// A case may only offer a write chunk for a procedure whose reply carries
+    /// a zero-copy payload; anywhere else the chunk would go unused and the
+    /// case would silently be testing the inline path instead.
+    val writeChunkOnlyWhereItApplies =
+        WRITE_CHUNK_CLASSES.contains(current.chunk) implies current.proc == EchoZbytes
+
+    val wellFormed = boundedWithinBound and writeChunkOnlyWhereItApplies
+
+    // ------------------------------------------------------------------
+    // Scenario tests
+    // ------------------------------------------------------------------
+
+    run scalarExtremesTest =
+        init
+            .then(all {
+                current' = DEFAULT_CASE.with("proc", EchoScalars)
+                    .with("i", I32Min).with("u", U32Max)
+                    .with("l", I64Min).with("ul", U64Max).with("f", FNan)
+            })
+            .expect(wellFormed)
+
+    run boundedNeverExceedsTest =
+        init
+            .then(pick)
+            .expect(boundedWithinBound)
+            .then(pick)
+            .expect(boundedWithinBound)
+}


### PR DESCRIPTION
The model-based conformance suite that found the RPC2 and XDR fixes merged in #123, #124 and chimera-nas/xdrzcc#14. Three commits: server suite, client suite, docs.

## How it works

Quint models enumerate the cases symbolically; a build step turns them into a C table; the test binary replays them against a real RPC2 server (or, for the client suite, against a hostile one the test implements).

- `values.qnt` — boundary-value classes per XDR type. 1037 cases, oracle is round-trip identity, so no predicted output is needed.
- `defects.qnt` — a taxonomy of wire defects and the outcome each RFC requires, written onto a socket the test owns because libevpl's own client cannot express them.
- `client.qnt` — reply defects, for the client's inbound path.

The models encode the **specification** (RFC 5531, RFC 4506, RFC 2203, RFC 8166), not libevpl's behaviour. Encoding the latter would freeze today's bugs into the spec and guarantee the suite never finds them. Divergences are therefore expected; each reviewed one goes in `known_divergences[]` with its RFC citation, and an unlisted one fails the test.

## What is generated, and what that costs

Nothing generated is checked in. The ITF traces and case tables are build artifacts, regenerated whenever a model or converter changes. That makes **quint and python3 build dependencies** — cmake detects them and registers the test only when both are present, so a build without them is unaffected:

```
-- RPC2 conformance test enabled (quint: /usr/local/bin/quint)
-- RPC2 conformance test disabled (needs quint and python3 on PATH)
```

Seeds are fixed, so a given quint release always yields the same cases; a different release may sample differently, which is why the devcontainer pins one. `-DQUINT_EXECUTABLE=OFF` forces it off.

## Transports

The server suite runs on all five: TCP, TCP-RDMA, AF_UNIX, and inproc both ways. The value matrix is identical everywhere, but 686 of its 1037 cases request an RDMA chunk, so each is two different tests depending on whether the transport reports RDMA — the summary line says which. The raw-socket defect phase needs a stream transport with a descriptor of its own, so it runs on TCP and AF_UNIX and self-skips on the rest.

The AF_UNIX and inproc instances take no port, no network namespace and no resource lock: the socket name carries the pid and lives under the build tree, so they are safe to run concurrently. Verified with three concurrent ctest processes at `-j 12`.

## Divergences still open

Six, all RPCSEC_GSS, all recorded rather than fixed. The one to look at first is that a krb5i reply whose results cannot be signed is returned **unwrapped** rather than not at all (RFC 2203 §5.3.3.4.1) — an integrity-protected call can complete with unauthenticated results. The others: a `seq_num` above MAXSEQ is silently discarded instead of denied (§5.3.3.3), and an undecodable init token is denied with an auth_stat that §5.2.3.2 rules out on a creation response.

`CONFORMANCE.md` also records leads found by reading rather than by a failing test, including an `alloca` sized from unauthenticated input and a `strcmp` on a decoded string that is not NUL-terminated on the multi-iovec path.

RPCSEC_GSS is driven through a deterministic stub provider, so no KDC is needed — and no real krb5 token is exercised.

Verified: 180/180 in release, 15/15 under ASan, `reuse lint` clean, `make syntax-check` clean.
