### PR TITLE
Bump xdrzcc: brace the void-reply dispatch case body

### DIFF
--- a/src/rpc2/tests/hello_world.x
+++ b/src/rpc2/tests/hello_world.x
@@ -12,5 +12,8 @@ struct Hello {
 program HELLO_PROGRAM {
     version HELLO_V1 {
         Hello GREET(Hello) = 1;
+        /* Never called by the tests; declared so the generated void-reply
+         * dispatch branch is compiled by CI, which no other test .x covers. */
+        void  NOOP(void)   = 2;
     } = 1;
 } = 42;


### PR DESCRIPTION
Bumps ext/xdrzcc to pick up chimera-nas/xdrzcc#17, which fixes the reply dispatch emitting the void-reply callback declaration directly after its `case` label. That is a C23 feature; the Apple clang on the GitHub macOS runners rejects it with `expected expression`, which broke the macOS Debug/Release jobs in chimera's merge queue for chimera-nas/chimera#1513 on every generated `*_xdr.c` with a void-reply procedure (portmap, mount, nfs3, nlm4).

This repo's macOS CI never caught it because no test `.x` declares a void-reply procedure, so the generated void-reply dispatch branch was never compiled here (the synthesized RFC 5531 NULL procedure only appears in the call dispatch, which was already braced). The second commit declares a never-called `NOOP(void)` procedure in `hello_world.x` so the macOS jobs compile that branch from now on — without the xdrzcc bump, that commit alone would fail the macOS jobs.

Verified locally on an arm64 Mac: full native build succeeds, the generated `hello_world_xdr.c` now contains the braced void-reply dispatch, and the hello_world/multifrag/conformance_client tests pass (34/34). Generated output for the existing test programs is byte-identical between the old and new xdrzcc pins, since none of them declared a void-reply procedure before this change.