### PR TITLE
doorbell_remove: stop freeing out of the array it then re-reads

### DIFF
--- a/src/core/tests/doorbell_remove.c
+++ b/src/core/tests/doorbell_remove.c
@@ -68,25 +68,33 @@ pair_callback(
     struct evpl          *evpl,
     struct evpl_doorbell *doorbell)
 {
-    int i;
+    struct evpl_doorbell *other = NULL;
+    int                   i;
 
     pair_fired++;
 
+    /* Empty the array before releasing anything.  Freeing straight out of
+     * pair[] and then looping over it again reads a slot that an earlier
+     * iteration may already have released -- harmless here, since the two
+     * slots hold distinct allocations, but nothing local says so, and it is
+     * exactly the shape a use-after-free takes. */
     for (i = 0; i < 2; ++i) {
         if (pair[i] && pair[i] != doorbell) {
-            evpl_remove_doorbell(evpl, pair[i]);
-            free(pair[i]);
-            pair[i] = NULL;
+            other = pair[i];
         }
+        pair[i] = NULL;
     }
 
-    for (i = 0; i < 2; ++i) {
-        if (pair[i] == doorbell) {
-            evpl_remove_doorbell(evpl, doorbell);
-            free(doorbell);
-            pair[i] = NULL;
-        }
+    /* The other one first, then this one: retiring an entry the dispatch loop
+     * has yet to reach and one it is sitting on are the two orders this case
+     * exists to cover. */
+    if (other) {
+        evpl_remove_doorbell(evpl, other);
+        free(other);
     }
+
+    evpl_remove_doorbell(evpl, doorbell);
+    free(doorbell);
 } /* pair_callback */
 
 static void


### PR DESCRIPTION
`pair_callback` in the doorbell removal test freed `pair[i]` in one loop and then read `pair[]` again in the next.

The two slots hold distinct allocations, so nothing was ever actually freed twice. But that fact lives in the caller, not in the callback, and the shape is indistinguishable from a use-after-free — clang's analyzer reads it as one:

```
src/core/tests/doorbell_remove.c:85:13:
    warning: Use of memory after it is freed [unix.Malloc]
```

This is not theoretical. chimera runs `scan-build --status-bugs` over its whole tree, `ext/` included, and this fails that build on all four analyze jobs (amd64/arm64 × Debug/Release). It is currently blocking chimera-nas/chimera#1506.

## The change

Empty the array first, then release: the other doorbell, then this one. That is the order the case exists to cover — retiring an entry the dispatch loop has yet to reach, and one it is sitting on — so the coverage is unchanged. Both slots still end up NULL, which is what the caller asserts.

No library code is touched; this is the test only.

## Verified

- `doorbell_remove` passes under Release and under Debug/AddressSanitizer, which is the build the test is actually written for
- full suite 180/180, and 63/63 for core+rpc2 under ASan
- `scan-build` on chimera's exact configuration with this fix: **No bugs found** (was 1)
- `make syntax-check` clean

## One thing worth raising separately

libevpl's CI has no static analysis — `ci.yml`, `pages.yml`, `reuse-compliance.yml`, `syntax-check.yml`. This file landed in #122 without ever being analyzed, and chimera's CI is what found it. Adding scan-build here would catch the next one at source rather than in a downstream bump.
