### PR TITLE
http tests: check socket/accept returns in http_max_headers

### DIFF
--- a/src/http/tests/http_max_headers.c
+++ b/src/http/tests/http_max_headers.c
@@ -315,6 +315,10 @@ test_inbound_server_limit(void)
     int                i;
 
     fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        perror("inbound-server: socket");
+        return 1;
+    }
 
     memset(&addr, 0, sizeof(addr));
     addr.sin_family      = AF_INET;
@@ -377,6 +381,10 @@ raw_server_function(void *ptr)
     ssize_t            n;
 
     lfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (lfd < 0) {
+        perror("raw-server: socket");
+        exit(2);
+    }
     setsockopt(lfd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
 
     memset(&addr, 0, sizeof(addr));
@@ -391,6 +399,10 @@ raw_server_function(void *ptr)
     }
 
     cfd = accept(lfd, NULL, NULL);
+    if (cfd < 0) {
+        perror("raw-server: accept");
+        exit(2);
+    }
 
     n = read(cfd, buf, sizeof(buf));
     (void) n;


### PR DESCRIPTION
chimera's Analyze (scan-build) jobs fail on this test since the libevpl bump in chimera-nas/chimera#1513 pulled it in: the `unix.StdCLibraryFunctions` checker flags the paths where `socket()` returns -1 and the fd flows unchecked into `connect()` (line 324) / `bind()` (line 387). This repo's scan-build job doesn't enable that checker, which is why #130 merged green here.

Check the `socket()` returns in both spots, and the `accept()` return as well — running clang's analyzer with that checker locally reports three findings (the third being `read(cfd)` on the `accept() == -1` path), so fixing only the two CI reported would just uncover the third on the next chimera run. Three findings before, zero after; all 8 http tests still pass.