### PR TITLE
http: enforce a configurable header block size limit, default 8KB

### DIFF
--- a/include/evpl/evpl_config.h
+++ b/include/evpl/evpl_config.h
@@ -103,6 +103,18 @@ void evpl_global_config_set_tls_ktls_enabled(
     struct evpl_global_config *config,
     int                        enabled);
 
+/*
+ * Maximum size in bytes of an HTTP/1.x header block (request or status
+ * line, all header lines, and the terminating blank line), applied in both
+ * directions.  Inbound, a peer exceeding it gets the connection closed (a
+ * server answers 400 Bad Request first).  Outbound, adding a header that
+ * would overflow it makes evpl_http_request_add_header() fail.  Default
+ * 8192, in line with Apache's request field limits.
+ */
+void evpl_global_config_set_http_max_header_size(
+    struct evpl_global_config *config,
+    unsigned int               size);
+
 struct evpl_thread_config *
 evpl_thread_config_init(
     void);

--- a/include/evpl/evpl_http.h
+++ b/include/evpl/evpl_http.h
@@ -80,7 +80,14 @@ evpl_http_server_destroy(
     struct evpl_http_agent  *agent,
     struct evpl_http_server *server);
 
-void
+/*
+ * Attach a header to the outbound block (request headers on a client
+ * connection, response headers on a server connection).  Returns 0 on
+ * success, or -1 if adding the header would push the block past the
+ * configured http_max_header_size (see
+ * evpl_global_config_set_http_max_header_size); the header is not added.
+ */
+int
 evpl_http_request_add_header(
     struct evpl_http_request *request,
     const char               *name,
@@ -173,6 +180,10 @@ evpl_http_client_close(
     struct evpl_http_agent *agent,
     struct evpl_http_conn  *conn);
 
+/*
+ * Create a client request.  Returns NULL if the request line alone (method
+ * plus url) cannot fit within the configured http_max_header_size.
+ */
 struct evpl_http_request *
 evpl_http_request_create(
     struct evpl_http_conn      *conn,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,12 +22,14 @@ macro(unit_test module test_name)
         add_test(NAME libevpl/${module}/${test_name} COMMAND ${LIBEVPL_SOURCE_DIR}/scripts/netns_test_wrapper.sh ${CMAKE_CURRENT_BINARY_DIR}/${module}_${test_name})
 
         set_tests_properties(libevpl/${module}/${test_name} PROPERTIES
+            TIMEOUT 60
             ENVIRONMENT "TEST_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${first_source}")
     else()
         add_test(NAME libevpl/${module}/${test_name} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${module}_${test_name})
 
         set_tests_properties(libevpl/${module}/${test_name} PROPERTIES
             RESOURCE_LOCK evpl_net
+            TIMEOUT 60
             ENVIRONMENT "TEST_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${first_source}")
     endif()
 

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -49,6 +49,8 @@ evpl_global_config_init(void)
         config->page_size = 4096;
     }
 
+    config->http_max_header_size = 8192;
+
     config->io_uring_enabled = 1;
     config->io_uring_entries = 8192;
 
@@ -291,6 +293,20 @@ evpl_global_config_set_tls_ktls_enabled(
 {
     config->tls_ktls_enabled = enabled;
 } /* evpl_global_config_set_tls_ktls_enabled */
+
+SYMBOL_EXPORT void
+evpl_global_config_set_http_max_header_size(
+    struct evpl_global_config *config,
+    unsigned int               size)
+{
+    config->http_max_header_size = size;
+} /* evpl_global_config_set_http_max_header_size */
+
+SYMBOL_EXPORT unsigned int
+evpl_global_config_get_http_max_header_size(void)
+{
+    return evpl_shared->config->http_max_header_size;
+} /* evpl_global_config_get_http_max_header_size */
 
 SYMBOL_EXPORT struct evpl_thread_config *
 evpl_thread_config_init(void)

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -110,7 +110,16 @@ struct evpl_global_config {
     char                     *tls_cipher_list;
     int                       tls_verify_peer;
     int                       tls_ktls_enabled;
+
+    unsigned int              http_max_header_size;
 };
+
+/* Read the configured HTTP header block limit from the live global config.
+ * Exported so the http module (a separate library that cannot see the
+ * hidden evpl_shared symbol) can fetch it at agent init. */
+unsigned int
+evpl_global_config_get_http_max_header_size(
+    void);
 
 typedef void (*evpl_accept_callback_t)(
     struct evpl         *evpl,

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -114,6 +115,14 @@ evpl_http_init(struct evpl *evpl)
     agent = evpl_zalloc(sizeof(*agent));
 
     agent->evpl = evpl;
+
+    /* Floor the configured limit so the fixed parts of a header block
+     * (status/request line, framing headers, terminator) always fit. */
+    agent->max_header_size = evpl_global_config_get_http_max_header_size();
+
+    if (agent->max_header_size < 512) {
+        agent->max_header_size = 512;
+    }
 
     return agent;
 } /* evpl_http_init */
@@ -312,6 +321,87 @@ evpl_http_handle_body(
     return 0;
 } /* evpl_http_handle_body */
 
+/*
+ * Fixed overhead reserved out of max_header_size for the parts of the
+ * outbound header block that are not application-added headers: the status
+ * line (<= 47 bytes; a client request line is instead counted exactly at
+ * request create time), the Content-Length or Transfer-Encoding line
+ * (<= 38), the internally added "Connection: keep-alive\r\n" (24) and the
+ * terminating "\r\n" (2).  Enforcing the limit minus this reserve at
+ * evpl_http_request_add_header() time means emission can never overflow
+ * the buffer it allocates.
+ */
+#define EVPL_HTTP_HEADER_EMIT_RESERVE 128
+
+/*
+ * Stage a header for emission.  With enforce_limit set (the public API),
+ * refuse a header that would push the block past max_header_size less the
+ * emission reserve.  The library's own fixed headers are added with
+ * enforce_limit clear: the reserve already accounts for them, so they
+ * cannot overflow the block and must not be dropped.  Returns 0 on
+ * success, -1 if the header was refused.
+ */
+static int
+evpl_http_request_add_header_common(
+    struct evpl_http_request *request,
+    const char               *name,
+    const char               *value,
+    int                       enforce_limit)
+{
+    struct evpl_http_conn           *conn  = request->conn;
+    struct evpl_http_agent          *agent = conn->agent;
+    struct evpl_http_request_header *header;
+    unsigned int                     line_bytes;
+
+    header = evpl_http_request_header_alloc(agent);
+
+    strncpy(header->name, name, sizeof(header->name) - 1);
+    strncpy(header->value, value, sizeof(header->value) - 1);
+
+    /* accounted as emitted: "<name>: <value>\r\n", using the stored
+     * (possibly truncated) field lengths */
+    line_bytes = strlen(header->name) + strlen(header->value) + 4;
+
+    if (enforce_limit &&
+        request->header_bytes + line_bytes + EVPL_HTTP_HEADER_EMIT_RESERVE >
+        agent->max_header_size) {
+        evpl_http_request_header_free(agent, header);
+        return -1;
+    }
+
+    request->header_bytes += line_bytes;
+
+    if (conn->is_server) {
+        DL_APPEND(request->response_headers, header);
+    } else {
+        DL_APPEND(request->request_headers, header);
+    }
+
+    return 0;
+} /* evpl_http_request_add_header_common */
+
+/*
+ * Inbound request headers exceeded max_header_size, or a single header
+ * line overflowed the parser: answer 400 Bad Request and close, as Apache
+ * does when its LimitRequestField* limits are exceeded.
+ */
+static void
+evpl_http_server_reject_headers(
+    struct evpl      *evpl,
+    struct evpl_bind *bind)
+{
+    static const char rsp[] =
+        "HTTP/1.1 400 Bad Request\r\n"
+        "Content-Length: 0\r\n"
+        "Connection: close\r\n"
+        "\r\n";
+
+    evpl_http_debug("inbound request header block exceeds max_header_size");
+
+    evpl_send(evpl, bind, rsp, sizeof(rsp) - 1);
+    evpl_finish(evpl, bind);
+} /* evpl_http_server_reject_headers */
+
 static void
 evpl_http_server_handle_data(struct evpl_http_conn *conn)
 {
@@ -397,7 +487,8 @@ evpl_http_server_handle_data(struct evpl_http_conn *conn)
         rc = evpl_http_parse_line(evpl, bind, line, sizeof(line));
 
         if (unlikely(rc == -2)) {
-            evpl_close(evpl, bind);
+            /* single header line overflowed the parse buffer */
+            evpl_http_server_reject_headers(evpl, bind);
             return;
         }
 
@@ -406,6 +497,9 @@ evpl_http_server_handle_data(struct evpl_http_conn *conn)
         }
 
         if (line[0] == '\0') {
+            /* inbound header block complete; reset the accounting for the
+             * outbound response block the application builds from here */
+            request->header_bytes  = 0;
             request->request_state = EVPL_HTTP_REQUEST_STATE_BODY;
 
             if (request->request_flags & EVPL_HTTP_REQUEST_WANTS_CONTINUE) {
@@ -417,6 +511,13 @@ evpl_http_server_handle_data(struct evpl_http_conn *conn)
                                       &request->notify_data,
                                       server->private_data);
         } else {
+            request->header_bytes += strlen(line) + 2;
+
+            if (unlikely(request->header_bytes > agent->max_header_size)) {
+                evpl_http_server_reject_headers(evpl, bind);
+                return;
+            }
+
             header = evpl_http_request_header_alloc(agent);
 
             token = strtok_r(line, ":", &saveptr);
@@ -554,6 +655,10 @@ evpl_http_client_handle_data(struct evpl_http_conn *conn)
         request->status        = atoi(token);
         request->request_state = EVPL_HTTP_REQUEST_STATE_HEADERS;
 
+        /* header_bytes counted the outbound request block; reuse it for
+         * the inbound response header accounting */
+        request->header_bytes = 0;
+
         goto again;
 
     } else if (request->request_state == EVPL_HTTP_REQUEST_STATE_HEADERS) {
@@ -581,6 +686,15 @@ evpl_http_client_handle_data(struct evpl_http_conn *conn)
 
             goto again;
         } else {
+            request->header_bytes += strlen(line) + 2;
+
+            if (unlikely(request->header_bytes > agent->max_header_size)) {
+                evpl_http_debug(
+                    "inbound response header block exceeds max_header_size");
+                evpl_close(evpl, bind);
+                return;
+            }
+
             header = evpl_http_request_header_alloc(agent);
 
             token = strtok_r(line, ":", &saveptr);
@@ -835,6 +949,55 @@ evpl_http_event(
 
 } /* evpl_http_event */
 
+/*
+ * Append a formatted line into [rsp_base, rsp_base + cap) at *rsp,
+ * advancing *rsp only by what vsnprintf actually had room to write, never
+ * past the end of the buffer.  The add-time accounting against
+ * max_header_size makes truncation unreachable here; this is the backstop
+ * that keeps an accounting bug from becoming a heap overflow.
+ */
+static void
+evpl_http_append_line(
+    char       *rsp_base,
+    size_t      cap,
+    char      **rsp,
+    const char *fmt,
+    ...) __attribute__((format(printf, 4, 5)));
+
+static void
+evpl_http_append_line(
+    char       *rsp_base,
+    size_t      cap,
+    char      **rsp,
+    const char *fmt,
+    ...)
+{
+    size_t  used = *rsp - rsp_base;
+    size_t  remain;
+    int     wanted;
+    va_list ap;
+
+    if (used >= cap) {
+        return;
+    }
+
+    remain = cap - used;
+
+    va_start(ap, fmt);
+    wanted = vsnprintf(*rsp, remain, fmt, ap);
+    va_end(ap);
+
+    if (wanted < 0) {
+        return;
+    }
+
+    if ((size_t) wanted >= remain) {
+        *rsp = rsp_base + cap;
+    } else {
+        *rsp += wanted;
+    }
+} /* evpl_http_append_line */
+
 static void
 evpl_http_server_send_headers(
     struct evpl              *evpl,
@@ -846,31 +1009,35 @@ evpl_http_server_send_headers(
     struct evpl_iovec                iov;
     int                              niov;
     char                            *rsp_base, *rsp;
+    const unsigned int               cap = conn->agent->max_header_size;
 
-    niov = evpl_iovec_alloc(evpl, 4096, 4096, 1, 0, &iov);
+    niov = evpl_iovec_alloc(evpl, cap, 4096, 1, 0, &iov);
 
     evpl_http_abort_if(niov < 0, "failed to allocate iovec");
 
     rsp_base = iov.data;
     rsp      = rsp_base;
 
-    rsp += snprintf(rsp, 4096, "%s %d %s\r\n",
-                    http_version_string[request->http_version],
-                    request->status,
-                    evpl_http_response_status_string(request->status));
+    evpl_http_append_line(rsp_base, cap, &rsp, "%s %d %s\r\n",
+                          http_version_string[request->http_version],
+                          request->status,
+                          evpl_http_response_status_string(request->status));
 
     DL_FOREACH(request->response_headers, header)
     {
-        rsp += snprintf(rsp, 4096 - (rsp - rsp_base), "%s: %s\r\n", header->name, header->value);
+        evpl_http_append_line(rsp_base, cap, &rsp, "%s: %s\r\n", header->name, header->value);
     }
 
     if (request->response_transfer_encoding == EVPL_HTTP_REQUEST_TRANSFER_ENCODING_DEFAULT) {
-        rsp += snprintf(rsp, 4096 - (rsp - rsp_base), "Content-Length: %" PRIu64 "\r\n", request->response_length);
+        evpl_http_append_line(rsp_base, cap, &rsp, "Content-Length: %" PRIu64 "\r\n", request->response_length);
     } else {
-        rsp += snprintf(rsp, 4096 - (rsp - rsp_base), "Transfer-Encoding: chunked\r\n");
+        evpl_http_append_line(rsp_base, cap, &rsp, "Transfer-Encoding: chunked\r\n");
     }
 
-    rsp +=  snprintf(rsp, 4096 - (rsp - rsp_base), "\r\n");
+    evpl_http_append_line(rsp_base, cap, &rsp, "\r\n");
+
+    evpl_http_abort_if((unsigned int) (rsp - rsp_base) >= cap,
+                       "http response header block overflowed max_header_size");
 
     iov.length = rsp - rsp_base;
 
@@ -888,30 +1055,34 @@ evpl_http_client_send_headers(
     struct evpl_iovec                iov;
     int                              niov;
     char                            *rsp_base, *rsp;
+    const unsigned int               cap = conn->agent->max_header_size;
 
-    niov = evpl_iovec_alloc(evpl, 4096, 4096, 1, 0, &iov);
+    niov = evpl_iovec_alloc(evpl, cap, 4096, 1, 0, &iov);
 
     evpl_http_abort_if(niov < 0, "failed to allocate iovec");
 
     rsp_base = iov.data;
     rsp      = rsp_base;
 
-    rsp += snprintf(rsp, 4096, "%s %s HTTP/1.1\r\n",
-                    evpl_http_method_to_wire(request->request_type),
-                    request->uri);
+    evpl_http_append_line(rsp_base, cap, &rsp, "%s %s HTTP/1.1\r\n",
+                          evpl_http_method_to_wire(request->request_type),
+                          request->uri);
 
     DL_FOREACH(request->request_headers, header)
     {
-        rsp += snprintf(rsp, 4096 - (rsp - rsp_base), "%s: %s\r\n", header->name, header->value);
+        evpl_http_append_line(rsp_base, cap, &rsp, "%s: %s\r\n", header->name, header->value);
     }
 
     if (request->response_transfer_encoding == EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED) {
-        rsp += snprintf(rsp, 4096 - (rsp - rsp_base), "Transfer-Encoding: chunked\r\n");
+        evpl_http_append_line(rsp_base, cap, &rsp, "Transfer-Encoding: chunked\r\n");
     } else {
-        rsp += snprintf(rsp, 4096 - (rsp - rsp_base), "Content-Length: %" PRIu64 "\r\n", request->response_length);
+        evpl_http_append_line(rsp_base, cap, &rsp, "Content-Length: %" PRIu64 "\r\n", request->response_length);
     }
 
-    rsp += snprintf(rsp, 4096 - (rsp - rsp_base), "\r\n");
+    evpl_http_append_line(rsp_base, cap, &rsp, "\r\n");
+
+    evpl_http_abort_if((unsigned int) (rsp - rsp_base) >= cap,
+                       "http request header block overflowed max_header_size");
 
     iov.length = rsp - rsp_base;
 
@@ -1241,11 +1412,23 @@ evpl_http_request_create(
     const char                 *url)
 {
     struct evpl_http_request *request;
+    struct evpl_http_agent   *agent = conn->agent;
 
-    request               = evpl_http_request_alloc(conn->agent);
+    request               = evpl_http_request_alloc(agent);
     request->conn         = conn;
     request->request_type = method;
     request->uri_len      = evpl_copy_string(request->uri, url, sizeof(request->uri));
+
+    /* seed the outbound accounting with "<METHOD> <uri> HTTP/1.1\r\n" */
+    request->header_bytes = strlen(evpl_http_method_to_wire(method)) +
+        request->uri_len + 12;
+
+    if (request->header_bytes + EVPL_HTTP_HEADER_EMIT_RESERVE >
+        agent->max_header_size) {
+        evpl_http_debug("request line exceeds http max_header_size");
+        evpl_http_request_free(agent, request);
+        return NULL;
+    }
 
     return request;
 } /* evpl_http_request_create */
@@ -1306,27 +1489,13 @@ evpl_http_request_type(struct evpl_http_request *request)
     return request->request_type;
 } /* evpl_http_request_type */
 
-SYMBOL_EXPORT void
+SYMBOL_EXPORT int
 evpl_http_request_add_header(
     struct evpl_http_request *request,
     const char               *name,
     const char               *value)
 {
-    struct evpl_http_conn           *conn = request->conn;
-    struct evpl_http_request_header *header;
-
-    header = evpl_http_request_header_alloc(conn->agent);
-
-    strncpy(header->name, name, sizeof(header->name) - 1);
-    strncpy(header->value, value, sizeof(header->value) - 1);
-
-    if (conn->is_server) {
-        DL_APPEND(request->response_headers, header);
-    } else {
-        DL_APPEND(request->request_headers, header);
-    }
-
-
+    return evpl_http_request_add_header_common(request, name, value, 1);
 } /* evpl_http_request_add_header */
 
 SYMBOL_EXPORT void
@@ -1407,7 +1576,7 @@ evpl_http_server_dispatch_default(
     }
 #endif /* ifdef HAVE_NGHTTP2 */
 
-    evpl_http_request_add_header(request, "Connection", "keep-alive");
+    evpl_http_request_add_header_common(request, "Connection", "keep-alive", 0);
 
     evpl_defer(evpl, &conn->flush);
 } /* evpl_http_server_complete_request */

--- a/src/http/http_internal.h
+++ b/src/http/http_internal.h
@@ -91,6 +91,14 @@ struct evpl_http_request {
     uint64_t                                 request_flags;
     int                                      status;
     int                                      uri_len;
+
+    /* Wire bytes of the header block accumulated so far, counted against
+     * agent->max_header_size.  Repurposed per direction: while parsing
+     * inbound headers it tracks received header-line bytes (reset when the
+     * block completes); for the outbound block it is seeded with the
+     * request line at create time (client) or 0 (server response) and
+     * grows as headers are added. */
+    unsigned int                             header_bytes;
     struct evpl_http_conn                   *conn;
     struct evpl_iovec_ring                   send_ring;
     struct evpl_iovec_ring                   recv_ring;
@@ -135,6 +143,7 @@ struct evpl_http_agent {
     struct evpl_http_request_header *free_headers;
     struct evpl_http_conn           *conns; /* live connections; see conn */
     struct evpl                     *evpl;
+    unsigned int                     max_header_size;
 };
 
 static inline struct evpl_http_request_header *
@@ -189,6 +198,7 @@ evpl_http_request_alloc(struct evpl_http_agent *agent)
     request->request_flags              = 0;
     request->status                     = 0;
     request->uri_len                    = 0;
+    request->header_bytes               = 0;
     request->notify_callback            = NULL;
     request->notify_data                = NULL;
     request->request_headers            = NULL;

--- a/src/http/tests/CMakeLists.txt
+++ b/src/http/tests/CMakeLists.txt
@@ -12,6 +12,12 @@ target_link_libraries(http_chunked evpl_http curl)
 unit_test(http client http1_client.c)
 target_link_libraries(http_client evpl_http)
 
+# Configurable header block limit (http_max_header_size): outbound refusal
+# via evpl_http_request_add_header, server-side 400 on an oversized inbound
+# request block, client-side disconnect on an oversized response block.
+unit_test(http max_headers http_max_headers.c)
+target_link_libraries(http_max_headers evpl_http)
+
 if (HAVE_NGHTTP2)
     # evpl HTTP/2 client <-> evpl server (h2c prior-knowledge, and h2 over TLS)
     unit_test(http h2_client http2_client.c)

--- a/src/http/tests/http_max_headers.c
+++ b/src/http/tests/http_max_headers.c
@@ -1,0 +1,534 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Exercises the configurable HTTP header block limit (http_max_header_size,
+ * default 8192) in all four places it is enforced:
+ *
+ * 1. Outbound, both directions: evpl_http_request_add_header() refuses (-1)
+ *    headers that would push the block past the limit, and the exchange
+ *    still completes cleanly with the headers that fit.  Before the limit
+ *    existed, emission built the block in a fixed 4096-byte iovec with
+ *    unchecked snprintf cursor arithmetic, so an oversized block corrupted
+ *    the heap.
+ *
+ * 2. Inbound at the server: a raw client sending more than the limit worth
+ *    of request headers is answered with 400 Bad Request and disconnected,
+ *    as Apache does when its LimitRequestField* limits are exceeded.
+ *
+ * 3. Inbound at the client: a raw server sending more than the limit worth
+ *    of response headers gets the connection closed; previously each parsed
+ *    header pinned a ~16KB struct with no bound on the count.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+
+#define TEST_PORT            8091
+#define RAW_SERVER_PORT      8093
+
+#define BIG_HEADER_VALUE_LEN 150
+#define MAX_ADD_ATTEMPTS     200
+
+static const char   response_body[] = "hello world";
+
+static char         big_value[BIG_HEADER_VALUE_LEN + 1];
+
+/* written by the server thread, read by main after the exchange completes */
+static volatile int g_server_hdrs_added;
+static volatile int g_server_hdrs_refused;
+
+/* ------------------------------------------------------------- evpl server */
+
+struct test_server {
+    pthread_t            thread;
+    volatile int         run;
+    struct evpl_doorbell doorbell;
+};
+
+static void
+server_wake(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+} /* server_wake */
+
+static void
+server_notify(
+    struct evpl                *evpl,
+    struct evpl_http_agent     *agent,
+    struct evpl_http_request   *request,
+    enum evpl_http_notify_type  notify_type,
+    enum evpl_http_request_type request_type,
+    const char                 *uri,
+    void                       *notify_data,
+    void                       *private_data)
+{
+    struct evpl_iovec iov;
+    char              name[32];
+    int               i;
+
+    switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
+            /* Attach far more response header bytes than the limit allows;
+             * the surplus must be refused, not truncated on the wire. */
+            for (i = 0; i < MAX_ADD_ATTEMPTS; i++) {
+                snprintf(name, sizeof(name), "X-Meta-%d", i);
+                if (evpl_http_request_add_header(request, name, big_value) == 0) {
+                    g_server_hdrs_added++;
+                } else {
+                    g_server_hdrs_refused++;
+                }
+            }
+
+            evpl_iovec_alloc(evpl, sizeof(response_body) - 1, 0, 1, 0, &iov);
+            memcpy(iov.data, response_body, sizeof(response_body) - 1);
+            iov.length = sizeof(response_body) - 1;
+            evpl_http_server_set_response_length(request, sizeof(response_body) - 1);
+            evpl_http_request_add_datav(request, &iov, 1);
+            evpl_http_server_dispatch_default(request, 200);
+            break;
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+        case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
+            break;
+    } /* switch */
+} /* server_notify */
+
+static void
+server_dispatch(
+    struct evpl                 *evpl,
+    struct evpl_http_agent      *agent,
+    struct evpl_http_request    *request,
+    evpl_http_notify_callback_t *notify_callback,
+    void                       **notify_data,
+    void                        *private_data)
+{
+    *notify_callback = server_notify;
+    *notify_data     = NULL;
+} /* server_dispatch */
+
+static void *
+server_function(void *ptr)
+{
+    struct test_server      *server_ctx = ptr;
+    struct evpl_http_server *server;
+    struct evpl             *evpl;
+    struct evpl_endpoint    *endpoint;
+    struct evpl_listener    *listener;
+    struct evpl_http_agent  *agent;
+
+    evpl = evpl_create(NULL);
+
+    evpl_add_doorbell(evpl, &server_ctx->doorbell, server_wake);
+
+    agent = evpl_http_init(evpl);
+
+    endpoint = evpl_endpoint_create("0.0.0.0", TEST_PORT);
+
+    listener = evpl_listener_create();
+
+    server = evpl_http_attach(agent, listener, server_dispatch, NULL);
+
+    evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint);
+
+    __sync_synchronize();
+
+    server_ctx->run = 1;
+
+    while (server_ctx->run) {
+        evpl_continue(evpl);
+    }
+
+    evpl_http_server_destroy(agent, server);
+    evpl_http_destroy(agent);
+
+    evpl_listener_destroy(listener);
+    evpl_destroy(evpl);
+
+    return NULL;
+} /* server_function */
+
+/* ------------------------------------------------------------- evpl client */
+
+struct req_ctx {
+    int  done;
+    int  status;
+    int  body_len;
+    char body[256];
+};
+
+static void
+client_drain(
+    struct evpl              *evpl,
+    struct evpl_http_request *request,
+    struct req_ctx           *rc)
+{
+    struct evpl_iovec iov[8];
+    uint64_t          avail;
+    int               niov, i;
+
+    avail = evpl_http_request_get_data_avail(request);
+
+    while (avail > 0) {
+        niov = evpl_http_request_get_datav(evpl, request, iov, (int) avail);
+
+        for (i = 0; i < niov; i++) {
+            memcpy(rc->body + rc->body_len, iov[i].data, iov[i].length);
+            rc->body_len += iov[i].length;
+            evpl_iovec_release(evpl, &iov[i]);
+        }
+
+        avail = evpl_http_request_get_data_avail(request);
+    }
+} /* client_drain */
+
+static void
+client_notify(
+    struct evpl                *evpl,
+    struct evpl_http_agent     *agent,
+    struct evpl_http_request   *request,
+    enum evpl_http_notify_type  notify_type,
+    enum evpl_http_request_type request_type,
+    const char                 *uri,
+    void                       *notify_data,
+    void                       *private_data)
+{
+    struct req_ctx *rc = notify_data;
+
+    switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+            rc->status = evpl_http_request_status(request);
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+            client_drain(evpl, request, rc);
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
+            client_drain(evpl, request, rc);
+            rc->done = 1;
+            break;
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+        case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
+            break;
+    } /* switch */
+} /* client_notify */
+
+/*
+ * Part 1: attach an oversized set of headers on the request, check the
+ * surplus is refused, and check the exchange (whose response block is
+ * likewise refused down to fit) completes cleanly.
+ */
+static int
+test_outbound_limits(
+    struct evpl           *evpl,
+    struct evpl_http_conn *conn)
+{
+    struct evpl_http_request *request;
+    struct req_ctx            rc;
+    char                      name[32];
+    int                       i, added = 0, refused = 0;
+
+    memset(&rc, 0, sizeof(rc));
+
+    request = evpl_http_request_create(conn, EVPL_HTTP_REQUEST_TYPE_GET, "/");
+
+    if (!request) {
+        fprintf(stderr, "outbound: request_create failed\n");
+        return 1;
+    }
+
+    evpl_http_request_add_header(request, "Host", "localhost");
+
+    for (i = 0; i < MAX_ADD_ATTEMPTS; i++) {
+        snprintf(name, sizeof(name), "X-Req-Meta-%d", i);
+        if (evpl_http_request_add_header(request, name, big_value) == 0) {
+            added++;
+        } else {
+            refused++;
+        }
+    }
+
+    if (refused == 0 || added == 0) {
+        fprintf(stderr, "outbound: expected both accepted and refused "
+                "request headers (added %d, refused %d)\n", added, refused);
+        return 1;
+    }
+
+    evpl_http_client_set_request_length(request, 0);
+
+    evpl_http_request_dispatch(request, client_notify, &rc);
+
+    while (!rc.done) {
+        evpl_continue(evpl);
+    }
+
+    if (rc.status != 200) {
+        fprintf(stderr, "outbound: bad status %d\n", rc.status);
+        return 1;
+    }
+
+    if (rc.body_len != (int) (sizeof(response_body) - 1) ||
+        memcmp(rc.body, response_body, rc.body_len) != 0) {
+        fprintf(stderr, "outbound: bad body '%.*s' (%d bytes)\n",
+                rc.body_len, rc.body, rc.body_len);
+        return 1;
+    }
+
+    if (g_server_hdrs_refused == 0 || g_server_hdrs_added == 0) {
+        fprintf(stderr, "outbound: expected both accepted and refused "
+                "response headers (added %d, refused %d)\n",
+                g_server_hdrs_added, g_server_hdrs_refused);
+        return 1;
+    }
+
+    fprintf(stderr, "outbound: ok (request %d/%d added, response %d/%d added)\n",
+            added, added + refused,
+            g_server_hdrs_added, g_server_hdrs_added + g_server_hdrs_refused);
+
+    return 0;
+} /* test_outbound_limits */
+
+/*
+ * Part 2: a raw client sends a request whose header block exceeds the
+ * limit and must get 400 Bad Request back, then EOF.
+ */
+static int
+test_inbound_server_limit(void)
+{
+    struct sockaddr_in addr;
+    char               buf[65536];
+    char               reply[256];
+    int                fd, off = 0, n, got = 0;
+    int                i;
+
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family      = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port        = htons(TEST_PORT);
+
+    if (connect(fd, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+        perror("inbound-server: connect");
+        return 1;
+    }
+
+    off += snprintf(buf + off, sizeof(buf) - off,
+                    "GET / HTTP/1.1\r\nHost: localhost\r\n");
+
+    /* ~64 lines x ~166 bytes: comfortably past the 8192 default */
+    for (i = 0; i < 64; i++) {
+        off += snprintf(buf + off, sizeof(buf) - off,
+                        "X-Big-%d: %s\r\n", i, big_value);
+    }
+
+    if (write(fd, buf, off) != off) {
+        perror("inbound-server: write");
+        close(fd);
+        return 1;
+    }
+
+    while (got < (int) sizeof(reply) - 1) {
+        n = read(fd, reply + got, sizeof(reply) - 1 - got);
+        if (n <= 0) {
+            break;
+        }
+        got += n;
+    }
+    reply[got] = '\0';
+
+    close(fd);
+
+    if (strncmp(reply, "HTTP/1.1 400 ", 13) != 0) {
+        fprintf(stderr, "inbound-server: expected 400, got '%.40s'\n", reply);
+        return 1;
+    }
+
+    fprintf(stderr, "inbound-server: ok (got 400 Bad Request)\n");
+
+    return 0;
+} /* test_inbound_server_limit */
+
+/* --------------------------------------------------------------- raw server */
+
+/*
+ * Part 3's peer: accept one connection, read the request, answer with more
+ * response header bytes than the limit allows, then close.
+ */
+static void *
+raw_server_function(void *ptr)
+{
+    struct sockaddr_in addr;
+    char               buf[65536];
+    int                lfd, cfd, off = 0, i, one = 1;
+    ssize_t            n;
+
+    lfd = socket(AF_INET, SOCK_STREAM, 0);
+    setsockopt(lfd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family      = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port        = htons(RAW_SERVER_PORT);
+
+    if (bind(lfd, (struct sockaddr *) &addr, sizeof(addr)) < 0 ||
+        listen(lfd, 1) < 0) {
+        perror("raw-server: bind/listen");
+        exit(2);
+    }
+
+    cfd = accept(lfd, NULL, NULL);
+
+    n = read(cfd, buf, sizeof(buf));
+    (void) n;
+
+    off += snprintf(buf + off, sizeof(buf) - off, "HTTP/1.1 200 OK\r\n");
+
+    for (i = 0; i < 80; i++) {
+        off += snprintf(buf + off, sizeof(buf) - off,
+                        "X-Resp-%d: %s\r\n", i, big_value);
+    }
+
+    /* the client is expected to hang up mid-block; ignore the short write */
+    n = write(cfd, buf, off);
+    (void) n;
+
+    usleep(200000);
+    close(cfd);
+    close(lfd);
+
+    return NULL;
+} /* raw_server_function */
+
+/*
+ * Part 3: the evpl client must abandon a response whose header block
+ * exceeds the limit by closing the connection, without completing the
+ * request and without corrupting anything (the debug build's ASan checks
+ * the teardown path).
+ */
+static int
+test_inbound_client_limit(struct evpl *evpl)
+{
+    pthread_t                 raw_thread;
+    struct evpl_http_agent   *agent;
+    struct evpl_endpoint     *endpoint;
+    struct evpl_http_conn    *conn;
+    struct evpl_http_request *request;
+    struct req_ctx            rc;
+    int                       i;
+
+    memset(&rc, 0, sizeof(rc));
+
+    pthread_create(&raw_thread, NULL, raw_server_function, NULL);
+    usleep(100000); /* let the raw server reach accept() */
+
+    agent = evpl_http_init(evpl);
+
+    endpoint = evpl_endpoint_create("127.0.0.1", RAW_SERVER_PORT);
+
+    conn = evpl_http_client_connect(agent, EVPL_STREAM_SOCKET_TCP, endpoint,
+                                    EVPL_HTTP_VERSION_HTTP1, NULL);
+
+    request = evpl_http_request_create(conn, EVPL_HTTP_REQUEST_TYPE_GET, "/");
+
+    evpl_http_request_add_header(request, "Host", "localhost");
+    evpl_http_client_set_request_length(request, 0);
+    evpl_http_request_dispatch(request, client_notify, &rc);
+
+    /* pump long enough (bounded, wait_ms below caps each pass) to send the
+     * request, hit the limit mid-parse, and tear the connection down */
+    for (i = 0; i < 300 && !rc.done; i++) {
+        evpl_continue(evpl);
+    }
+
+    pthread_join(raw_thread, NULL);
+
+    evpl_http_destroy(agent);
+
+    if (rc.done) {
+        fprintf(stderr, "inbound-client: oversized response unexpectedly "
+                "completed (status %d)\n", rc.status);
+        return 1;
+    }
+
+    fprintf(stderr, "inbound-client: ok (connection abandoned)\n");
+
+    return 0;
+} /* test_inbound_client_limit */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct test_server         server;
+    struct evpl               *evpl;
+    struct evpl_http_agent    *agent;
+    struct evpl_endpoint      *endpoint;
+    struct evpl_http_conn     *conn;
+    struct evpl_thread_config *tconfig;
+    int                        rc = 0;
+
+    /* the raw peers close mid-conversation; a late write must not kill us */
+    signal(SIGPIPE, SIG_IGN);
+
+    memset(big_value, 'A', BIG_HEADER_VALUE_LEN);
+    big_value[BIG_HEADER_VALUE_LEN] = '\0';
+
+    evpl_init(NULL);
+
+    server.run = 0;
+
+    pthread_create(&server.thread, NULL, server_function, &server);
+
+    while (!server.run) {
+        __sync_synchronize();
+    }
+
+    /* bound event waits so the part-3 pump loop keeps ticking when idle */
+    tconfig = evpl_thread_config_init();
+    evpl_thread_config_set_wait_ms(tconfig, 10);
+    evpl = evpl_create(tconfig);
+
+    agent = evpl_http_init(evpl);
+
+    endpoint = evpl_endpoint_create("127.0.0.1", TEST_PORT);
+
+    conn = evpl_http_client_connect(agent, EVPL_STREAM_SOCKET_TCP, endpoint,
+                                    EVPL_HTTP_VERSION_HTTP1, NULL);
+
+    rc |= test_outbound_limits(evpl, conn);
+
+    evpl_http_client_close(agent, conn);
+
+    rc |= test_inbound_server_limit();
+
+    rc |= test_inbound_client_limit(evpl);
+
+    evpl_http_destroy(agent);
+    evpl_destroy(evpl);
+
+    server.run = 0;
+    __sync_synchronize();
+    evpl_ring_doorbell(&server.doorbell);
+    pthread_join(server.thread, NULL);
+
+    if (rc == 0) {
+        fprintf(stderr, "all header limit checks ok\n");
+    }
+
+    return rc;
+} /* main */


### PR DESCRIPTION
The HTTP/1.x paths had no bound on header volume in either direction:

- **Outbound**, `evpl_http_server_send_headers()` / `evpl_http_client_send_headers()` built the entire header block into a fixed 4096-byte iovec with unchecked snprintf cursor arithmetic. Once the cumulative block exceeded 4096 bytes, `4096 - (rsp - rsp_base)` went negative, wrapped to a huge `size_t`, and the next header line was written past the end of the allocation — heap corruption reachable on the server by any client whose request produces enough response headers (e.g. an S3 GET re-emitting large stored `x-amz-meta-*` values).
- **Inbound**, header lines were parsed with a per-line cap but no limit on count, so a peer could stream tiny header lines indefinitely, pinning a ~16KB `evpl_http_request_header` per ~6 wire bytes.

This adds `http_max_header_size` to the global config (default 8192, in line with Apache's request field limits), bounding the whole header block — request/status line, header lines, and terminator — in both directions:

- **Send side:** `evpl_http_request_add_header()` now returns an error instead of accepting a header that cannot fit, accounted per line at add time against the limit less a fixed reserve covering the status/request line, `Content-Length`/`Transfer-Encoding`, the internal `Connection` header, and the terminator. `evpl_http_request_create()` returns NULL if the request line alone cannot fit. Emission allocates the limit-sized iovec and writes through a saturating append helper, with an abort backstop should the accounting ever disagree — an oversized block can no longer be emitted, truncated or otherwise.
- **Receive side:** both parsers count received header-line bytes against the limit. A server answers an oversized request block (or a single line overflowing the parser) with `400 Bad Request` + `Connection: close`, matching Apache's `LimitRequestField*` behavior; a client abandons an oversized response block by closing the connection.

The new `http_max_headers` test covers all of the above: add_header refusal on both sides with the exchange still completing cleanly, the 400 for a raw oversized request, and the disconnect of a raw server sending an oversized response.

Two supporting commits ride along:

- The fix from #117 is included as its own commit (original authorship preserved): the new client-side close-on-oversized-response path frees the in-flight request through the disconnect handler, which double-frees without it. If #117 merges first, this branch merges cleanly on top.
- `unit_test()` now sets a 60-second ctest `TIMEOUT` so a deadlocked test fails in a minute instead of holding CI for the 1500-second default.

Supersedes #114, which stopped the outbound overflow by silently truncating the header block — the truncated block loses the `Content-Length` line and terminating blank line (plus a trailing NUL and partial header line), so the peer can never finish parsing it and both sides deadlock; its own regression test hangs. Explicit refusal at `add_header()` time keeps the wire output well-formed instead.
