### PR TITLE
libaio: grow the staging array instead of aborting when it fills

### DIFF
--- a/src/core/libaio/libaio.c
+++ b/src/core/libaio/libaio.c
@@ -198,8 +198,9 @@ evpl_libaio_create(
 
     ctx = evpl_zalloc(sizeof(*ctx));
 
-    ctx->max_pending   = evpl_shared->config->libaio_max_pending;
-    ctx->pending_iocbs = evpl_zalloc(ctx->max_pending * sizeof(struct iocb *));
+    ctx->max_pending      = evpl_shared->config->libaio_max_pending;
+    ctx->pending_capacity = ctx->max_pending;
+    ctx->pending_iocbs    = evpl_zalloc(ctx->pending_capacity * sizeof(struct iocb *));
 
     memset(&ctx->io_ctx, 0, sizeof(ctx->io_ctx));
 

--- a/src/core/libaio/libaio_block.c
+++ b/src/core/libaio/libaio_block.c
@@ -65,11 +65,7 @@ evpl_libaio_read(
     io_set_eventfd(&req->iocb, ctx->eventfd);
     req->iocb.data = req;
 
-    evpl_libaio_abort_if(ctx->num_pending >= ctx->max_pending, "too many pending iocbs");
-
-    ctx->pending_iocbs[ctx->num_pending++] = &req->iocb;
-
-    evpl_defer(evpl, &ctx->flush);
+    evpl_libaio_enqueue(evpl, ctx, req);
 } /* evpl_libaio_read */
 
 static void
@@ -130,11 +126,7 @@ evpl_libaio_write(
     io_set_eventfd(&req->iocb, ctx->eventfd);
     req->iocb.data = req;
 
-    evpl_libaio_abort_if(ctx->num_pending >= ctx->max_pending, "too many pending iocbs");
-
-    ctx->pending_iocbs[ctx->num_pending++] = &req->iocb;
-
-    evpl_defer(evpl, &ctx->flush);
+    evpl_libaio_enqueue(evpl, ctx, req);
 } /* evpl_libaio_write */
 
 static void
@@ -158,11 +150,7 @@ evpl_libaio_flush(
     io_set_eventfd(&req->iocb, ctx->eventfd);
     req->iocb.data = req;
 
-    evpl_libaio_abort_if(ctx->num_pending >= ctx->max_pending, "too many pending iocbs");
-
-    ctx->pending_iocbs[ctx->num_pending++] = &req->iocb;
-
-    evpl_defer(evpl, &ctx->flush);
+    evpl_libaio_enqueue(evpl, ctx, req);
 } /* evpl_libaio_flush */
 
 static void

--- a/src/core/libaio/libaio_internal.h
+++ b/src/core/libaio/libaio_internal.h
@@ -50,7 +50,8 @@ struct evpl_libaio_context {
     struct evpl_deferral        flush;
     struct evpl_libaio_request *free_requests;
     struct iocb               **pending_iocbs;
-    int                         max_pending;
+    int                         max_pending;      /* aio ring depth (io_setup nr_events) */
+    int                         pending_capacity; /* allocated slots in pending_iocbs */
     int                         num_pending;
     struct evpl_poll           *poll;
 };
@@ -85,3 +86,38 @@ evpl_libaio_request_free(
 {
     LL_PREPEND(ctx->free_requests, req);
 } /* evpl_libaio_request_free */
+
+/*
+ * Stage an iocb for the next deferred io_submit().
+ *
+ * The staging array is not the ring.  evpl_defer() only arms the flush, so
+ * nothing submits or completes until the current callback chain returns: a
+ * caller that issues a batch in one event-loop iteration stages all of it
+ * first.  Callers legitimately exceed the ring depth doing so -- diskfs' tail
+ * pusher caps home writes per device, so its in-flight budget is (per-device
+ * cap x device count) -- which makes a full staging array ordinary
+ * backpressure rather than a caller error.
+ *
+ * Grow instead of failing, and let evpl_libaio_flush_submit() feed the ring at
+ * its own depth.  Draining is already handled: a short or -EAGAIN io_submit()
+ * keeps its unsubmitted tail queued, and evpl_libaio_complete() re-arms this
+ * deferral after any completion batch, so the surplus always goes out.
+ */
+static inline void
+evpl_libaio_enqueue(
+    struct evpl                *evpl,
+    struct evpl_libaio_context *ctx,
+    struct evpl_libaio_request *req)
+{
+    if (ctx->num_pending == ctx->pending_capacity) {
+        ctx->pending_capacity *= 2;
+
+        ctx->pending_iocbs = evpl_realloc(ctx->pending_iocbs,
+                                          ctx->pending_capacity *
+                                          sizeof(struct iocb *));
+    }
+
+    ctx->pending_iocbs[ctx->num_pending++] = &req->iocb;
+
+    evpl_defer(evpl, &ctx->flush);
+} /* evpl_libaio_enqueue */

--- a/src/core/libaio/tests/CMakeLists.txt
+++ b/src/core/libaio/tests/CMakeLists.txt
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 
 unit_test(libaio basic basic.c)
+unit_test(libaio burst burst.c)

--- a/src/core/libaio/tests/burst.c
+++ b/src/core/libaio/tests/burst.c
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Stage more block writes in one event-loop iteration than the aio ring holds.
+ *
+ * Deferrals only arm; the flush callback does not run until the current
+ * callback chain returns.  Every write issued in the loop below is therefore
+ * staged before a single io_submit() happens, so the staging array must absorb
+ * the whole burst regardless of the ring depth.  Callers reach this shape
+ * routinely -- diskfs' tail pusher gates its home writes per device, so its
+ * total in-flight budget is (per-device cap x device count), well above the
+ * ring -- and a full staging array is ordinary backpressure, not an error.
+ *
+ * The ring is deliberately set far smaller than the burst so submission is
+ * forced to make partial progress and drain via completions.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_config.h"
+
+#define BURST_RING   32     /* aio ring depth (io_setup nr_events) */
+#define BURST_WRITES 512    /* iocbs staged before anything submits */
+
+static void
+write_callback(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    int *pending = private_data;
+
+    (void) evpl;
+
+    if (status) {
+        fprintf(stderr, "burst write failed: %d\n", status);
+        exit(1);
+    }
+
+    (*pending)--;
+
+} /* write_callback */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct evpl_global_config *config;
+    struct evpl               *evpl;
+    struct evpl_block_device  *bdev;
+    struct evpl_block_queue   *bqueue;
+    struct evpl_iovec          iov;
+    int                        fd, rc, i, niov;
+    int                        pending = 0;
+
+    (void) argc;
+    (void) argv;
+
+    fd = open("burst.img", O_RDWR | O_CREAT, 0666);
+
+    if (fd < 0) {
+        perror("open");
+        exit(1);
+    }
+
+    rc = ftruncate(fd, (off_t) BURST_WRITES * 4096);
+
+    if (rc < 0) {
+        perror("ftruncate");
+        exit(1);
+    }
+
+    close(fd);
+
+    config = evpl_global_config_init();
+
+    evpl_global_config_set_libaio_max_pending(config, BURST_RING);
+
+    evpl_init(config);
+
+    evpl = evpl_create(NULL);
+
+    bdev = evpl_block_open_device(EVPL_BLOCK_PROTOCOL_LIBAIO, "burst.img");
+
+    if (!bdev) {
+        fprintf(stderr, "failed to open burst.img\n");
+        exit(1);
+    }
+
+    bqueue = evpl_block_open_queue(evpl, bdev);
+
+    niov = evpl_iovec_alloc(evpl, 4096, 4096, 1, 0, &iov);
+
+    /* No evpl_continue() in this loop: nothing submits or completes until it
+     * returns, so all BURST_WRITES iocbs pile into the staging array at once. */
+    for (i = 0; i < BURST_WRITES; i++) {
+        pending++;
+        evpl_block_write(evpl, bqueue, &iov, niov, (uint64_t) i * 4096, 0,
+                         write_callback, &pending);
+    }
+
+    while (pending) {
+        evpl_continue(evpl);
+    }
+
+    evpl_iovec_release(evpl, &iov);
+
+    evpl_block_close_queue(evpl, bqueue);
+
+    evpl_block_close_device(bdev);
+
+    evpl_destroy(evpl);
+
+    unlink("burst.img");
+
+    return 0;
+} /* main */


### PR DESCRIPTION
## Summary

`evpl_libaio_read/write/flush` staged each iocb into a fixed `pending_iocbs` array and killed the process once it filled:

```c
evpl_libaio_abort_if(ctx->num_pending >= ctx->max_pending, "too many pending iocbs");
```

That treats a full submission queue as a caller bug, but it is ordinary backpressure. This PR grows the array instead, and adds a regression test that reproduces the abort deterministically.

## Why the array fills

`evpl_defer()` only *arms* the flush — the callback does not run until the current callback chain returns (`evpl.c`, deferrals are drained at the top of the loop). So a caller that issues a batch inside one event-loop iteration stages **all** of it before a single `io_submit()` happens. Nothing drains in between.

The array is sized to `libaio_max_pending` (256 by default), which is the **ring** depth passed to `io_setup()` — not a bound on what a caller may hand us in one pass. Callers exceed it legitimately. In chimera's diskfs there are at least two independent paths that can:

- The tail-push thread caps home writes *per device* (`DISKFS_PUSH_DEV_WATERMARK`, 64), so its in-flight budget is 64 × device count — 640 across the ten devices its test harness configures.
- The commit thread's gate is checked once *per batch* rather than per write: `diskfs_iq_process_batch()` returns early only if `redo_inflight >= DISKFS_COMMIT_WATERMARK` (256) on entry, then admits a batch whose records each issue several chunk writes. Overshoot past the watermark is expected there by design — the adjacent retire ring is sized `1024 /* >= DISKFS_COMMIT_WATERMARK */`.

Either way the caller's ceiling is above 256 while the staging array is exactly 256, and the process dies on the 257th iocb staged in a single pass.

This is the intermittent `"too many pending iocbs"` abort in chimera CI (`chimera/posix/diskfs_evict_diskfs_aio`, ~1–5 s into a ~60 s test). It is libaio-only because the io_uring backend's ring defaults to 8192 — 32× deeper — so the same burst fits. The io_uring backend has the same shape of hard failure at its own limit (`evpl_io_uring_abort_if(!sqe, ...)`); only the depth differs.

## The change

- `max_pending` keeps its real meaning — the `io_setup()` `nr_events` ring depth. A new `pending_capacity` tracks allocated staging slots and doubles on demand. `evpl_realloc()` already fatals on OOM like the rest of the allocator API, so there is no new error path.
- The three copies of the stage-and-defer sequence collapse into one `evpl_libaio_enqueue()` helper.
- Draining needed no new machinery: a short or `-EAGAIN` `io_submit()` already keeps its unsubmitted tail queued, and `evpl_libaio_complete()` re-arms the flush after any completion batch, so the surplus goes out as ring slots free up.

Growth is bounded in practice by whatever in-flight cap the caller enforces, and the array holds one pointer per staged iocb — 640 entries is ~5 KB.

## Verification

ubuntu24 / aarch64, Release, libaio via `/usr/lib/aarch64-linux-gnu/libaio.so`.

**New test `libevpl/libaio/burst`** sets the ring to 32 and stages 512 writes in one event-loop iteration, forcing submission to make partial progress and drain through completions:

| | result |
|---|---|
| before this change | `"too many pending iocbs"` at `libaio_block.c:133`, SIGABRT (rc=134) |
| after this change | passes, all 512 completions delivered (5/5 runs) |

`libevpl/libaio/basic` passes in both builds, so the abort is specific to the burst shape.

**Full suite on a clean build of this branch: 162/162 pass.**

## Note on the chimera-side reproduction

The end-to-end `diskfs_evict_diskfs_aio` failure did **not** reproduce on my box, and it is worth saying so rather than claiming more than was shown. With the staging high-water mark instrumented, the observed peaks were:

| condition | max staged |
|---|---|
| single run, devices on tmpfs | 40 |
| 4 concurrent runs, devices on tmpfs | 59 |
| 4 concurrent runs, devices on disk | 41 |

All far below 256, and the test passes every time. Burst depth is a function of how long writes stay outstanding, and this box completes them too quickly for in-flight to accumulate toward either caller ceiling — consistent with the CI failure being Release-heavy (10 of 11 tracker events), since it takes an optimized build plus real device latency to hold 257+ writes outstanding. Reproducing it faithfully likely needs CI's degree of oversubscription, where the issuing thread is descheduled while other threads keep feeding its queue.

So what is demonstrated here is the mechanism and the fix, on the exact abort site, message and line seen in CI. The chimera-side attribution above is read off the caller's own constants and corroborated by the CI signature being libaio-only and never io_uring — it is not something I reproduced end to end, and the two candidate paths are not distinguished by the evidence I have.

Separately, chimera should probably not offer a backend more concurrent I/O than its submission path is configured for — a global in-flight ceiling derived from a queryable backend depth rather than constants maintained in parallel on both sides. That belongs in a chimera PR, not here; this change makes the backend correct regardless of what the caller offers.
