### PR TITLE
Darwin runtime fixes: 8MB worker stacks, full-pipe wakeup delivery, duplicate pthread link

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ macro(unit_test module test_name)
 
     add_executable(${module}_${test_name} ${sources})
 
-    target_link_libraries(${module}_${test_name} evpl pthread)
+    target_link_libraries(${module}_${test_name} evpl)
 
     list(GET sources 0 first_source)
 
@@ -42,7 +42,7 @@ macro(unit_test_all_mechs module test_name)
 
     add_executable(${module}_${test_name} ${sources})
 
-    target_link_libraries(${module}_${test_name} evpl pthread)
+    target_link_libraries(${module}_${test_name} evpl)
 
     list(GET sources 0 first_source)
 
@@ -133,7 +133,7 @@ macro(unit_test_local module test_name)
 
     add_executable(${module}_${test_name} ${sources})
 
-    target_link_libraries(${module}_${test_name} evpl pthread)
+    target_link_libraries(${module}_${test_name} evpl)
 
     list(GET sources 0 first_source)
 

--- a/src/core/thread/thread.c
+++ b/src/core/thread/thread.c
@@ -146,10 +146,20 @@ evpl_thread_create(
     pthread_mutex_init(&evpl_thread->lock, NULL);
     pthread_cond_init(&evpl_thread->cond, NULL);
 
+    /* Give worker threads an explicit 8MB stack: Linux (glibc) defaults
+     * there, but macOS pthreads default to 512KB, which deep inline
+     * completion chains (e.g. a synchronous backend walking a
+     * near-SYMLOOP_MAX symlink chain under ASan) overflow. */
+    pthread_attr_t thread_attr;
+    pthread_attr_init(&thread_attr);
+    pthread_attr_setstacksize(&thread_attr, 8 * 1024 * 1024);
+
     /* If the thread is never created, the ready-wait below would block
      * forever, so a creation failure must abort rather than fall through. */
-    rc = evpl_pthread_create(&evpl_thread->thread, NULL,
+    rc = evpl_pthread_create(&evpl_thread->thread, &thread_attr,
                              evpl_thread_function, evpl_thread);
+
+    pthread_attr_destroy(&thread_attr);
 
     evpl_thread_abort_if(rc, "evpl_thread_create: pthread_create failed: %s",
                          strerror(rc));

--- a/src/core/wakeup.h
+++ b/src/core/wakeup.h
@@ -97,6 +97,16 @@ evpl_wakeup_signal(struct evpl_wakeup *w)
         len = write(w->wfd, &word, sizeof(word));
     } while (len < 0 && errno == EINTR);
 
+    /* A wakeup that cannot be written is a wakeup already delivered: EAGAIN
+     * means the buffer holds signals the reader has not drained yet (a
+     * self-pipe fills after ~2K undrained words; an eventfd counter would
+     * have to reach 2^64-1), so the reader is guaranteed to wake without
+     * this write.  Report it delivered rather than surfacing an error the
+     * callers treat as fatal. */
+    if (len < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        return (ssize_t) sizeof(word);
+    }
+
     return len;
 } /* evpl_wakeup_signal */
 

--- a/src/rpc2/tests/CMakeLists.txt
+++ b/src/rpc2/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ macro(unit_test_rpc2 test_name xdr_file)
     include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
     add_executable(evpl_rpc2_${test_name} ${sources} ${XDR_C} ${XDR_H})
-    target_link_libraries(evpl_rpc2_${test_name} evpl_rpc2 evpl pthread)
+    target_link_libraries(evpl_rpc2_${test_name} evpl_rpc2 evpl)
 
     # Set the first source for TEST_FILE environment variable
     list(GET sources 0 first_source)


### PR DESCRIPTION
Three small fixes from running chimera's full test suite natively on macOS, where libevpl's portability fallbacks see real load:

- **thread: give worker threads an explicit 8MB stack.** macOS pthreads default to 512KB (glibc: 8MB); deep inline completion chains -- a synchronous backend walking a near-SYMLOOP_MAX symlink chain under ASan -- overflow it.  Requesting the glibc size explicitly gives workers the same headroom on both platforms.

- **wakeup: treat EAGAIN from a full buffer as a delivered wakeup.** The macOS self-pipe behind `evpl_wakeup_signal` fills after ~2K undrained 8-byte words; a burst of doorbell rings ahead of a busy consumer then hit EAGAIN, which `evpl_ring_doorbell` turned into a fatal abort mid-suite.  A full buffer means the reader is guaranteed to wake anyway, so the signal is delivered by definition.  (Unreachable on Linux: an eventfd counter would have to reach 2^64-1.)

- **tests: drop the direct pthread mention from the unit-test link macros.** pthread propagates unconditionally through prometheus-c, so the direct mention just duplicates `-lpthread`, which Xcode 15+ ld warns about on every test target.