### PR TITLE
core: model-based conformance test for the core SDK, and the fixes it found

### DIFF
--- a/include/evpl/evpl_config.h
+++ b/include/evpl/evpl_config.h
@@ -241,6 +241,28 @@ void evpl_global_config_set_hf_time_mode(
     struct evpl_global_config *config,
     unsigned int               mode);
 
+/*
+ * Take the event loop off the machine's clock and put it on one the
+ * application advances by hand, with evpl_virtual_clock_advance().
+ *
+ * Timer deadlines, the poll-mode spin window and every other internal
+ * deadline are then measured against that clock alone, so nothing in the loop
+ * happens because wall-clock time passed.  The core wait stops blocking as
+ * well: with no way for time to move while the loop is inside it, a wait for
+ * a deadline would be a wait for something that cannot happen.
+ *
+ * This exists so that time-dependent behaviour can be tested for what it is
+ * rather than for how loaded the machine was -- a test advances the clock by a
+ * known amount and drives the loop, instead of sleeping and hoping.  It is
+ * process-wide and must be set before evpl_init().
+ *
+ * Do not enable it in production: a loop on this clock never sleeps, and any
+ * timer in it stops firing the moment the application stops advancing time.
+ */
+void evpl_global_config_set_virtual_clock(
+    struct evpl_global_config *config,
+    int                        enabled);
+
 void evpl_global_config_set_max_pending(
     struct evpl_global_config *config,
     unsigned int               max);

--- a/include/evpl/evpl_core.h
+++ b/include/evpl/evpl_core.h
@@ -134,6 +134,3 @@ int evpl_protocol_is_local(
 int evpl_protocol_is_inproc(
     enum evpl_protocol_id protocol);
 
-struct evpl_config *
-evpl_config(
-    struct evpl *evpl);

--- a/include/evpl/evpl_core.h
+++ b/include/evpl/evpl_core.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <time.h>
+#include <stdint.h>
 
 #ifndef EVPL_INCLUDED
 #error "Do not include evpl_core.h directly, include evpl/evpl.h instead"
@@ -69,6 +70,25 @@ void
 evpl_get_hf_monotonic_time(
     struct evpl     *evpl,
     struct timespec *ts);
+
+/*
+ * Move the virtual clock forward by ns nanoseconds, and read it.
+ *
+ * Only meaningful when evpl_global_config_set_virtual_clock() was set before
+ * evpl_init(); calling either otherwise is a hard error rather than a silent
+ * no-op, because a test that believed it was advancing time and was not would
+ * pass for the wrong reason.
+ *
+ * Advancing does not itself run anything: it makes deadlines due, and the
+ * next evpl_continue() on a thread dispatches whatever became due on it.
+ */
+void
+evpl_virtual_clock_advance(
+    uint64_t ns);
+
+uint64_t
+evpl_virtual_clock_now(
+    void);
 
 void evpl_destroy(
     struct evpl *evpl);

--- a/include/evpl/evpl_deferral.h
+++ b/include/evpl/evpl_deferral.h
@@ -24,6 +24,14 @@ evpl_deferral_init(
     deferral_callback_t   callback,
     void                 *private_data);
 
+/*
+ * Arm a deferral: its callback runs once, on the next pass of the event loop.
+ *
+ * Arming one that is already armed is a no-op, so any number of calls before
+ * the loop next runs produce exactly one callback.  Arming from inside the
+ * callback is legal and produces another, since the deferral is disarmed
+ * before it is called.
+ */
 void
 evpl_defer(
     struct evpl          *evpl,
@@ -31,7 +39,9 @@ evpl_defer(
 
 /*
  * Disarm a deferral that has been armed but has not yet run.  A no-op on one
- * that is not armed.
+ * that is not armed, including one that has already run, so a caller tearing
+ * down state need not track whether it armed anything.  Must be called on the
+ * thread that armed it.
  *
  * Needed by anything that frees the object a deferral points at: the event
  * loop holds the pointer until the deferral fires, so tearing the object down

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -27,6 +27,7 @@ evpl_global_config_init(void)
     config->thread_default.wait_ms         = -1;
 
     config->hf_time_mode           = 2;
+    config->virtual_clock          = 0;
     config->max_pending            = 16;
     config->max_poll_fd            = 16;
     config->max_num_iovec          = 128;
@@ -555,6 +556,14 @@ evpl_global_config_set_hf_time_mode(
 {
     config->hf_time_mode = mode;
 } /* evpl_global_config_set_hf_time_mode */
+
+SYMBOL_EXPORT void
+evpl_global_config_set_virtual_clock(
+    struct evpl_global_config *config,
+    int                        enabled)
+{
+    config->virtual_clock = !!enabled;
+} /* evpl_global_config_set_virtual_clock */
 
 SYMBOL_EXPORT void
 evpl_global_config_set_max_pending(

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -151,6 +151,11 @@ evpl_shared_init(struct evpl_global_config *config)
     clock_gettime(CLOCK_MONOTONIC, &evpl_shared->hf_base_time);
     stopwatch_start(&evpl_shared->hf_stopwatch, &evpl_shared->hf_base_sw);
 
+    /* Lifted out of the config so the time path reads one cache line rather
+     * than chasing the config pointer on every call. */
+    evpl_shared->virtual_clock = evpl_shared->config->virtual_clock;
+    evpl_shared->virtual_ticks = 0;
+
     /* Block I/O metric definitions.  Per-device series (labelled by
      * device and type) are created lazily when a device is opened; the
      * histograms use base-2 buckets, so 32 buckets cover up to ~2.1s of
@@ -592,6 +597,14 @@ evpl_continue(struct evpl *evpl)
             msecs = 0;
         }
 
+        /* On the virtual clock, nothing but the application moves time, so a
+         * wait for a deadline would be a wait for something that cannot
+         * happen while we are in it.  Poll instead and let the caller decide
+         * when to advance. */
+        if (unlikely(evpl_shared->virtual_clock)) {
+            msecs = 0;
+        }
+
         if (evpl->loop_hooks.pre_wait) {
             evpl->loop_hooks.pre_wait(evpl, evpl->loop_hooks.private_data);
         }
@@ -706,7 +719,32 @@ evpl_continue(struct evpl *evpl)
 
 } /* evpl_continue */
 
-SYMBOL_EXPORT SYMBOL_EXPORT void
+SYMBOL_EXPORT void
+evpl_virtual_clock_advance(uint64_t ns)
+{
+    evpl_core_abort_if(!evpl_shared,
+                       "evpl_virtual_clock_advance: evpl is not initialized");
+    evpl_core_abort_if(!evpl_shared->virtual_clock,
+                       "evpl_virtual_clock_advance: this process is not on the "
+                       "virtual clock; enable it with "
+                       "evpl_global_config_set_virtual_clock() before evpl_init()");
+
+    evpl_shared->virtual_ticks += ns;
+} /* evpl_virtual_clock_advance */
+
+SYMBOL_EXPORT uint64_t
+evpl_virtual_clock_now(void)
+{
+    evpl_core_abort_if(!evpl_shared,
+                       "evpl_virtual_clock_now: evpl is not initialized");
+    evpl_core_abort_if(!evpl_shared->virtual_clock,
+                       "evpl_virtual_clock_now: this process is not on the "
+                       "virtual clock");
+
+    return evpl_shared->virtual_ticks;
+} /* evpl_virtual_clock_now */
+
+SYMBOL_EXPORT void
 evpl_get_hf_monotonic_time(
     struct evpl     *evpl,
     struct timespec *ts)

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -457,6 +457,13 @@ evpl_create(struct evpl_thread_config *config)
      * compares it without converting on every iteration. */
     evpl->spin_ticks = evpl_ns_to_ticks(evpl->config.spin_ns);
 
+    /* Start the spin grace period now rather than at the epoch.  Left at zero
+     * the loop measures inactivity from process init, so a thread created
+     * more than spin_ns after that never enters poll mode at all until
+     * something calls evpl_activity() -- which makes poll_mode a setting that
+     * silently does nothing on any thread but the first. */
+    evpl->last_activity_ticks = evpl_now_ticks();
+
     evpl_core_init(&evpl->core, 64);
 
     evpl->running = 1;

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -706,7 +706,7 @@ evpl_continue(struct evpl *evpl)
 
 } /* evpl_continue */
 
-SYMBOL_EXPORT void
+SYMBOL_EXPORT SYMBOL_EXPORT void
 evpl_get_hf_monotonic_time(
     struct evpl     *evpl,
     struct timespec *ts)

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -508,13 +508,22 @@ evpl_continue(struct evpl *evpl)
 
                 if (remain > 0) {
                     /* Timer not yet due; convert the remaining ticks to the
-                     * millisecond wait only here, off the busy path. */
+                     * millisecond wait only here, off the busy path.
+                     *
+                     * The break is unconditional: the timers are a min-heap,
+                     * so the head not being due means none of them is, and
+                     * falling through would fire a timer before its deadline.
+                     * Only the wait is conditional -- a caller that asked for
+                     * a shorter wait_ms than this timer's remaining time
+                     * still gets the shorter wait, and the timer fires on a
+                     * later pass once it is genuinely due. */
                     remain = (int64_t) (evpl_ticks_to_ns((uint64_t) remain) / 1000000);
 
                     if (remain < msecs || msecs == -1) {
                         msecs = remain;
-                        break;
                     }
+
+                    break;
                 }
 
                 if (timer->oneshot) {

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -59,6 +59,7 @@ struct evpl_global_config {
     unsigned int              core_mech;
 
     unsigned int              hf_time_mode;
+    unsigned int              virtual_clock;
     unsigned int              max_pending;
     unsigned int              max_poll_fd;
     unsigned int              max_num_iovec;

--- a/src/core/evpl_shared.h
+++ b/src/core/evpl_shared.h
@@ -12,6 +12,7 @@
 #include "protocol.h"
 #include "allocator.h"
 #include "stopwatch.h"
+#include "macros.h"
 
 struct evpl_allocator;
 
@@ -29,6 +30,19 @@ struct evpl_shared {
     struct stopwatch_context     hf_stopwatch;
     struct stopwatch             hf_base_sw;
     struct timespec              hf_base_time;
+
+    /* Virtual clock.  When enabled by the global config, the event loop takes
+     * its time from virtual_ticks -- which nothing but the application
+     * advances -- instead of from the stopwatch above, and a tick is exactly a
+     * nanosecond so the application's units are the loop's units.
+     *
+     * This exists so that behaviour which depends on time can be tested
+     * deterministically: a test advances the clock by a known amount and then
+     * drives the loop, rather than sleeping and hoping.  See
+     * evpl_global_config_set_virtual_clock().
+     */
+    unsigned int                 virtual_clock;
+    uint64_t                     virtual_ticks;
 
     struct prometheus_metrics   *metrics;
     struct prometheus_histogram *block_latency;
@@ -53,18 +67,34 @@ extern struct evpl_shared *evpl_shared;
 static inline uint64_t
 evpl_now_ticks(void)
 {
+    if (unlikely(evpl_shared->virtual_clock)) {
+        return evpl_shared->virtual_ticks;
+    }
+
     return stopwatch_read_ticks(&evpl_shared->hf_stopwatch, &evpl_shared->hf_base_sw);
 } /* evpl_now_ticks */
 
+/* On the virtual clock a tick IS a nanosecond, so both conversions are the
+ * identity.  Anything else would reinterpret the application's advances
+ * through the TSC frequency, which is exactly the machine-dependence the
+ * virtual clock exists to remove. */
 static inline uint64_t
 evpl_ns_to_ticks(uint64_t ns)
 {
+    if (unlikely(evpl_shared->virtual_clock)) {
+        return ns;
+    }
+
     return stopwatch_ns_to_ticks(&evpl_shared->hf_stopwatch, ns);
 } /* evpl_ns_to_ticks */
 
 static inline uint64_t
 evpl_ticks_to_ns(uint64_t ticks)
 {
+    if (unlikely(evpl_shared->virtual_clock)) {
+        return ticks;
+    }
+
     return stopwatch_ticks_to_ns(&evpl_shared->hf_stopwatch, ticks);
 } /* evpl_ticks_to_ns */
 

--- a/src/core/iovec.c
+++ b/src/core/iovec.c
@@ -34,7 +34,15 @@ evpl_iovec_reserve(
 
         chunk = (buffer->size - buffer->used);
 
-        if (chunk < pad + left && niovs + 1 <= max_iovecs) {
+        /* Not enough room here for the rest of the request.  If the buffer
+         * has been used, discard the remainder and take a fresh one -- but
+         * only then: a FRESH buffer that is still too small means the request
+         * is larger than a buffer, and discarding that one for another of the
+         * same size would do the same thing forever.  Fall through instead
+         * and place what fits, which is what the loop below already does with
+         * the remainder. */
+        if (chunk < pad + left && niovs + 1 <= max_iovecs &&
+            buffer->used > 0) {
             evpl_buffer_release(evpl, buffer);
             evpl->current_buffer = NULL;
             continue;
@@ -134,7 +142,15 @@ evpl_iovec_alloc(
 
         chunk = (buffer->size - buffer->used);
 
-        if (chunk < pad + left && niovs + 1 <= max_iovecs) {
+        /* Not enough room here for the rest of the request.  If the buffer
+         * has been used, discard the remainder and take a fresh one -- but
+         * only then: a FRESH buffer that is still too small means the request
+         * is larger than a buffer, and discarding that one for another of the
+         * same size would do the same thing forever.  Fall through instead
+         * and place what fits, which is what the loop below already does with
+         * the remainder. */
+        if (chunk < pad + left && niovs + 1 <= max_iovecs &&
+            buffer->used > 0) {
             evpl_buffer_release(evpl, buffer);
             *bufferp = NULL;
             continue;

--- a/src/core/recv.c
+++ b/src/core/recv.c
@@ -168,6 +168,12 @@ evpl_recv(
         memcpy(ptr, cur->data, chunk);
 
         left -= chunk;
+        /* Advance, or every iovec after the first lands on top of the one
+         * before it: the caller is handed the last one's bytes at offset zero,
+         * the correct length, and no way to tell.  Only reachable when a
+         * single receive spans more than one buffered iovec, which is what a
+         * payload arriving split does. */
+        ptr += chunk;
 
         cur = evpl_iovec_ring_next(&bind->iovec_recv, cur);
     }

--- a/src/core/recv.c
+++ b/src/core/recv.c
@@ -244,21 +244,3 @@ evpl_recvv(
     return niovs;
 
 } /* evpl_readv */
-
-int
-evpl_recv_peek_iovec(
-    struct evpl       *evpl,
-    struct evpl_bind  *conn,
-    struct evpl_iovec *iovecs,
-    int                nbufvecs,
-    int                length)
-{
-    int niovs = 0, left = length;
-
-    do{
-
-    } while (left);
-
-    return niovs;
-
-} /* evpl_recv_peek_iovec */

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -37,3 +37,79 @@ unit_test_local(core endpoint_local endpoint_local.c)
 # In-process endpoints: named through a registry private to the process, so
 # nothing outside it is shared and no namespace is needed either.
 unit_test_local(core endpoint_inproc endpoint_inproc.c)
+
+# ---------------------------------------------------------------------------
+# Model-based core SDK conformance test
+#
+# The programs this test runs are generated from the Quint model in quint/ by
+# a build step, so the traces and the resulting table are build artifacts
+# under the build tree rather than checked-in files that could drift from the
+# model they came from.  That makes quint a build dependency, so the whole
+# test is registered only when quint and python3 are both present; without
+# them the rest of the suite builds and runs as normal.
+#
+# Registered like the other networked tests: the programs run over TCP and UDP
+# as well as the two in-process transports, so they bind real ports and cannot
+# run alongside anything else that does.  Under network namespaces each
+# instance is isolated; without them they share the "evpl_net" lock.
+# ---------------------------------------------------------------------------
+
+find_program(QUINT_EXECUTABLE quint)
+find_program(PYTHON3_EXECUTABLE NAMES python3 python)
+
+if(QUINT_EXECUTABLE AND PYTHON3_EXECUTABLE)
+    set(CORE_QUINT_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/quint)
+    set(CORE_QUINT_WORK_DIR ${CMAKE_CURRENT_BINARY_DIR}/quint)
+    set(CORE_CASES ${CORE_QUINT_WORK_DIR}/core_cases.h)
+
+    add_custom_command(
+        OUTPUT ${CORE_CASES}
+        COMMAND ${CORE_QUINT_SRC_DIR}/generate_core_cases.sh
+                ${QUINT_EXECUTABLE} ${PYTHON3_EXECUTABLE}
+                ${CORE_QUINT_SRC_DIR} ${CORE_QUINT_WORK_DIR} ${CORE_CASES}
+        DEPENDS ${CORE_QUINT_SRC_DIR}/core.qnt
+                ${CORE_QUINT_SRC_DIR}/itf_to_core_cases.py
+                ${CORE_QUINT_SRC_DIR}/generate_core_cases.sh
+        COMMENT "Generating core conformance programs from the Quint model"
+        VERBATIM)
+
+    add_custom_target(core_cases DEPENDS ${CORE_CASES})
+
+    unit_test_all_mechs(core core_conformance core_conformance.c)
+    target_sources(core_core_conformance PRIVATE ${CORE_CASES})
+    target_include_directories(core_core_conformance
+                               PRIVATE ${CORE_QUINT_WORK_DIR})
+
+    # AF_UNIX programs need somewhere to put their socket files.  Appended
+    # rather than set, so the mechanism and TEST_FILE the macro already put
+    # there survive.
+    foreach(mech ${EVPL_MECHANISMS})
+        set_property(TEST libevpl/core/core_conformance_${mech} APPEND
+                     PROPERTY ENVIRONMENT
+                     "EVPL_TEST_SOCKET_DIR=${EVPL_TEST_SOCKET_DIR}")
+    endforeach()
+
+    # Every quiesce runs its full window rather than stopping once its
+    # obligations are met, since an absence is only observed by getting to the
+    # end without it -- but a window is an advance of libevpl's virtual clock,
+    # not a sleep, so the whole suite is a fraction of a second and this
+    # timeout is only here to bound a hang.
+    foreach(mech ${EVPL_MECHANISMS})
+        set_tests_properties(libevpl/core/core_conformance_${mech}
+                             PROPERTIES TIMEOUT 60)
+    endforeach()
+
+    # The model checking itself: scenario tests plus a random-simulation pass
+    # against its invariants.  Separate from generation so that a broken
+    # specification is a failing test rather than a failing build.
+    add_test(NAME libevpl/core/quint_core_model
+             COMMAND ${CORE_QUINT_SRC_DIR}/check_core_models.sh
+                     ${QUINT_EXECUTABLE} ${CORE_QUINT_SRC_DIR})
+    set_tests_properties(libevpl/core/quint_core_model PROPERTIES
+                         LABELS "quint" TIMEOUT 120)
+
+    message(STATUS "Core conformance test enabled (quint: ${QUINT_EXECUTABLE})")
+else()
+    message(STATUS
+        "Core conformance test disabled (needs quint and python3 on PATH)")
+endif()

--- a/src/core/tests/CORE_CONFORMANCE.md
+++ b/src/core/tests/CORE_CONFORMANCE.md
@@ -1,0 +1,363 @@
+<!--
+SPDX-FileCopyrightText: 2026 Ben Jarvis
+
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+# Model-based core SDK conformance test
+
+`core_conformance.c` + `quint/core.qnt` form a conformance suite for libevpl's
+core API — the event loop, its timers, deferrals and doorbells, and the
+connection lifecycle and data plane of a transport. A formal model written in
+[Quint](https://quint-lang.org) generates the test programs; a converter turns
+them into a C table; the test binary interprets them against a real `evpl`.
+
+It is the same idea as the RPC2 suite in `src/rpc2/tests`, applied to a
+different shape of problem — see [Programs, not cases](#programs-not-cases).
+
+Quint and python3 are build dependencies for this test. CMake detects them;
+when either is missing the test is not registered and the rest of the suite is
+unaffected:
+
+```
+-- Core conformance test enabled (quint: /usr/local/bin/quint)
+-- Core conformance test disabled (needs quint and python3 on PATH)
+```
+
+```
+ctest -R libevpl/core/core_conformance --output-on-failure
+ctest -R libevpl/core/quint_core_model --output-on-failure   # the model's own tests
+```
+
+Nothing generated is checked in. The ITF traces and the program table are build
+artifacts under `<build>/src/core/tests/quint/`, regenerated whenever the model,
+the converter or the generator script changes. Seeds are fixed, so a given
+quint release always yields the same programs.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `quint/core.qnt` | The model: the core API as a state machine, and what each operation leaves the library owing |
+| `quint/itf_to_core_cases.py` | ITF traces → C program table |
+| `quint/generate_core_cases.sh` | Build step: model → traces → table |
+| `quint/check_core_models.sh` | The `quint_core_model` test: scenario tests + invariants |
+| `<build>/…/quint/core_cases.h` | **Generated**, not checked in |
+| `core_conformance.c` | The interpreter: object table, event log, obligation checker |
+
+## Programs, not cases
+
+`values.qnt`, `defects.qnt` and `client.qnt` are stateless case enumerators.
+Each trace state is an independent test case and the trace is only a sampling
+device, which works because an RPC exchange is memoryless.
+
+Nothing about the core API is memoryless. A one-shot fires once and then must
+not fire again; a deferral armed twice runs once; a doorbell retired from
+inside its own callback must not be called back afterwards; bytes handed to
+`evpl_send` before an `evpl_finish` must still arrive. Every one of those is a
+statement about a *sequence*.
+
+So here a trace is a **program** — a run of SDK operations against a freshly
+created `evpl`, delimited by `OpReset` — and the C driver is an interpreter for
+it. Programs are short (twelve operations) and numerous, because a failure at
+step 380 of a 400-step program is not debuggable.
+
+## The oracle
+
+An asynchronous API has no return value to check against, so the oracle is the
+event log. Each operation registers, arms or retires something; each
+`OpQuiesce` runs the loop to the end of a window and holds the callbacks that
+arrived against the obligations the model says were owed, in three directions:
+
+1. **Every obligation is discharged.** A missing callback is a caller waiting
+   forever — in production a hang, not a crash.
+2. **Nothing arrives that was not owed.** This is what makes "the removed timer
+   stopped firing" and "the one-shot did not refire" checkable at all: they are
+   absences, and an absence is only observed by getting to the end of a window
+   without it.
+3. **Ordered callbacks arrive in that order**, where the model claims an order.
+
+Rule 2 is why a quiesce always runs its whole window and never stops early at
+satisfaction. An early exit observes no absence.
+
+Obligations carry a multiplicity: *exactly* n, or *at least* n. The distinction
+is not laziness — how many times a periodic timer fires in a window, and how
+many callbacks a repeatedly-rung doorbell coalesces into, are genuinely
+unspecified, and demanding a number there would be demanding a guarantee the
+API does not make. `EvRecv` counts **bytes** rather than callbacks for the same
+reason: how many notifications a stream is delivered in is the transport's
+business; how many bytes come out of it is not.
+
+Payload content is checked as well as length. The sender writes a
+position-keyed pattern and the receiver checks it against its own stream
+offset, so a payload delivered short, duplicated, reordered or at the wrong
+offset fails on content — which is how the `evpl_recv` bug below was caught,
+since it produced the right length every time.
+
+## The virtual clock
+
+Half of what this model states is about time: a 50ms timer must not fire inside
+a 10ms window, and must fire in the window its deadline falls in. Checking that
+against wall-clock time makes the test a test of the machine — and this suite
+is meant to run in CI, on hosts with indeterminate load.
+
+So it does not use wall-clock time at all. `evpl_global_config_set_virtual_clock()`
+takes the library off the machine's clock and puts it on one the application
+advances by hand with `evpl_virtual_clock_advance()`; the core wait stops
+blocking, since with no way for time to move while the loop is inside it, a
+wait for a deadline would be a wait for something that cannot happen.
+
+The driver then advances the clock a millisecond at a time and drives the loop
+after each tick. A deadline the model places at 50ms is a deadline the event
+loop places at 50ms, exactly, under any load. Both sides reduce to integer
+arithmetic: there is no guard band around a window edge, no tolerance for a
+descheduled millisecond, and nothing to retry.
+
+Advancing a tick at a time rather than in one jump per window matters. A single
+jump would collapse every deadline in the window onto one instant, so two
+timers due 40ms apart would come due together and their order would stop
+meaning anything, and a periodic timer would fire once for the window instead
+of throughout it.
+
+What is left genuinely asynchronous is not time-dependent: `evpl_listener_create()`
+runs the accept path on a thread of its own, so a connection's arrival is a
+hand-off between threads. The driver waits for obligations that have not
+arrived yet by driving the loop, which costs nothing when they are prompt and
+weakens nothing — a callback that *must* arrive is waited for, while a callback
+that must *not* arrive is still decided by the clock, which does not move.
+
+The result is a suite that runs in about 60ms and gives the same answer every
+time. On a real clock the same programs took 14 seconds and disagreed with
+themselves about once in five runs.
+
+## Coverage
+
+The transport is a per-program dimension, over four protocols:
+
+| Transport | Lifecycle | Owes |
+|---|---|---|
+| `EVPL_STREAM_INPROC` | listen / connect | bytes |
+| `EVPL_DATAGRAM_INPROC` | listen / connect | messages |
+| `EVPL_STREAM_SOCKET_TCP` | listen / connect | bytes |
+| `EVPL_STREAM_SOCKET_UNIX` | listen / connect | bytes |
+| `EVPL_DATAGRAM_SOCKET_UDP` | bind pair | messages |
+
+The in-process transports came first because they make a whole connection
+lifecycle reachable from one thread and one `evpl`: both ends are in this
+process, so the model can state what *both* of them are owed, with no port to
+collide on and nothing for a crash to leave behind. TCP and AF_UNIX then cost almost nothing, being the same lifecycle with a
+different address -- a port for one, a filesystem path for the other. The
+driver supplies the path (under `EVPL_TEST_SOCKET_DIR`, falling back rather
+than truncating past `sun_path`'s 108 bytes); libevpl owns it from bind
+onwards, removing it at teardown and stepping over a stale predecessor.
+
+UDP is the odd one and needs a lifecycle of its own: it is bind-only —
+`connected = 0`, no `.listen`, no `.connect` — so there is no handshake, no
+CONNECTED, and each end names the other by endpoint on every send. That is
+modelled as a single `OpBindPair`, because an unconnected pair has no
+observable intermediate state to be in: it exists as soon as both ends do.
+
+The socket transports bind real ports, so the test is registered like the other
+networked ones — a network namespace where CAP_NET_ADMIN allows, and the shared
+`evpl_net` lock where it does not. That is a change from the inproc-only
+version, which ran fully in parallel.
+
+| Area | Operations |
+|---|---|
+| Timers | one-shot, periodic, one-shot re-armed from its own callback, removal while armed, removal after firing; four slots, so the heap sifts |
+| Deferrals | arm, arm twice before the loop runs, re-arm from inside the callback, cancel while armed, cancel while idle |
+| Doorbells | add, ring, ring twice, remove, remove from inside the doorbell's own callback |
+| Poll mode | add, remove, report activity, pin and unpin; the enter/exit pair bracketing when the loop was spinning |
+| Loop hooks | install and clear; each of `iteration_end`, `pre_wait` and `post_wait` running while installed and none after |
+| Connections | listen, stop listening, connect, close, finish, slot reuse after teardown, over `EVPL_STREAM_INPROC` and `EVPL_DATAGRAM_INPROC` alike |
+| Send notifications | opt in per end, and every byte queued afterwards reported back — the flag being read at flush, not at send |
+| Message boundaries | a datagram owes exactly one delivery per send; a stream owes the bytes and says nothing about how they are divided. Coalescing or splitting keeps the byte total and fails the message count |
+| Data plane | four payload size classes across five send modes (`evpl_send`, `evpl_sendv` with and without `EVPL_SEND_FLAG_TAKE_REF`, `evpl_iovec_reserve`+`commit`, and `evpl_iovec_alloc_global`) and four drain modes (`evpl_recv`, `evpl_recvv`, `evpl_peek`+`evpl_consume`, `evpl_peekv`+`evpl_consume`), both directions independently |
+
+The send and drain modes are where the iovec ownership rules get exercised:
+`evpl_sendv` without `TAKE_REF` clones and the caller must release its own,
+with it the references are handed over and releasing them would be a double
+free; `evpl_recvv` clones and the receiver must release, while `evpl_peekv`
+borrows and the receiver must not. All four are asymmetries the headers do not
+state, and `evpl_allocator_destroy`'s leak check fails the run either way
+round.
+
+### What that reaches
+
+From `make coverage COVERAGE_TESTS=core_conformance` — this test alone, nothing
+else in the suite. Function coverage is the number to watch: lines and branches
+say how thoroughly a path is walked, but a function at 0% is an entry point
+nothing calls at all.
+
+**Functions: 202 of 238 (84.9%)**, counting everything in the core modules
+except the global-config setters for subsystems this test has no business in
+(rdmacm, xlio, vfio, libaio, io_uring, tls, http). Lines 73.5%, branches 54.7%
+over the same set.
+
+| `doorbell.c` | 100.0% | 66.7% |
+| `deferral.c` | 100.0% | 100.0% |
+| `timer.c` | 95.1% | 88.0% |
+| `protocol.c` | 93.3% | 66.7% |
+| `poll.c` | 92.0% | 50.0% |
+| `iovec.c` | 91.3% | 81.0% |
+| `epoll.c` | 89.7% | 72.2% |
+| `send.c` | 89.5% | 68.8% |
+| `evpl.c` | 88.7% | 76.5% |
+| `address.c` | 87.5% | 75.0% |
+| `socket/udp.c` | 78.5% | 51.6% |
+| `inproc/inproc.c` | 76.9% | 52.7% |
+| `listen.c` | 76.3% | 50.6% |
+| `endpoint.c` | 75.8% | 56.7% |
+| `select.c` | 75.6% | 64.3% |
+| `bind.c` | 74.2% | 43.7% |
+| `socket/tcp.c` | 71.5% | 50.0% |
+| `recv.c` | 67.4% | 56.0% |
+| `socket/unix_stream.c` | 66.0% | 25.9% |
+| **Together** | **73.5%** | **54.7%** |
+
+Fourteen modules have every function called, including `endpoint.c`,
+`socket/tcp.c`, `iovec.c` and `send.c`. What is left is a short list with no
+common theme, and most of it is error handling that needs injection rather
+than a new operation:
+
+- **`bind.c`** — `evpl_bind_abort`, reached only when a listen fails after the
+  bind has been prepared.
+- **`socket/udp.c`** — `evpl_socket_udp_error`, an error path.
+- **`socket/unix_stream.c`** — `evpl_socket_unix_clear_stale`, which runs only
+  when a socket file is left behind by a crashed predecessor. Reachable by
+  creating one deliberately, which is an injection rather than an op.
+- **`thread.c`** — `evpl_threadpool_create`/`_destroy`; threads are not
+  modelled.
+- **`memory.c`**, **`core.c`**, **`allocator.c`** — `evpl_malloc`/`evpl_realloc`,
+  `evpl_core_mech_name`, and slab-allocation internals.
+- **`config.c`** — tuning knobs this test has no reason to set.
+- **`evpl.c`** — the two `evpl_rpc2_queue_depth_*` helpers, which live here but
+  belong to rpc2.
+
+Two program shapes exist in the generator purely to keep these numbers honest.
+Half the programs open with a prologue that leaves a live connection and sends
+on it, and a quarter open by arming three timers — because a uniform random
+walk over twenty-eight enabled actions builds neither, and unlike a missing
+operation (which fails generation) a heap that never sifts just quietly stops
+being tested. Adding the timer prologue moved `evpl_timer_heap_down` from 64%
+to 92%; adding the send to the transport prologue took payload bytes verified
+from 131 KB to 1.1 MB.
+
+## Divergences found, and fixed
+
+Both were found by the first two runs of the suite, and both are fixed, so any
+recurrence fails the test.
+
+| What the API promises | What libevpl did | Fix |
+|---|---|---|
+| `evpl_add_oneshot_timer` fires "once, `delay_us` from now" | fired **before** its deadline whenever the thread's `wait_ms` was shorter than the time remaining — and a periodic timer in that state re-armed and re-fired without bound inside a single `evpl_continue`, spinning the loop | the timer scan now breaks unconditionally once the head of the heap is not yet due, and only the *wait* is shortened |
+| `evpl_recv` fills the caller's buffer with the bytes it reports | copied every buffered iovec to the **start** of the buffer, so a receive spanning more than one landed the last one's bytes at offset zero and returned the correct length | the destination pointer is advanced by each chunk |
+| `evpl_thread_config_set_poll_mode()` makes the thread spin | the spin window was measured from process init rather than from thread creation, so any thread created more than `spin_ns` after startup never entered poll mode at all unless something happened to call `evpl_activity()` | `evpl_create` starts the spin window |
+| `evpl_iovec_alloc`/`evpl_iovec_reserve` place a request across as many buffers as it takes | when a **fresh** buffer was still too small they discarded it and asked for another of the same size — forever. Any request larger than one buffer was an unbounded loop, and the multi-iovec code below it was unreachable | the discard is now conditional on the buffer having been used; a fresh one that cannot hold the rest is filled and the remainder placed in the next |
+| `evpl_get_hf_monotonic_time()` is declared in `evpl_core.h` | missing `SYMBOL_EXPORT`, so with `-fvisibility=hidden` it was not in the library's dynamic symbol table: any consumer calling it failed to link | exported |
+| `evpl_config()` is declared in `evpl_core.h` | no such function exists. The implementation is `evpl_get_config(void)` — a different name *and* a different signature (the header promises a per-`evpl` accessor, the code returns the global config) | the declaration is removed; nothing could have been calling it |
+
+The first of those was only reachable at all because this test now configures a
+32 KiB buffer rather than the 2 MiB default — which it does precisely so that
+payloads span several iovecs. At the default, every allocation fits in one and
+the loop never spins. It is also why the buffer is 32 KiB and not smaller:
+`evpl_send` bounces through `evpl_iovec_alloc` with room for four iovecs and
+aborts if the payload needs more, so a buffer under a quarter of the largest
+payload class turns `evpl_send` into an abort. That ceiling is worth removing
+separately.
+
+The timer one was invisible to the rest of the suite because the default
+`wait_ms` is -1, which takes the one branch that behaved correctly; any bounded
+wait took the other. The `evpl_recv` one was invisible because every existing
+test compares byte *counts* — `bulk_stream.c` and friends would pass on
+arbitrarily corrupt data — and because whether a receive spans two iovecs
+depends on how the payload happened to arrive. It reproduced under the `select`
+mechanism and not under `epoll`.
+
+## Open, and deliberately constrained
+
+**`evpl_sendtoep`/`evpl_sendtoepv` leak an address reference on every
+transport but UDP.** They resolve the endpoint for a +1 reference and hand it
+to `evpl_sendto`/`evpl_sendtov`, which keep the bare pointer in the queued
+dgram. Whether anyone gives it back is then up to the transport: `udp.c` and
+`rdmacm.c` release `dgram->addr` when the send completes, and nothing else
+does — not inproc, not the stream sockets.
+
+So the same public call is balanced on one transport and leaks on the others,
+and the model has to know which: it generates the endpoint-addressed sends
+only where they are the *only* option, which is UDP, and uses the connected
+forms everywhere else. That is not a workaround for a test problem — an
+unconnected bind genuinely has no peer to send to and a connected one has no
+endpoint to name — but it is why the constraint is stated as a precondition
+rather than left to chance.
+
+Releasing the reference in the wrapper is *not* the fix, and this suite is how
+that was established: with the release added, inproc came clean and the UDP
+tests turned into use-after-free, because an INET endpoint's cached address is
+re-resolved on `resolve_timeout_ms` and the old one freed while a queued dgram
+still points at it. The coherent fix is for `evpl_sendtov` to take a reference
+of its own and every transport to release it on completion — a change across
+all of them, including the two (rdmacm, xlio) that cannot be exercised here.
+
+**`buffer_size` must be at least `max_datagram_size`, and nothing enforces it.**
+A datagram receive buffer is one contiguous iovec, so it cannot be assembled
+from several buffers. Configure a buffer smaller than the maximum datagram and
+`evpl_iovec_alloc_datagram` quietly hands back a short one; datagrams then stop
+arriving, with no error anywhere. Before the `evpl_iovec_alloc` fix above it
+did not even do that — it looped forever. This test sets
+`max_datagram_size` to half the buffer size for exactly that reason, and
+libevpl should reject the combination at `evpl_init` instead.
+
+**Two smaller behaviours are modelled rather than fixed**, because both are
+defensible and changing them would be a behaviour change on existing callers:
+
+- An activity reported while no poll is registered is remembered indefinitely
+  and brings the loop into poll mode the moment one is added, however long
+  afterwards. `evpl_continue` only syncs its activity counter inside the
+  `num_poll > 0` guard.
+- `evpl_remove_poll` leaves the loop's `poll_mode` flag set, so removing the
+  last poll emits no exit callback, and adding one again afterwards emits no
+  enter callback. The model never generates a re-add rather than encoding it.
+
+## What the suite does not cover
+
+- **TLS, io_uring, XLIO and RDMA transports**, which need build options or
+  hardware. `EVPL_DATAGRAM_TCP_RDMA` is the interesting one, since it needs
+  neither and carries the RPC-over-RDMA framing.
+- **Abstract-namespace AF_UNIX sockets** (`@name`), which are Linux-only and
+  have no filesystem object at all.
+- **The segment callback.** `evpl_segment_callback_t` documents three return
+  cases including one that must close the connection; none is exercised here.
+- **iovec ownership.** `evpl_iovec_alloc`/`clone`/`move`/`release`, the
+  LOCAL/SHARED/GLOBAL flags and `EVPL_SEND_FLAG_TAKE_REF` are the other half of
+  the core API and are only touched incidentally, through `evpl_recvv`'s
+  cloning. A refcount-ledger model with `evpl_allocator_destroy`'s leak check
+  and the allocator gauges from `evpl_metrics_scrape()` as its oracles is the
+  obvious companion.
+- **The loop hooks** (`evpl_set_loop_hooks`), which have no coverage at all.
+- **Threads and thread pools**, and doorbells rung from a thread other than the
+  one that added them — which is what a doorbell is actually for.
+- **Whether a listener may be torn down under live connections.** The model
+  deliberately does not generate it: the headers do not say, and a model may
+  not invent an answer it would then report libevpl for failing.
+
+## Regenerating
+
+CMake runs `quint/generate_core_cases.sh` as a build step, so nothing needs
+doing by hand. To inspect the traces, run it the same way:
+
+```sh
+quint/generate_core_cases.sh "$(which quint)" python3 quint /tmp/coreq /tmp/coreq/core_cases.h
+```
+
+The converter fails generation if any operation the model declares is never
+reached by a generated program. A trace is a sample, so a seed bump or a quint
+release that samples differently could otherwise drop an operation entirely and
+leave a smaller suite that still looks green.
+
+That check is also what forced the model's program shape: half the programs
+open with a three-operation prologue that leaves a live connection, because a
+uniform random walk over the operation set almost never builds one — `send`,
+`close` and `finish` all need a connection that is up, which takes `listen`,
+`connect` and a quiesce to reach, and the odds of drawing that sequence out of
+seventeen enabled actions inside a twelve-operation program are negligible.

--- a/src/core/tests/core_conformance.c
+++ b/src/core/tests/core_conformance.c
@@ -1,0 +1,1988 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Ben Jarvis
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Model-based conformance test for libevpl's core SDK.
+ *
+ * The RPC2 conformance tests replay a table of independent cases.  This one
+ * replays PROGRAMS: quint/core.qnt models the core API as a state machine,
+ * and each generated program is a sequence of SDK calls against a freshly
+ * created evpl.  This file is the interpreter.
+ *
+ * The oracle is not a return value -- an asynchronous API has none to check
+ * against.  It is the event log.  Each program op registers, arms or retires
+ * something; each OpQuiesce runs the loop to an absolute deadline and then
+ * holds the callbacks that arrived against the obligations the model says
+ * were owed, in three directions:
+ *
+ *   - every obligation is discharged (a missing callback is a caller waiting
+ *     forever, which in production is a hang and not a crash);
+ *   - no callback arrives that nothing expected (this is what makes "the
+ *     removed timer stopped firing" and "the one-shot did not refire"
+ *     observable at all -- they are absences);
+ *   - callbacks that the model orders arrive in that order.
+ *
+ * A quiesce therefore always runs its whole window and never returns early on
+ * satisfaction: an early exit would observe no absence, and the second and
+ * third checks above would be worthless.
+ *
+ * The transport half runs over EVPL_STREAM_INPROC.  In-process is what makes
+ * a whole connection lifecycle reachable from one thread and one evpl: both
+ * ends are in this process, so the model can state what BOTH of them are
+ * owed, and there is no port to collide on, no namespace to need and nothing
+ * for a crash to leave behind.  Everything here is transport-agnostic above
+ * the protocol id, so widening it to the socket transports is a matter of
+ * parameterizing that id rather than of rewriting the harness.
+ *
+ * The model encodes the SPECIFICATION that include/evpl states, so a mismatch
+ * is a candidate bug in libevpl rather than a broken test.  Reviewed,
+ * consciously deferred divergences go in known_divergences[] with a note;
+ * anything else fails.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "core/test_log.h"
+#include "evpl/evpl.h"
+#include "tests/test_common.h"
+
+#include "core_cases.h"
+
+/*
+ * The delay classes, in microseconds.  These MUST match core.qnt's delayMs():
+ * the model computes which quiesce window each deadline falls in, so a driver
+ * that armed a different delay would be checking a different program from the
+ * one that was generated.
+ */
+#define DELAY_FAST_US    1000
+#define DELAY_SLOW_US    50000
+
+/*
+ * The clock is advanced a millisecond at a time rather than in one jump per
+ * window.  Jumping would collapse every deadline in the window onto a single
+ * instant: two timers due 40ms apart would come due together and their order
+ * would stop meaning anything, and a periodic timer would fire once for the
+ * window instead of throughout it.
+ */
+#define TICK_NS          1000000ull
+
+/*
+ * How many consecutive passes of the loop must produce nothing before it is
+ * considered settled.
+ *
+ * With the clock frozen, the only thing left that can make progress is I/O
+ * and the deferrals it schedules, so this is bounded and small -- the peer's
+ * queue is filled synchronously by the send and the wakeup is already
+ * readable by the next pass.  It is generous because the cost of being
+ * generous is a few more non-blocking passes, and the cost of being mean is a
+ * missed callback reported as a conformance failure.
+ */
+#define SETTLE_PASSES    8
+
+/*
+ * A backstop on settling.  With the clock frozen the loop has a bounded
+ * amount of work to do, so needing more passes than this means something is
+ * producing events without end -- and a loop that never settles is a hang,
+ * which is the least debuggable way for a test to fail.
+ */
+#define SETTLE_LIMIT     200000
+
+/*
+ * How long to keep driving the loop at the end of a window for obligations
+ * that have not arrived yet.
+ *
+ * evpl_listener_create() runs the accept path on a thread of its own, so a
+ * connection's arrival is handed across threads and how many passes of THIS
+ * loop it takes is a property of the scheduler, not of libevpl.  Waiting for
+ * it costs nothing when it is prompt and does not weaken anything: a callback
+ * that must arrive is waited for, while a callback that must NOT arrive is
+ * still decided by the clock, which does not move here.
+ *
+ * The bound is a backstop against a genuine hang.  Each pass is a
+ * non-blocking poll, so exhausting it takes well under a second, and what
+ * follows is the ordinary "obligation not discharged" failure -- which is
+ * exactly what a callback that never comes is.
+ */
+#define AWAIT_PASSES     200000
+
+/* Object slots the model may name.  It declares two of each; the driver
+ * carries a little slack so that widening the model is a one-line change
+ * there.  Connection ends share the slot space with the rest, two per
+ * connection -- see END_SLOT. */
+#define MAX_SLOT         4
+#define MAX_CONN         2
+
+#define SIDE_CLIENT      0
+#define SIDE_SERVER      1
+#define NUM_SIDE         2
+
+#define END_SLOT(conn, side) ((conn) * NUM_SIDE + (side))
+#define PEER(side)           (1 - (side))
+
+/* Comes from the generated header; see CORE_NUM_EVENT_KIND. */
+#define NUM_EVENT_KIND   CORE_NUM_EVENT_KIND
+
+/*
+ * Poll mode, as the driver configures it.
+ *
+ * poll_iterations is deliberately 1 rather than the default 1000.  The loop
+ * runs that many pure-polling passes between each full pass, and only a full
+ * pass can observe activity or let the spin window expire -- so with the
+ * default, settle() would give up long before the loop ever looked at whether
+ * it should still be spinning, and no mode transition would ever be seen.
+ * One keeps the poll callback firing regularly while leaving a full pass
+ * between each, which is the same state machine at a legible cadence.
+ */
+#define POLL_ITERATIONS  1
+
+/* The largest number of iovecs a payload is allowed to arrive in or be sent
+ * as; ample for the largest size class at any sane buffer size. */
+#define MAX_SEND_IOV     64
+
+/*
+ * Buffer size for the run, well below the largest payload class on purpose.
+ *
+ * The default is 2 MiB, which puts every payload this model sends into a
+ * single iovec and leaves the gather and scatter paths -- the ones that walk
+ * a chain -- almost entirely unexercised.  At 32 KiB the largest class spans
+ * four.
+ *
+ * Not smaller, because evpl_send bounces through evpl_iovec_alloc with room
+ * for four iovecs and aborts if the payload needs more -- so a buffer under a
+ * quarter of the largest class turns evpl_send into an abort rather than a
+ * test.
+ */
+#define CONF_BUFFER_SIZE (32 * 1024)
+
+/* Must match core.qnt's SPIN_MS.  Set rather than assumed: the model's poll
+ * transitions are computed against it. */
+#define CONF_SPIN_NS     1000000UL
+
+/*
+ * Where AF_UNIX socket files go.
+ *
+ * ctest points EVPL_TEST_SOCKET_DIR at the build tree so a run leaves nothing
+ * behind in /tmp; the fallbacks are for running the binary by hand.  sun_path
+ * is only 108 bytes, so a deep build tree can push a generated name past it --
+ * hence the length check and the fallback to /tmp rather than a truncated
+ * path, which would be a different socket.
+ *
+ * libevpl owns the file from bind onwards: it removes it at teardown and steps
+ * over a stale predecessor, so nothing here has to clean up after itself.
+ */
+static const char *
+socket_dir(void)
+{
+    const char *dir = getenv("EVPL_TEST_SOCKET_DIR");
+
+    if (!dir || dir[0] != '/') {
+        dir = getenv("TMPDIR");
+    }
+
+    if (!dir || dir[0] != '/') {
+        dir = "/tmp";
+    }
+
+    return dir;
+} /* socket_dir */
+
+/*
+ * Base port for the socket transports.  Each listen takes the next one, and
+ * a program never reuses one, so nothing here contends with itself; what it
+ * does contend with is the rest of the suite, which is why the test is
+ * registered under the same network serialization as the other socket tests.
+ */
+#define CONF_BASE_PORT 9300
+
+/* Global iovecs are one whole buffer each and are released at teardown, so a
+ * program can hold at most this many at once. */
+#define MAX_GLOBAL_IOV 16
+
+/* Sized from the model's largest payload class; see size_bytes(). */
+#define MAX_SEND_BYTES 131072
+#define RECV_SCRATCH   65536
+#define MAX_RECVV_IOV  64
+
+/* A program is a dozen ops and its quiesces are bounded, so the log cannot
+ * grow without bound -- except through a periodic timer, which fires as often
+ * as the loop spins.  The cap is a backstop against a runaway rather than an
+ * expected limit, and overflowing it fails the run rather than truncating
+ * silently, which would turn a storm of spurious callbacks into a pass. */
+#define MAX_LOG        65536
+
+struct log_entry {
+    uint8_t  kind;
+    uint8_t  slot;
+    /* One for a callback; a byte count for CEV_EVRECV, because what a stream
+     * owes is bytes and not notifications. */
+    uint32_t count;
+};
+
+struct prog_state;
+
+struct timer_slot {
+    struct evpl_timer  timer;     /* first member: the callback casts back */
+    struct prog_state *ps;
+    int                slot;
+    int                rearm_left;
+    uint64_t           delay_us;
+    int                armed;
+};
+
+struct deferral_slot {
+    struct evpl_deferral deferral;
+    struct prog_state   *ps;
+    int                  slot;
+    int                  redefer_left;
+};
+
+struct doorbell_slot {
+    struct evpl_doorbell doorbell;  /* first member: same trick */
+    struct prog_state   *ps;
+    int                  slot;
+    int                  present;
+    int                  remove_in_cb;
+};
+
+/* What a notify callback needs to know about the end it was registered for.
+ * A bind carries no slot of its own, so this is how a callback finds its way
+ * back into the model's object space. */
+struct end_ctx {
+    struct prog_state *ps;
+    int                conn;
+    int                side;
+};
+
+struct conn_slot {
+    struct evpl_bind     *bind[NUM_SIDE];
+    /* Where each end of an unconnected pair lives.  A connected transport
+     * has one endpoint for the pair, held on the program; an unconnected one
+     * has an address per end, because that is what its peer has to name. */
+    struct evpl_endpoint *ep[NUM_SIDE];
+    struct end_ctx        ctx[NUM_SIDE];
+    uint8_t               drain;
+    /* Byte-stream offsets, indexed by the end that RECEIVES.  The sender
+     * writes a position-keyed pattern from tx_off and the receiver checks it
+     * against rx_off, so a payload delivered short, twice, out of order or at
+     * the wrong offset fails on content rather than only on length. */
+    uint64_t              tx_off[NUM_SIDE];
+    uint64_t              rx_off[NUM_SIDE];
+};
+
+struct prog_state {
+    struct evpl                  *evpl;
+    struct timer_slot             timers[MAX_SLOT];
+    struct deferral_slot          deferrals[MAX_SLOT];
+    struct doorbell_slot          doorbells[MAX_SLOT];
+
+    struct evpl_listener         *listener;
+    struct evpl_listener_binding *binding;
+    struct evpl_endpoint         *endpoint;
+    int                           listen_seq;
+    struct conn_slot              conns[MAX_CONN];
+    /* The connection awaiting its accept, or -1.  The model generates at most
+     * one connect in flight precisely so that this is unambiguous: an accept
+     * callback is handed a bind with nothing on it that says which connect it
+     * answers. */
+    int                           pending_connect;
+
+    struct log_entry              log[MAX_LOG];
+    int                           nlog;
+    int                           window;   /* first log index of this window */
+    struct evpl_poll             *poll;
+    /* Global iovecs are owned outright by whoever allocated them: the library
+     * never frees one, and a borrow taken by the send path does not keep it
+     * alive.  So they are held here for the life of the program and released
+     * exactly once at teardown, which is both the documented contract and the
+     * only way the payload is guaranteed to still be there when the transport
+     * gets to it. */
+    struct evpl_iovec             globals[MAX_GLOBAL_IOV];
+    int                           nglobals;
+    struct evpl_loop_hooks        hooks;
+    /* The protocol this program runs over, taken from its steps.  Fixed for
+     * the program: listen and connect must agree, and both ends of a
+     * connection are the same transport by construction. */
+    enum evpl_protocol_id         proto;
+    /* A poll callback fires on every pass of the loop while the thread is
+     * spinning.  Logging each one would mean the loop never looked settled,
+     * so the driver records only the first in a window -- which is what the
+     * model claims: that the poll ran, not how often. */
+    int                           poll_logged;
+    /* As poll_logged: the hooks run on every pass, so only the first of each
+     * in a window is recorded. */
+    int                           hook_logged[3];
+    /* The virtual clock reading this program calls zero.  The clock is
+     * process-wide and never rewinds, so each program takes its own base
+     * rather than resetting it. */
+    uint64_t                      base_ns;
+
+    uint8_t                       sendbuf[MAX_SEND_BYTES];
+    uint8_t                       recvbuf[RECV_SCRATCH];
+};
+
+/*
+ * Failure kinds.  These are the three directions the check runs in, plus the
+ * ordering claim; they are what a known divergence is keyed on.
+ */
+enum core_failure {
+    CFAIL_MISSING = 0,      /* fewer callbacks than the obligation requires */
+    CFAIL_EXTRA,            /* more than an exact obligation allows         */
+    CFAIL_UNEXPECTED,       /* a callback no obligation covers              */
+    CFAIL_ORDER,            /* a required ordering was violated             */
+};
+
+/*
+ * Known divergences from the specification.
+ *
+ * Keyed on the shape of the obligation rather than on the program that
+ * happened to hit it, because the programs are regenerated and a program
+ * index is not stable across a seed or quint bump.  The shape is
+ * discriminating even so: (EvTimer, exactly 1) is a one-shot, (EvTimer,
+ * exactly 2) a re-armer, (EvTimer, at least 1) a periodic, (EvDeferral,
+ * exactly 1) a coalesced arming, (EvDeferral, exactly 2) a re-armed one,
+ * (EvDoorbell, at least 1) a ring, (EvDoorbell, exactly 1) a doorbell that
+ * retires itself from its own callback.
+ *
+ * Removing an entry turns its divergence back into a hard failure, which is
+ * what should happen once the underlying issue is fixed.
+ */
+struct known_divergence {
+    uint8_t     kind;
+    uint8_t     mult;
+    uint32_t    count;
+    uint8_t     failure;
+    const char *note;
+};
+
+static const struct known_divergence known_divergences[] = {
+    /* Empty: every obligation the model states is currently met. */
+    { 0, 0, 0, 0, NULL }
+};
+
+static int
+is_known_divergence(
+    uint8_t  kind,
+    uint8_t  mult,
+    uint32_t count,
+    uint8_t  failure)
+{
+    unsigned int i;
+
+    for (i = 0; i < sizeof(known_divergences) / sizeof(known_divergences[0]);
+         i++) {
+        if (known_divergences[i].note &&
+            known_divergences[i].kind == kind &&
+            known_divergences[i].mult == mult &&
+            known_divergences[i].count == count &&
+            known_divergences[i].failure == failure) {
+            return 1;
+        }
+    }
+
+    return 0;
+} /* is_known_divergence */
+
+/* Set from CORE_TRACE; prints each op as it runs, for when a program does
+ * something the failure message alone does not explain. */
+static int g_trace;
+
+/* Next socket port to hand out; see CONF_BASE_PORT. */
+static int g_port_seq;
+
+static struct {
+    int      programs;
+    int      steps;
+    int      obligations;
+    int      quiesces;
+    int      known;
+    int      failed;
+    uint64_t bytes;
+} g_results;
+
+/* ------------------------------------------------------------------ */
+
+static const char *
+op_name(uint8_t op)
+{
+    switch (op) {
+        case COP_OPRESET: return "Reset";
+        case COP_OPADDTIMER: return "AddTimer";
+        case COP_OPREMOVETIMER: return "RemoveTimer";
+        case COP_OPDEFER: return "Defer";
+        case COP_OPDEFERTWICE: return "DeferTwice";
+        case COP_OPDEFERREENTRANT: return "DeferReentrant";
+        case COP_OPADDDOORBELL: return "AddDoorbell";
+        case COP_OPRINGDOORBELL: return "RingDoorbell";
+        case COP_OPRINGDOORBELLTWICE: return "RingDoorbellTwice";
+        case COP_OPREMOVEDOORBELL: return "RemoveDoorbell";
+        case COP_OPREMOVEDOORBELLINCALLBACK: return "RemoveDoorbellInCallback";
+        case COP_OPREMOVEDEFERRAL: return "RemoveDeferral";
+        case COP_OPREMOVEDEFERRALIDLE: return "RemoveDeferralIdle";
+        case COP_OPADDPOLL: return "AddPoll";
+        case COP_OPREMOVEPOLL: return "RemovePoll";
+        case COP_OPACTIVITY: return "Activity";
+        case COP_OPPOLLPIN: return "PollPin";
+        case COP_OPPOLLUNPIN: return "PollUnpin";
+        case COP_OPREQUESTSENDNOTIFY: return "RequestSendNotify";
+        case COP_OPSETLOOPHOOKS: return "SetLoopHooks";
+        case COP_OPCLEARLOOPHOOKS: return "ClearLoopHooks";
+        case COP_OPLISTEN: return "Listen";
+        case COP_OPSTOPLISTEN: return "StopListen";
+        case COP_OPBINDPAIR: return "BindPair";
+        case COP_OPCONNECT: return "Connect";
+        case COP_OPSEND: return "Send";
+        case COP_OPCLOSE: return "Close";
+        case COP_OPFINISH: return "Finish";
+        case COP_OPQUIESCE: return "Quiesce";
+        default: return "?";
+    } /* switch */
+} /* op_name */
+
+static const char *
+event_name(uint8_t kind)
+{
+    switch (kind) {
+        case CEV_EVTIMER: return "timer";
+        case CEV_EVDEFERRAL: return "deferral";
+        case CEV_EVDOORBELL: return "doorbell";
+        case CEV_EVCONNECTED: return "connected";
+        case CEV_EVDISCONNECTED: return "disconnected";
+        case CEV_EVRECV: return "recv-bytes";
+        case CEV_EVPOLLENTER: return "poll-enter";
+        case CEV_EVPOLLEXIT: return "poll-exit";
+        case CEV_EVPOLL: return "poll";
+        case CEV_EVRECVMSG: return "recv-messages";
+        case CEV_EVSENT: return "sent-bytes";
+        case CEV_EVHOOK: return "loop-hook";
+        default: return "?";
+    } /* switch */
+} /* event_name */
+
+static const char *
+failure_name(uint8_t failure)
+{
+    switch (failure) {
+        case CFAIL_MISSING: return "missing";
+        case CFAIL_EXTRA: return "extra";
+        case CFAIL_UNEXPECTED: return "unexpected";
+        case CFAIL_ORDER: return "out-of-order";
+        default: return "?";
+    } /* switch */
+} /* failure_name */
+
+/* Must match core.qnt's sizeBytes(). */
+static int
+size_bytes(uint8_t size)
+{
+    switch (size) {
+        case CSZ_SZTINY: return 1;
+        case CSZ_SZSMALL: return 100;
+        case CSZ_SZMEDIUM: return 8192;
+        case CSZ_SZLARGE: return 131072;
+        default: return 0;
+    } /* switch */
+} /* size_bytes */
+
+/*
+ * Drive the loop until it settles.
+ *
+ * The clock is frozen while this runs, so nothing can become due inside it;
+ * what it waits for is the genuinely asynchronous part -- a payload becoming
+ * visible to its peer, a close being dispatched off its deferral -- which
+ * depends on passes of the loop and not on time.  That is what keeps the
+ * suite's verdicts independent of how loaded the machine is.
+ */
+static void
+settle(struct prog_state *ps)
+{
+    int quiet = 0, passes = 0;
+
+    while (quiet < SETTLE_PASSES) {
+        int before = ps->nlog;
+
+        evpl_continue(ps->evpl);
+
+        quiet = (ps->nlog == before) ? quiet + 1 : 0;
+
+        evpl_test_abort_if(++passes > SETTLE_LIMIT,
+                           "the loop has not settled in %d passes with the "
+                           "clock stopped; something is producing events "
+                           "without end (last was %s slot %d)",
+                           SETTLE_LIMIT,
+                           ps->nlog ? event_name(ps->log[ps->nlog - 1].kind) : "nothing",
+                           ps->nlog ? ps->log[ps->nlog - 1].slot : -1);
+    }
+} /* settle */
+
+static void
+log_event(
+    struct prog_state *ps,
+    uint8_t            kind,
+    int                slot,
+    uint32_t           count)
+{
+    evpl_test_abort_if(ps->nlog >= MAX_LOG,
+                       "event log overflow at %s slot %d: more than %d "
+                       "callbacks in one program, which is a callback storm "
+                       "rather than a capacity problem",
+                       event_name(kind), slot, MAX_LOG);
+
+    ps->log[ps->nlog].kind  = kind;
+    ps->log[ps->nlog].slot  = (uint8_t) slot;
+    ps->log[ps->nlog].count = count;
+    ps->nlog++;
+} /* log_event */
+
+/* ------------------------------------------------------------------ */
+
+static void
+timer_cb(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    struct timer_slot *ts = (struct timer_slot *) timer;
+
+    log_event(ts->ps, CEV_EVTIMER, ts->slot, 1);
+
+    /*
+     * A re-arming one-shot arms itself again from inside its own callback,
+     * which is only legal because the loop pops a one-shot BEFORE calling it.
+     * Doing it here rather than from the op is the whole point: arming it
+     * from the outside would test nothing about that ordering.
+     */
+    if (ts->rearm_left > 0) {
+        ts->rearm_left--;
+        evpl_add_oneshot_timer(evpl, timer, timer_cb, ts->delay_us);
+    } else if (ts->armed == 1) {
+        /* A plain one-shot is gone once it has fired; remember that so the
+         * teardown below does not try to remove it again... which is itself a
+         * documented no-op, but the model already covers that explicitly. */
+        ts->armed = 0;
+    }
+} /* timer_cb */
+
+static void
+deferral_cb(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct deferral_slot *ds = private_data;
+
+    log_event(ds->ps, CEV_EVDEFERRAL, ds->slot, 1);
+
+    /* Re-arm from inside the callback.  Distinct from arming twice before the
+     * loop runs, which coalesces: this one must produce a second callback. */
+    if (ds->redefer_left > 0) {
+        ds->redefer_left--;
+        evpl_defer(evpl, &ds->deferral);
+    }
+} /* deferral_cb */
+
+static void
+doorbell_cb(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct doorbell_slot *bs = (struct doorbell_slot *) doorbell;
+
+    log_event(bs->ps, CEV_EVDOORBELL, bs->slot, 1);
+
+    /*
+     * evpl_doorbell.h permits retiring a doorbell from inside its own
+     * callback and promises the library holds no reference afterwards, so the
+     * storage may be freed immediately.  Doing it here is what puts that
+     * promise under test -- a dispatch loop that keeps walking the array it
+     * just mutated fails here and nowhere else.
+     */
+    if (bs->remove_in_cb) {
+        bs->remove_in_cb = 0;
+        bs->present      = 0;
+        evpl_remove_doorbell(evpl, doorbell);
+    }
+} /* doorbell_cb */
+
+/* ------------------------------------------------------------------ */
+
+static void
+poll_enter_cb(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    log_event(private_data, CEV_EVPOLLENTER, 0, 1);
+} /* poll_enter_cb */
+
+static void
+poll_exit_cb(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    log_event(private_data, CEV_EVPOLLEXIT, 0, 1);
+} /* poll_exit_cb */
+
+static void
+poll_cb(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct prog_state *ps = private_data;
+
+    /* Once per window; see poll_logged. */
+    if (!ps->poll_logged) {
+        ps->poll_logged = 1;
+        log_event(ps, CEV_EVPOLL, 0, 1);
+    }
+} /* poll_cb */
+
+/*
+ * The three loop hooks.  Each fires on every pass of the loop, so like the
+ * poll callback only the first of each in a window is recorded; what the
+ * model claims is that each ran, not how often.
+ */
+static void
+hook_log(
+    struct prog_state *ps,
+    int                which)
+{
+    if (!ps->hook_logged[which]) {
+        ps->hook_logged[which] = 1;
+        log_event(ps, CEV_EVHOOK, which, 1);
+    }
+} /* hook_log */
+
+static void
+hook_iteration_end_cb(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    hook_log(private_data, 0);
+} /* hook_iteration_end_cb */
+
+static void
+hook_pre_wait_cb(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    hook_log(private_data, 1);
+} /* hook_pre_wait_cb */
+
+static void
+hook_post_wait_cb(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    hook_log(private_data, 2);
+} /* hook_post_wait_cb */
+
+/* Position-keyed, so the check is on WHICH bytes arrived and not merely how
+ * many.  A payload delivered at the wrong offset, duplicated, or reordered
+ * has the right length and the wrong content. */
+static inline uint8_t
+pattern_byte(uint64_t off)
+{
+    return (uint8_t) (off * 31u + 17u);
+} /* pattern_byte */
+
+static void
+verify_bytes(
+    struct prog_state *ps,
+    int                conn,
+    int                side,
+    const uint8_t     *data,
+    int                len)
+{
+    struct conn_slot *cs = &ps->conns[conn];
+    int               i;
+
+    for (i = 0; i < len; i++) {
+        uint8_t want = pattern_byte(cs->rx_off[side] + i);
+
+        evpl_test_abort_if(data[i] != want,
+                           "conn %d side %d: byte at stream offset %llu is "
+                           "0x%02x, expected 0x%02x -- the payload arrived "
+                           "corrupt, short, duplicated or out of order",
+                           conn, side,
+                           (unsigned long long) (cs->rx_off[side] + i),
+                           data[i], want);
+    }
+
+    cs->rx_off[side] += len;
+    g_results.bytes  += len;
+} /* verify_bytes */
+
+/*
+ * Take everything buffered on this end, whichever way the program asked for.
+ * The three modes must be interchangeable -- the byte stream is the same
+ * however it is drained -- so the model states one obligation and this is
+ * where the variation lives.
+ */
+static void
+drain_end(
+    struct prog_state *ps,
+    struct end_ctx    *ec)
+{
+    struct conn_slot *cs   = &ps->conns[ec->conn];
+    struct evpl_bind *bind = cs->bind[ec->side];
+    struct evpl_iovec iov[MAX_RECVV_IOV];
+    int               n, niov, length, i;
+
+    if (!bind) {
+        return;
+    }
+
+    switch (cs->drain) {
+        case CDRN_DRAINRECV:
+            while ((n = evpl_recv(ps->evpl, bind, ps->recvbuf, RECV_SCRATCH,
+                                  0)) > 0) {
+                verify_bytes(ps, ec->conn, ec->side, ps->recvbuf, n);
+                log_event(ps, CEV_EVRECV, END_SLOT(ec->conn, ec->side),
+                          (uint32_t) n);
+            }
+            break;
+
+        case CDRN_DRAINRECVV:
+            /* evpl_recvv CLONES: the iovecs it hands back carry references
+             * this end now owns, so failing to release them leaks a buffer
+             * per call and evpl_allocator_destroy aborts at teardown. */
+            while ((niov = evpl_recvv(ps->evpl, bind, iov, MAX_RECVV_IOV,
+                                      RECV_SCRATCH, &length)) > 0) {
+                for (i = 0; i < niov; i++) {
+                    verify_bytes(ps, ec->conn, ec->side, iov[i].data,
+                                 iov[i].length);
+                }
+
+                log_event(ps, CEV_EVRECV, END_SLOT(ec->conn, ec->side),
+                          (uint32_t) length);
+
+                evpl_iovecs_release(ps->evpl, iov, niov);
+            }
+            break;
+
+        case CDRN_DRAINPEEK:
+            /* evpl_peek copies without consuming, so the bytes are still
+             * there afterwards; consuming exactly what was peeked is the
+             * contract between the two, and consuming more than is buffered
+             * is required to fail. */
+            while ((n = evpl_peek(ps->evpl, bind, ps->recvbuf,
+                                  RECV_SCRATCH)) > 0) {
+                verify_bytes(ps, ec->conn, ec->side, ps->recvbuf, n);
+
+                evpl_test_abort_if(evpl_consume(ps->evpl, bind, n),
+                                   "conn %d side %d: consume of %d peeked "
+                                   "bytes failed, so peek reported bytes the "
+                                   "bind does not hold",
+                                   ec->conn, ec->side, n);
+
+                log_event(ps, CEV_EVRECV, END_SLOT(ec->conn, ec->side),
+                          (uint32_t) n);
+            }
+            break;
+
+        case CDRN_DRAINPEEKV:
+            /* evpl_peekv does NOT clone, unlike evpl_recvv: the iovecs it
+             * hands back are borrowed views of the receive ring, so they must
+             * not be released -- doing so would drop a reference this end
+             * never took.  Nor does it consume, which is why the length has
+             * to be summed back out of the iovecs and handed to
+             * evpl_consume. */
+            while ((niov = evpl_peekv(ps->evpl, bind, iov, MAX_RECVV_IOV,
+                                      RECV_SCRATCH)) > 0) {
+                length = 0;
+
+                for (i = 0; i < niov; i++) {
+                    verify_bytes(ps, ec->conn, ec->side, iov[i].data,
+                                 iov[i].length);
+                    length += iov[i].length;
+                }
+
+                evpl_test_abort_if(evpl_consume(ps->evpl, bind, length),
+                                   "conn %d side %d: consume of %d peeked "
+                                   "bytes failed, so peekv reported bytes the "
+                                   "bind does not hold",
+                                   ec->conn, ec->side, length);
+
+                log_event(ps, CEV_EVRECV, END_SLOT(ec->conn, ec->side),
+                          (uint32_t) length);
+            }
+            break;
+
+        default:
+            evpl_test_abort("unknown drain mode %d", cs->drain);
+    } /* switch */
+} /* drain_end */
+
+static void
+conn_notify_cb(
+    struct evpl        *evpl,
+    struct evpl_bind   *bind,
+    struct evpl_notify *notify,
+    void               *private_data)
+{
+    struct end_ctx   *ec = private_data;
+    struct conn_slot *cs = &ec->ps->conns[ec->conn];
+
+    switch (notify->notify_type) {
+        case EVPL_NOTIFY_CONNECTED:
+            cs->bind[ec->side] = bind;
+
+            /* Accessors on a bind that is definitely up.  Sequence-free, so
+             * they live here rather than in the model; the point of checking
+             * them on a live connection is that there is no other state in
+             * which their answers mean anything. */
+            {
+                char addr[EVPL_ADDRESS_STRLEN];
+
+                evpl_test_abort_if(evpl_bind_get_protocol(bind) !=
+                                   ec->ps->proto,
+                                   "a bind reports a protocol it was not "
+                                   "created with");
+                /* The in-process DATAGRAM transport advertises RDMA on
+                 * purpose -- it is what lets rpc2 exercise its chunk and
+                 * rdma_msg paths with no hardware -- so only the stream one
+                 * is required to say no. */
+                evpl_test_abort_if(ec->ps->proto == EVPL_STREAM_INPROC &&
+                                   evpl_bind_is_rdma(bind),
+                                   "an in-process stream bind claims to be RDMA");
+                evpl_test_abort_if(evpl_bind_is_closing(bind),
+                                   "a bind is closing before it has been used");
+
+                evpl_bind_get_local_address(bind, addr, sizeof(addr));
+                evpl_test_abort_if(addr[0] == '\0',
+                                   "a connected bind has no local address");
+
+                evpl_bind_get_remote_address(bind, addr, sizeof(addr));
+                evpl_test_abort_if(addr[0] == '\0',
+                                   "a connected bind has no remote address");
+            }
+            log_event(ec->ps, CEV_EVCONNECTED, END_SLOT(ec->conn, ec->side), 1);
+            break;
+
+        case EVPL_NOTIFY_DISCONNECTED:
+            /* The bind is freed once this returns, so drop it here: anything
+             * that reached for it afterwards would be a use after free, and
+             * the model's own state says this end is gone. */
+            cs->bind[ec->side] = NULL;
+            log_event(ec->ps, CEV_EVDISCONNECTED, END_SLOT(ec->conn, ec->side),
+                      1);
+            break;
+
+        case EVPL_NOTIFY_RECV_DATA:
+            drain_end(ec->ps, ec);
+            break;
+
+        case EVPL_NOTIFY_RECV_MSG:
+            /*
+             * A datagram arrives whole, in the notification, rather than being
+             * drained off the bind -- evpl_recv and friends are stream-only
+             * and refuse a datagram bind outright.  The iovecs are the
+             * receiver's to release, the same rule as evpl_recvv.
+             */
+        {
+            struct conn_slot *dcs = &ec->ps->conns[ec->conn];
+            unsigned int      i;
+
+            for (i = 0; i < notify->recv_msg.niov; i++) {
+                verify_bytes(ec->ps, ec->conn, ec->side,
+                             notify->recv_msg.iovec[i].data,
+                             notify->recv_msg.iovec[i].length);
+            }
+
+            (void) dcs;
+
+            log_event(ec->ps, CEV_EVRECV, END_SLOT(ec->conn, ec->side),
+                      notify->recv_msg.length);
+
+            /* One delivery.  Counting these separately from the bytes is
+             * the only way a coalesced or split datagram is visible. */
+            log_event(ec->ps, CEV_EVRECVMSG, END_SLOT(ec->conn, ec->side), 1);
+
+            evpl_iovecs_release(ec->ps->evpl, notify->recv_msg.iovec,
+                                notify->recv_msg.niov);
+        }
+        break;
+
+        case EVPL_NOTIFY_SENT:
+            /* Counted in bytes, not notifications: how many the transport
+             * batches the sends into is its business. */
+            log_event(ec->ps, CEV_EVSENT, END_SLOT(ec->conn, ec->side),
+                      (uint32_t) notify->sent.bytes);
+            break;
+
+        default:
+            break;
+    } /* switch */
+} /* conn_notify_cb */
+
+static void
+accept_cb(
+    struct evpl             *evpl,
+    struct evpl_bind        *bind,
+    evpl_notify_callback_t  *notify_callback,
+    evpl_segment_callback_t *segment_callback,
+    void                   **conn_private_data,
+    void                    *private_data)
+{
+    struct prog_state *ps = private_data;
+    int                c  = ps->pending_connect;
+
+    evpl_test_abort_if(c < 0,
+                       "a connection was accepted with no connect "
+                       "outstanding, so the accepted end cannot be attributed "
+                       "to one of the model's connections");
+
+    ps->conns[c].bind[SIDE_SERVER] = bind;
+
+    *notify_callback   = conn_notify_cb;
+    *conn_private_data = &ps->conns[c].ctx[SIDE_SERVER];
+
+    ps->pending_connect = -1;
+} /* accept_cb */
+
+/* ------------------------------------------------------------------ */
+
+/* Total occurrences of (kind, slot) logged in the current window. */
+static uint64_t
+window_count(
+    struct prog_state *ps,
+    uint8_t            kind,
+    uint8_t            slot)
+{
+    uint64_t total = 0;
+    int      i;
+
+    for (i = ps->window; i < ps->nlog; i++) {
+        if (ps->log[i].kind == kind && ps->log[i].slot == slot) {
+            total += ps->log[i].count;
+        }
+    }
+
+    return total;
+} /* window_count */
+
+/* Whether everything this window is owed has arrived.  Says nothing about
+ * what should NOT have arrived; that is check_window's business, and the
+ * clock's. */
+static int
+expectations_met(
+    struct prog_state      *ps,
+    const struct core_step *step)
+{
+    int i;
+
+    for (i = 0; i < step->expect_count; i++) {
+        const struct core_expect *e = &core_expects[step->expect_first + i];
+
+        if (window_count(ps, e->kind, e->slot) < e->count) {
+            return 0;
+        }
+    }
+
+    return 1;
+} /* expectations_met */
+
+/*
+ * Hold one quiesce window against what the model says was owed.
+ *
+ * Returns the number of unsuppressed failures.
+ */
+static int
+check_window(
+    struct prog_state      *ps,
+    const struct core_step *step,
+    int                     prog,
+    int                     stepno)
+{
+    uint64_t seen[NUM_EVENT_KIND][MAX_SLOT];
+    int      first[NUM_EVENT_KIND][MAX_SLOT];
+    int      covered[NUM_EVENT_KIND][MAX_SLOT];
+    int      i, k, s, failures = 0;
+
+    memset(seen, 0, sizeof(seen));
+    memset(covered, 0, sizeof(covered));
+
+    for (k = 0; k < NUM_EVENT_KIND; k++) {
+        for (s = 0; s < MAX_SLOT; s++) {
+            first[k][s] = -1;
+        }
+    }
+
+    for (i = ps->window; i < ps->nlog; i++) {
+        k = ps->log[i].kind;
+        s = ps->log[i].slot;
+
+        evpl_test_abort_if(k >= NUM_EVENT_KIND || s >= MAX_SLOT,
+                           "logged an event outside the model's object space");
+
+        seen[k][s] += ps->log[i].count;
+
+        if (first[k][s] < 0) {
+            first[k][s] = i;
+        }
+    }
+
+    /* Direction one: every obligation discharged. */
+    for (i = 0; i < step->expect_count; i++) {
+        const struct core_expect *e    = &core_expects[step->expect_first + i];
+        uint64_t                  got  = seen[e->kind][e->slot];
+        int                       fail = -1;
+
+        g_results.obligations++;
+        covered[e->kind][e->slot] = 1;
+
+        if (got < e->count) {
+            fail = CFAIL_MISSING;
+        } else if (e->mult == CMUL_MEXACTLY && got > e->count) {
+            fail = CFAIL_EXTRA;
+        }
+
+        if (fail < 0) {
+            continue;
+        }
+
+        if (is_known_divergence(e->kind, e->mult, e->count, (uint8_t) fail)) {
+            g_results.known++;
+            continue;
+        }
+
+        evpl_test_error(
+            "program %d step %d: %s %s for slot %d: required %s %u, got %llu",
+            prog, stepno, failure_name((uint8_t) fail), event_name(e->kind),
+            e->slot, e->mult == CMUL_MEXACTLY ? "exactly" : "at least",
+            e->count, (unsigned long long) got);
+        failures++;
+    }
+
+    /*
+     * Direction two: nothing arrived that was not owed.  This is the check
+     * that makes an absence observable, and the reason a quiesce runs its
+     * whole window instead of stopping once the obligations above are met.
+     */
+    for (k = 0; k < NUM_EVENT_KIND; k++) {
+        for (s = 0; s < MAX_SLOT; s++) {
+            if (!seen[k][s] || covered[k][s]) {
+                continue;
+            }
+
+            if (is_known_divergence((uint8_t) k, CMUL_MEXACTLY, 0,
+                                    CFAIL_UNEXPECTED)) {
+                g_results.known++;
+                continue;
+            }
+
+            evpl_test_error(
+                "program %d step %d: unexpected %s for slot %d (%llu) -- "
+                "nothing armed it, or something that was retired delivered "
+                "anyway",
+                prog, stepno, event_name((uint8_t) k), s,
+                (unsigned long long) seen[k][s]);
+            failures++;
+        }
+    }
+
+    /* Direction three: the orderings the model claims. */
+    for (i = 0; i < step->order_count; i++) {
+        const struct core_order *o = &core_orders[step->order_first + i];
+        int                      a = first[o->first_kind][o->first_slot];
+        int                      b = first[o->then_kind][o->then_slot];
+
+        if (a >= 0 && b >= 0 && a < b) {
+            continue;
+        }
+
+        if (is_known_divergence(o->first_kind, CMUL_MEXACTLY, 0, CFAIL_ORDER)) {
+            g_results.known++;
+            continue;
+        }
+
+        evpl_test_error(
+            "program %d step %d: %s slot %d must be delivered before %s slot "
+            "%d (first seen at %d and %d)",
+            prog, stepno, event_name(o->first_kind), o->first_slot,
+            event_name(o->then_kind), o->then_slot, a, b);
+        failures++;
+    }
+
+    return failures;
+} /* check_window */
+
+static int
+do_quiesce(
+    struct prog_state      *ps,
+    const struct core_step *step,
+    int                     prog,
+    int                     stepno)
+{
+    uint64_t target = ps->base_ns + (uint64_t) step->at_ms * TICK_NS;
+    int      i;
+
+    ps->window      = ps->nlog;
+    ps->poll_logged = 0;
+
+    memset(ps->hook_logged, 0, sizeof(ps->hook_logged));
+
+    /*
+     * The whole window, a tick at a time, unconditionally.  Stopping as soon
+     * as the obligations were met would make every "must not fire" claim
+     * vacuous, and those are half of what this model states -- an absence is
+     * only observed by getting to the end of the window without it.
+     *
+     * Which is cheap here in a way it is not on a real clock: the window
+     * costs a few hundred non-blocking passes of the loop rather than its
+     * length in milliseconds of sleep.
+     */
+    while (evpl_virtual_clock_now() < target) {
+        evpl_virtual_clock_advance(TICK_NS);
+        settle(ps);
+    }
+
+    /* Anything still outstanding is waiting on another thread rather than on
+     * the clock; see AWAIT_PASSES. */
+    for (i = 0; i < AWAIT_PASSES && !expectations_met(ps, step); i++) {
+        evpl_continue(ps->evpl);
+    }
+
+    g_results.quiesces++;
+
+    return check_window(ps, step, prog, stepno);
+} /* do_quiesce */
+
+/* ------------------------------------------------------------------ */
+
+static void
+do_listen(
+    struct prog_state *ps,
+    int                prog)
+{
+    /* Long enough for a socket path; sun_path is 108. */
+    char name[108];
+
+    if (evpl_protocol_is_local(ps->proto)) {
+        int len = snprintf(name, sizeof(name), "%s/cc-%d-%d-%d.sock",
+                           socket_dir(), (int) getpid(), prog,
+                           ps->listen_seq++);
+
+        if (len < 0 || (size_t) len >= sizeof(name)) {
+            snprintf(name, sizeof(name), "/tmp/cc-%d-%d-%d.sock",
+                     (int) getpid(), prog, ps->listen_seq++);
+        }
+
+        ps->endpoint = evpl_endpoint_create_local(name);
+    } else if (evpl_protocol_is_inproc(ps->proto)) {
+        /* The registry behind an in-process name is private to this process,
+         * so the pid is not needed for isolation from other test binaries --
+         * but the program and sequence numbers are, because a name is only
+         * released when its listener is destroyed and a program may listen
+         * more than once. */
+        snprintf(name, sizeof(name), "core-conf-%d-%d-%d", (int) getpid(),
+                 prog, ps->listen_seq++);
+
+        ps->endpoint = evpl_endpoint_create_inproc(name);
+    } else {
+        /* A port of its own per listen; see CONF_BASE_PORT. */
+        snprintf(name, sizeof(name), "127.0.0.1:%d",
+                 CONF_BASE_PORT + g_port_seq);
+
+        ps->endpoint = evpl_endpoint_create("127.0.0.1",
+                                            CONF_BASE_PORT + g_port_seq++);
+    }
+
+    evpl_test_abort_if(!ps->endpoint, "failed to create endpoint '%s'", name);
+
+    ps->listener = evpl_listener_create();
+    ps->binding  = evpl_listener_attach(ps->evpl, ps->listener, accept_cb, ps);
+
+    evpl_test_abort_if(evpl_listen(ps->listener, ps->proto, ps->endpoint),
+                       "failed to listen on '%s'", name);
+} /* do_listen */
+
+static void
+do_stop_listen(struct prog_state *ps)
+{
+    evpl_listener_detach(ps->evpl, ps->binding);
+    evpl_listener_destroy(ps->listener);
+    evpl_endpoint_close(ps->endpoint);
+
+    ps->binding  = NULL;
+    ps->listener = NULL;
+    ps->endpoint = NULL;
+} /* do_stop_listen */
+
+static void
+do_connect(
+    struct prog_state      *ps,
+    const struct core_step *step)
+{
+    struct conn_slot *cs = &ps->conns[step->conn];
+
+    cs->drain = step->drain;
+
+    memset(cs->tx_off, 0, sizeof(cs->tx_off));
+    memset(cs->rx_off, 0, sizeof(cs->rx_off));
+
+    ps->pending_connect = step->conn;
+
+    cs->bind[SIDE_CLIENT] = evpl_connect(ps->evpl, ps->proto, NULL,
+                                         ps->endpoint, conn_notify_cb, NULL,
+                                         &cs->ctx[SIDE_CLIENT]);
+
+    evpl_test_abort_if(!cs->bind[SIDE_CLIENT],
+                       "connect on conn %d returned no bind", step->conn);
+} /* do_connect */
+
+/*
+ * Fill freshly allocated iovecs with the pattern the peer expects.  The
+ * allocator may hand back several, so the pattern has to be written across
+ * them by position rather than per-buffer.
+ */
+static void
+fill_iovecs(
+    uint64_t           off,
+    struct evpl_iovec *iov,
+    int                niov,
+    int                len)
+{
+    uint64_t written = 0;
+    int      i, j;
+
+    for (i = 0; i < niov; i++) {
+        uint8_t *p = iov[i].data;
+
+        for (j = 0; j < (int) iov[i].length; j++) {
+            p[j] = pattern_byte(off + written + j);
+        }
+
+        written += iov[i].length;
+    }
+
+    evpl_test_abort_if(written != (uint64_t) len,
+                       "iovecs cover %llu bytes, asked for %d",
+                       (unsigned long long) written, len);
+} /* fill_iovecs */
+
+static int
+alloc_and_fill(
+    struct prog_state *ps,
+    uint64_t           off,
+    int                len,
+    struct evpl_iovec *iov)
+{
+    int niov = evpl_iovec_alloc(ps->evpl, len, 0, MAX_SEND_IOV, 0, iov);
+
+    evpl_test_abort_if(niov < 1,
+                       "failed to allocate %d bytes of send space in at most "
+                       "%d iovecs", len, MAX_SEND_IOV);
+
+    fill_iovecs(off, iov, niov, len);
+
+    return niov;
+} /* alloc_and_fill */
+
+/*
+ * Both ends of an unconnected pair.
+ *
+ * There is no listen, no connect and no handshake: each end binds an address
+ * of its own and names the other's when it sends.  Nothing is notified about
+ * the pair coming up, which is why the model owes nothing for this op where
+ * connect owes two CONNECTED.
+ */
+static void
+do_bind_pair(
+    struct prog_state      *ps,
+    const struct core_step *step)
+{
+    struct conn_slot *cs = &ps->conns[step->conn];
+    int               s;
+
+    memset(cs->tx_off, 0, sizeof(cs->tx_off));
+    memset(cs->rx_off, 0, sizeof(cs->rx_off));
+
+    for (s = 0; s < NUM_SIDE; s++) {
+        cs->ep[s] = evpl_endpoint_create("127.0.0.1",
+                                         CONF_BASE_PORT + g_port_seq++);
+
+        evpl_test_abort_if(!cs->ep[s], "failed to create a bind endpoint");
+
+        cs->bind[s] = evpl_bind(ps->evpl, ps->proto, cs->ep[s],
+                                conn_notify_cb, &cs->ctx[s]);
+
+        evpl_test_abort_if(!cs->bind[s],
+                           "failed to bind conn %d side %d", step->conn, s);
+    }
+} /* do_bind_pair */
+
+/*
+ * Every send mode must put the same bytes on the wire; what differs is who
+ * owns the references afterwards.  Without EVPL_SEND_FLAG_TAKE_REF the send
+ * path clones and this end must release its own; with it the references are
+ * handed over and releasing them here would be a double free.  Both directions
+ * of getting that wrong are caught at teardown by evpl_allocator_destroy.
+ */
+static void
+do_send(
+    struct prog_state      *ps,
+    const struct core_step *step)
+{
+    struct conn_slot     *cs   = &ps->conns[step->conn];
+    struct evpl_bind     *bind = cs->bind[step->side];
+    int                   dest = PEER(step->side);
+    int                   len  = size_bytes(step->size);
+    struct evpl_endpoint *dest_ep;
+    struct evpl_iovec     iov[MAX_SEND_IOV];
+    int                   niov, i;
+
+    evpl_test_abort_if(len <= 0 || len > MAX_SEND_BYTES,
+                       "size class %d is outside the driver's send buffer",
+                       step->size);
+
+    evpl_test_abort_if(!bind,
+                       "send on conn %d side %d, which has no bind -- the "
+                       "model believes this connection is up",
+                       step->conn, step->side);
+
+    switch (step->send) {
+        case CSND_SENDBUF:
+            for (i = 0; i < len; i++) {
+                ps->sendbuf[i] = pattern_byte(cs->tx_off[dest] + i);
+            }
+            evpl_send(ps->evpl, bind, ps->sendbuf, len);
+            break;
+
+        /* Not generated today; see SendMode in core.qnt.  The arms stay so
+         * that re-enabling them is a one-line change in the model once the
+         * address ownership on that path is settled. */
+        case CSND_SENDTOEP:
+            dest_ep = cs->ep[dest] ? cs->ep[dest] : ps->endpoint;
+            evpl_test_abort_if(!dest_ep,
+                               "sendtoep with no endpoint to address");
+            for (i = 0; i < len; i++) {
+                ps->sendbuf[i] = pattern_byte(cs->tx_off[dest] + i);
+            }
+            evpl_sendtoep(ps->evpl, bind, dest_ep, ps->sendbuf, len);
+            break;
+
+        case CSND_SENDV:
+            niov = alloc_and_fill(ps, cs->tx_off[dest], len, iov);
+            evpl_sendv(ps->evpl, bind, iov, niov, len, 0);
+            /* Cloned by the send path, so this end still holds its own. */
+            evpl_iovecs_release(ps->evpl, iov, niov);
+            break;
+
+        case CSND_SENDRESERVECOMMIT:
+            /* Reserve takes references on space without charging it to the
+             * buffer; commit is what tells the allocator how much was used
+             * and hands the rest back for the next allocation.  Sending with
+             * TAKE_REF then transfers the references reserve took. */
+            niov = evpl_iovec_reserve(ps->evpl, len, 0, MAX_SEND_IOV, iov);
+            evpl_test_abort_if(niov < 1,
+                               "failed to reserve %d bytes in at most %d iovecs",
+                               len, MAX_SEND_IOV);
+            fill_iovecs(cs->tx_off[dest], iov, niov, len);
+            evpl_iovec_commit(ps->evpl, 0, iov, niov);
+            evpl_sendv(ps->evpl, bind, iov, niov, len,
+                       EVPL_SEND_FLAG_TAKE_REF);
+            break;
+
+        case CSND_SENDGLOBAL:
+            /* One whole buffer whose lifetime this end owns outright.  Sent
+             * without TAKE_REF so the send path takes a borrow -- which for a
+             * GLOBAL buffer is not counted and does not keep it alive, so the
+             * owning reference is held until teardown rather than released
+             * here.  Releasing it now would hand the buffer back to the pool
+             * while the transport still has it queued. */
+            evpl_test_abort_if(ps->nglobals >= MAX_GLOBAL_IOV,
+                               "program holds more than %d global iovecs",
+                               MAX_GLOBAL_IOV);
+
+            evpl_iovec_alloc_global(ps->evpl, &iov[0]);
+
+            evpl_test_abort_if((int) evpl_iovec_length(&iov[0]) < len,
+                               "a global iovec is %u bytes, too small for a "
+                               "%d byte payload",
+                               evpl_iovec_length(&iov[0]), len);
+
+            evpl_iovec_set_length(&iov[0], len);
+            fill_iovecs(cs->tx_off[dest], iov, 1, len);
+
+            evpl_sendv(ps->evpl, bind, iov, 1, len, 0);
+
+            /* Moved, not copied: an iovec carries ownership, and the debug
+             * build tracks which struct holds it.  A plain assignment leaves
+             * that tracking pointing at the stack slot this one came from. */
+            evpl_iovec_move(&ps->globals[ps->nglobals++], &iov[0]);
+            break;
+
+        case CSND_SENDVTAKEREF:
+            niov = alloc_and_fill(ps, cs->tx_off[dest], len, iov);
+            evpl_sendv(ps->evpl, bind, iov, niov, len,
+                       EVPL_SEND_FLAG_TAKE_REF);
+            /* Handed over; releasing here would be a double free. */
+            break;
+
+        case CSND_SENDTOEPV:
+            dest_ep = cs->ep[dest] ? cs->ep[dest] : ps->endpoint;
+            evpl_test_abort_if(!dest_ep,
+                               "sendtoepv with no endpoint to address");
+            niov = alloc_and_fill(ps, cs->tx_off[dest], len, iov);
+            evpl_sendtoepv(ps->evpl, bind, dest_ep, iov, niov, len,
+                           EVPL_SEND_FLAG_TAKE_REF);
+            break;
+
+        default:
+            evpl_test_abort("unknown send mode %d", step->send);
+    } /* switch */
+
+    cs->tx_off[dest] += len;
+} /* do_send */
+
+static int
+run_step(
+    struct prog_state      *ps,
+    const struct core_step *step,
+    int                     prog,
+    int                     stepno)
+{
+    struct timer_slot    *ts;
+    struct deferral_slot *ds;
+    struct doorbell_slot *bs;
+    struct conn_slot     *cs;
+
+    g_results.steps++;
+
+    evpl_test_abort_if(step->slot >= MAX_SLOT || step->conn >= MAX_CONN,
+                       "program %d step %d: object index outside the driver's "
+                       "tables", prog, stepno);
+
+    switch (step->op) {
+        case COP_OPADDTIMER:
+            ts           = &ps->timers[step->slot];
+            ts->delay_us = step->delay == CDLY_DFAST ? DELAY_FAST_US
+                                                     : DELAY_SLOW_US;
+            ts->rearm_left = step->timer_kind == CTK_TREARM ? 1 : 0;
+            ts->armed      = 1;
+
+            if (step->timer_kind == CTK_TPERIODIC) {
+                evpl_add_timer(ps->evpl, &ts->timer, timer_cb, ts->delay_us);
+                /* Periodic timers stay in the set until removed, so teardown
+                 * has to know to take them out. */
+                ts->armed = 2;
+            } else {
+                evpl_add_oneshot_timer(ps->evpl, &ts->timer, timer_cb,
+                                       ts->delay_us);
+            }
+            break;
+
+        case COP_OPREMOVETIMER:
+            ts = &ps->timers[step->slot];
+            evpl_remove_timer(ps->evpl, &ts->timer);
+            ts->rearm_left = 0;
+            ts->armed      = 0;
+            break;
+
+        case COP_OPDEFER:
+            ds = &ps->deferrals[step->slot];
+            evpl_defer(ps->evpl, &ds->deferral);
+            break;
+
+        case COP_OPDEFERTWICE:
+            /* Two armings before the loop gets a chance to run either.  The
+             * `armed` flag is supposed to collapse them into one callback. */
+            ds = &ps->deferrals[step->slot];
+            evpl_defer(ps->evpl, &ds->deferral);
+            evpl_defer(ps->evpl, &ds->deferral);
+            break;
+
+        case COP_OPDEFERREENTRANT:
+            ds               = &ps->deferrals[step->slot];
+            ds->redefer_left = 1;
+            evpl_defer(ps->evpl, &ds->deferral);
+            break;
+
+        case COP_OPADDDOORBELL:
+            bs          = &ps->doorbells[step->slot];
+            bs->present = 1;
+            evpl_add_doorbell(ps->evpl, &bs->doorbell, doorbell_cb);
+            evpl_test_abort_if(evpl_doorbell_fd(&bs->doorbell) < 0,
+                               "program %d step %d: doorbell %d has no "
+                               "descriptor after being added",
+                               prog, stepno, step->slot);
+            break;
+
+        case COP_OPRINGDOORBELL:
+            bs = &ps->doorbells[step->slot];
+            evpl_ring_doorbell(&bs->doorbell);
+            break;
+
+        case COP_OPRINGDOORBELLTWICE:
+            bs = &ps->doorbells[step->slot];
+            evpl_ring_doorbell(&bs->doorbell);
+            evpl_ring_doorbell(&bs->doorbell);
+            break;
+
+        case COP_OPREMOVEDOORBELL:
+            bs          = &ps->doorbells[step->slot];
+            bs->present = 0;
+            evpl_remove_doorbell(ps->evpl, &bs->doorbell);
+            break;
+
+        case COP_OPREMOVEDOORBELLINCALLBACK:
+            /* Arm the callback to retire it, then ring once.  The removal
+             * happens inside the callback, during the next quiesce. */
+            bs               = &ps->doorbells[step->slot];
+            bs->remove_in_cb = 1;
+            evpl_ring_doorbell(&bs->doorbell);
+            break;
+
+        case COP_OPREMOVEDEFERRAL:
+        case COP_OPREMOVEDEFERRALIDLE:
+            /* One call for both: the difference is the state it is made in,
+             * which is the model's business, and the library's promise is
+             * that the idle case is harmless. */
+            ds               = &ps->deferrals[step->slot];
+            ds->redefer_left = 0;
+            evpl_remove_deferral(ps->evpl, &ds->deferral);
+            break;
+
+        case COP_OPREQUESTSENDNOTIFY:
+            cs = &ps->conns[step->conn];
+            evpl_test_abort_if(!cs->bind[step->side],
+                               "send notifications requested on conn %d side "
+                               "%d, which has no bind", step->conn, step->side);
+            evpl_bind_request_send_notifications(ps->evpl,
+                                                 cs->bind[step->side]);
+            break;
+
+        case COP_OPSETLOOPHOOKS:
+            ps->hooks.iteration_end = hook_iteration_end_cb;
+            ps->hooks.pre_wait      = hook_pre_wait_cb;
+            ps->hooks.post_wait     = hook_post_wait_cb;
+            ps->hooks.private_data  = ps;
+            evpl_set_loop_hooks(ps->evpl, &ps->hooks);
+            break;
+
+        case COP_OPCLEARLOOPHOOKS:
+            evpl_set_loop_hooks(ps->evpl, NULL);
+            break;
+
+        case COP_OPADDPOLL:
+            ps->poll = evpl_add_poll(ps->evpl, poll_enter_cb, poll_exit_cb,
+                                     poll_cb, ps);
+            evpl_test_abort_if(!ps->poll, "evpl_add_poll returned nothing");
+            break;
+
+        case COP_OPREMOVEPOLL:
+            evpl_remove_poll(ps->evpl, ps->poll);
+            ps->poll = NULL;
+            break;
+
+        case COP_OPACTIVITY:
+            evpl_activity(ps->evpl);
+            break;
+
+        case COP_OPPOLLPIN:
+            evpl_poll_pin(ps->evpl);
+            break;
+
+        case COP_OPPOLLUNPIN:
+            evpl_poll_unpin(ps->evpl);
+            break;
+
+        case COP_OPLISTEN:
+            do_listen(ps, prog);
+            break;
+
+        case COP_OPSTOPLISTEN:
+            do_stop_listen(ps);
+            break;
+
+        case COP_OPBINDPAIR:
+            do_bind_pair(ps, step);
+            break;
+
+        case COP_OPCONNECT:
+            do_connect(ps, step);
+            break;
+
+        case COP_OPSEND:
+            do_send(ps, step);
+            break;
+
+        case COP_OPCLOSE:
+            cs = &ps->conns[step->conn];
+            evpl_test_abort_if(!cs->bind[step->side],
+                               "close on conn %d side %d, which has no bind",
+                               step->conn, step->side);
+            evpl_close(ps->evpl, cs->bind[step->side]);
+            break;
+
+        case COP_OPFINISH:
+            cs = &ps->conns[step->conn];
+            evpl_test_abort_if(!cs->bind[step->side],
+                               "finish on conn %d side %d, which has no bind",
+                               step->conn, step->side);
+            evpl_finish(ps->evpl, cs->bind[step->side]);
+            break;
+
+        case COP_OPQUIESCE:
+            return do_quiesce(ps, step, prog, stepno);
+
+        default:
+            evpl_test_abort("program %d step %d: op %d has no arm in the "
+                            "driver", prog, stepno, step->op);
+    } /* switch */
+
+    return 0;
+} /* run_step */
+
+/*
+ * Teardown is the driver's own business, not part of the specification under
+ * test: the model does not require a program to leave its objects retired, so
+ * anything still armed, connected or listening is taken out here rather than
+ * left for evpl_destroy to find.
+ */
+static void
+teardown_program(struct prog_state *ps)
+{
+    int i, s;
+
+    for (i = 0; i < MAX_CONN; i++) {
+        for (s = 0; s < NUM_SIDE; s++) {
+            if (ps->conns[i].bind[s]) {
+                evpl_close(ps->evpl, ps->conns[i].bind[s]);
+            }
+        }
+    }
+
+    /* Let those closes dispatch.  Their disconnect callbacks land after the
+     * last window, where nothing is checking, which is the point: a program's
+     * claims end with its last quiesce. */
+    settle(ps);
+
+    if (ps->listener) {
+        do_stop_listen(ps);
+    }
+
+    for (i = 0; i < MAX_CONN; i++) {
+        for (s = 0; s < NUM_SIDE; s++) {
+            if (ps->conns[i].ep[s]) {
+                evpl_endpoint_close(ps->conns[i].ep[s]);
+                ps->conns[i].ep[s] = NULL;
+            }
+        }
+    }
+
+    if (ps->poll) {
+        evpl_remove_poll(ps->evpl, ps->poll);
+    }
+
+    /* The owning reference on each global buffer, given back exactly once.
+    * Clones the send path took are non-owning and must not be released. */
+    for (i = 0; i < ps->nglobals; i++) {
+        evpl_iovec_release(ps->evpl, &ps->globals[i]);
+    }
+
+    for (i = 0; i < MAX_SLOT; i++) {
+        if (ps->timers[i].armed) {
+            evpl_remove_timer(ps->evpl, &ps->timers[i].timer);
+        }
+        if (ps->doorbells[i].present) {
+            evpl_remove_doorbell(ps->evpl, &ps->doorbells[i].doorbell);
+        }
+    }
+
+    evpl_destroy(ps->evpl);
+} /* teardown_program */
+
+static int
+run_program(
+    const struct core_program *p,
+    int                        prog)
+{
+    struct evpl_thread_config *tcfg;
+    struct prog_state         *ps;
+    int                        i, s, failures = 0;
+
+    ps = calloc(1, sizeof(*ps));
+    evpl_test_abort_if(!ps, "out of memory");
+
+    ps->pending_connect = -1;
+
+    for (i = 0; i < MAX_SLOT; i++) {
+        ps->timers[i].ps      = ps;
+        ps->timers[i].slot    = i;
+        ps->deferrals[i].ps   = ps;
+        ps->deferrals[i].slot = i;
+        ps->doorbells[i].ps   = ps;
+        ps->doorbells[i].slot = i;
+
+        evpl_deferral_init(&ps->deferrals[i].deferral, deferral_cb,
+                           &ps->deferrals[i]);
+    }
+
+    for (i = 0; i < MAX_CONN; i++) {
+        for (s = 0; s < NUM_SIDE; s++) {
+            ps->conns[i].ctx[s].ps   = ps;
+            ps->conns[i].ctx[s].conn = i;
+            ps->conns[i].ctx[s].side = s;
+        }
+    }
+
+    /*
+     * Poll mode on for every program: with no poll registered the loop never
+     * enters it, so this costs the programs that do not use one nothing and
+     * saves the model a per-program dimension.  See POLL_ITERATIONS for why
+     * the default iteration count would make the mode untestable.
+     *
+     * No wait_ms: on the virtual clock the core wait is already non-blocking,
+     * because nothing can become due while the loop is inside it.
+     *
+     * evpl_create() takes ownership of the config and releases it itself.
+     */
+    tcfg = evpl_thread_config_init();
+    evpl_thread_config_set_poll_mode(tcfg, 1);
+    evpl_thread_config_set_poll_iterations(tcfg, POLL_ITERATIONS);
+    ps->evpl = evpl_create(tcfg);
+
+    /* Every step of a program carries the same transport, so the first one
+     * settles it. */
+    switch (core_steps[p->first_step].transport) {
+        case CTR_TSTREAMINPROC:
+            ps->proto = EVPL_STREAM_INPROC;
+            break;
+        case CTR_TDATAGRAMINPROC:
+            ps->proto = EVPL_DATAGRAM_INPROC;
+            break;
+        case CTR_TSTREAMTCP:
+            ps->proto = EVPL_STREAM_SOCKET_TCP;
+            break;
+        case CTR_TSTREAMUNIX:
+            ps->proto = EVPL_STREAM_SOCKET_UNIX;
+            break;
+        case CTR_TDATAGRAMUDP:
+            ps->proto = EVPL_DATAGRAM_SOCKET_UDP;
+            break;
+        default:
+            evpl_test_abort("program %d names a transport the driver has no "
+                            "arm for", prog);
+    } /* switch */
+
+    /* Where this program's model clock starts.  The clock is process-wide and
+     * monotonic, so each program takes a base rather than resetting it. */
+    ps->base_ns = evpl_virtual_clock_now();
+
+    for (i = 0; i < p->nsteps; i++) {
+        if (g_trace) {
+            const struct core_step *ts = &core_steps[p->first_step + i];
+
+            fprintf(stderr, "prog %d step %d: %s conn=%d side=%d size=%d "
+                    "send=%d\n", prog, i, op_name(ts->op), ts->conn, ts->side,
+                    ts->size, ts->send);
+        }
+
+        failures += run_step(ps, &core_steps[p->first_step + i], prog, i);
+    }
+
+    teardown_program(ps);
+
+    free(ps);
+
+    return failures;
+} /* run_program */
+
+/*
+ * Facts that are neither model state nor sequence-dependent.
+ *
+ * The protocol predicates and the endpoint accessors are pure functions of
+ * their arguments: there is no ordering to get wrong and nothing for a
+ * quiesce to observe, so bending them into the model would be bending it
+ * around something it is not about.  They are held here as a flat table
+ * instead, the same way conformance.c holds its connection-notification
+ * checks.
+ */
+static void
+check_static_facts(void)
+{
+    struct evpl_endpoint *inproc, *inet, *local;
+    enum evpl_protocol_id proto;
+    char                  scrape[8192];
+    struct timespec       t0, t1;
+    struct evpl          *evpl;
+    int                   n;
+
+    /* Protocol predicates.  Each protocol is exactly one of stream and
+     * datagram, and at most one of local and in-process; an unavailable one
+     * reports 0 from every predicate, which is how a caller tells "not a
+     * stream" from "not built". */
+    evpl_test_abort_if(!evpl_protocol_available(EVPL_STREAM_INPROC) ||
+                       !evpl_protocol_available(EVPL_DATAGRAM_INPROC),
+                       "the in-process protocols are not available");
+
+    evpl_test_abort_if(!evpl_protocol_is_stream(EVPL_STREAM_INPROC) ||
+                       evpl_protocol_is_stream(EVPL_DATAGRAM_INPROC),
+                       "stream/datagram misreported for the inproc protocols");
+
+    evpl_test_abort_if(!evpl_protocol_is_inproc(EVPL_STREAM_INPROC) ||
+                       evpl_protocol_is_inproc(EVPL_STREAM_SOCKET_TCP),
+                       "in-process misreported");
+
+    evpl_test_abort_if(evpl_protocol_is_local(EVPL_STREAM_INPROC) ||
+                       !evpl_protocol_is_local(EVPL_STREAM_SOCKET_UNIX),
+                       "local misreported: an inproc name is not a socket path");
+
+    evpl_test_abort_if(evpl_protocol_lookup(&proto, "STREAM_INPROC") ||
+                       proto != EVPL_STREAM_INPROC,
+                       "protocol lookup by name failed");
+
+    /* Endpoint kinds are distinguished, and each renders back what it was
+     * given. */
+    inproc = evpl_endpoint_create_inproc("core-conf-facts");
+    inet   = evpl_endpoint_create("127.0.0.1", 8123);
+    local  = evpl_endpoint_create_local("/tmp/core-conf-facts.sock");
+
+    evpl_test_abort_if(!inproc || !inet || !local,
+                       "an endpoint of one of the three kinds was refused");
+
+    evpl_test_abort_if(!evpl_endpoint_is_inproc(inproc) ||
+                       evpl_endpoint_is_local(inproc),
+                       "an in-process endpoint reports the wrong kind");
+
+    evpl_test_abort_if(evpl_endpoint_is_inproc(local) ||
+                       !evpl_endpoint_is_local(local),
+                       "a local endpoint reports the wrong kind");
+
+    evpl_test_abort_if(evpl_endpoint_is_inproc(inet) ||
+                       evpl_endpoint_is_local(inet),
+                       "an inet endpoint reports the wrong kind");
+
+    evpl_test_abort_if(strcmp(evpl_endpoint_address(inet), "127.0.0.1") ||
+                       evpl_endpoint_port(inet) != 8123,
+                       "an inet endpoint does not render back what it was given");
+
+    evpl_endpoint_close(inproc);
+    evpl_endpoint_close(inet);
+    evpl_endpoint_close(local);
+
+    /* The high-frequency clock is monotonic.  It is deliberately NOT the
+     * virtual clock -- it is anchored to CLOCK_MONOTONIC at init and reports
+     * real time, so this is the one thing here that a stopped clock does not
+     * stop. */
+    evpl = evpl_create(NULL);
+
+    evpl_get_hf_monotonic_time(evpl, &t0);
+    evpl_get_hf_monotonic_time(evpl, &t1);
+
+    evpl_test_abort_if(t1.tv_sec < t0.tv_sec ||
+                       (t1.tv_sec == t0.tv_sec && t1.tv_nsec < t0.tv_nsec),
+                       "the high-frequency clock went backwards");
+
+    evpl_destroy(evpl);
+
+    evpl_test_abort_if(evpl_get_slab_size() == 0, "the slab size is zero");
+
+    /* Metrics serialize into a caller's buffer, and report -1 rather than
+     * truncating when it is too small. */
+    n = evpl_metrics_scrape(scrape, sizeof(scrape));
+
+    evpl_test_abort_if(n <= 0, "metrics scrape produced nothing (%d)", n);
+    evpl_test_abort_if(!strstr(scrape, "evpl_allocator"),
+                       "metrics scrape has no allocator counters in it");
+    evpl_test_abort_if(evpl_metrics_scrape(scrape, 4) != -1,
+                       "metrics scrape into a 4 byte buffer did not report -1");
+} /* check_static_facts */
+
+/*
+ * Everything this test claims about time is claimed against libevpl's own
+ * clock, so the first thing it does is take that clock over.  Without this
+ * the model's windows would be wall-clock windows and every verdict in the
+ * suite would carry the machine's load in it.
+ */
+static void
+core_conformance_init(void)
+{
+    struct evpl_global_config *config = evpl_global_config_init();
+
+    evpl_global_config_set_virtual_clock(config, 1);
+
+    /* A buffer well under the largest payload class, so payloads actually
+     * span several iovecs and the gather/scatter paths are walked rather than
+     * short-circuited; see CONF_BUFFER_SIZE. */
+    evpl_global_config_set_buffer_size(config, CONF_BUFFER_SIZE);
+
+    /* Set rather than left to the default, because the model computes its
+     * poll-mode transitions against it. */
+    evpl_global_config_set_spin_ns(config, CONF_SPIN_NS);
+
+    /* Stated explicitly for the same reason: the driver's MAX_SEND_IOV and
+     * the ring depth bound what a program can have in flight. */
+    evpl_global_config_set_max_num_iovec(config, MAX_SEND_IOV * 2);
+
+    /*
+     * Under the buffer size, and deliberately so: a datagram receive buffer
+     * is one contiguous iovec, so a max_datagram_size larger than a buffer
+     * cannot be satisfied from one.  The default is 64 KiB, which the 32 KiB
+     * buffer above cannot hold -- and libevpl neither rejects that
+     * combination nor copes with it, it just hands back a short buffer and
+     * loses datagrams.  Kept well above the largest payload the model sends
+     * over a datagram transport.
+     */
+    evpl_global_config_set_max_datagram_size(config, CONF_BUFFER_SIZE / 2);
+    evpl_global_config_set_iovec_ring_size(config, 1024);
+
+    /* As test_evpl_config(), which this replaces: ctest runs the suite once
+     * per event-loop mechanism compiled in and selects it through the
+     * environment. */
+    test_evpl_set_core_mech(config);
+
+    evpl_init(config);
+} /* core_conformance_init */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    unsigned int i;
+    int          failures = 0;
+
+    /* Unbuffered: a sanitizer that finds something at exit terminates the
+     * process without flushing, and losing the run's summary to that is how a
+     * report goes missing exactly when it is most wanted. */
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    g_trace = getenv("CORE_TRACE") != NULL;
+
+    g_trace = getenv("CORE_TRACE") != NULL;
+
+    core_conformance_init();
+
+    check_static_facts();
+
+    evpl_test_info("running %u core programs, %u steps",
+                   (unsigned int) CORE_NUM_PROGRAMS,
+                   (unsigned int) (sizeof(core_steps) / sizeof(core_steps[0])));
+
+    for (i = 0; i < CORE_NUM_PROGRAMS; i++) {
+        failures += run_program(&core_programs[i], (int) i);
+        g_results.programs++;
+    }
+
+    g_results.failed = failures;
+
+    printf("core programs: %d run, %d steps, %d quiesces, %d obligations "
+           "checked, %llu payload bytes verified, %d known divergences, "
+           "%d failures\n",
+           g_results.programs, g_results.steps, g_results.quiesces,
+           g_results.obligations, (unsigned long long) g_results.bytes,
+           g_results.known, g_results.failed);
+
+    if (failures) {
+        printf("Test FAILED\n");
+        return 1;
+    }
+
+    printf("Test PASSED\n");
+    return 0;
+} /* main */

--- a/src/core/tests/quint/check_core_models.sh
+++ b/src/core/tests/quint/check_core_models.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Ben Jarvis
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# check_core_models.sh - run the core Quint model's own tests and invariants
+#
+# Usage: check_core_models.sh QUINT SRC_DIR
+#
+# Registered as a ctest so that a broken specification surfaces as a failing
+# test rather than as a failing build or, worse, as a quietly wrong program
+# table.  This is the model checking the model; core_conformance is what
+# checks the implementation.
+
+set -euo pipefail
+
+QUINT="${1:?usage: check_core_models.sh QUINT SRC_DIR}"
+SRC_DIR="${2:?}"
+
+"${QUINT}" test "${SRC_DIR}/core.qnt"
+
+# Random simulation against the invariants: every op must be one the driver
+# knows, and every obligation must be attached to the quiesce that checks it.
+"${QUINT}" run "${SRC_DIR}/core.qnt" \
+    --invariant=safety --max-samples=500 --max-steps=60

--- a/src/core/tests/quint/core.qnt
+++ b/src/core/tests/quint/core.qnt
@@ -1,0 +1,1963 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+/**
+ * core.qnt -- a behaviour model of libevpl's core SDK, as a C program.
+ *
+ * The RPC2 models (src/rpc2/tests/quint) enumerate independent cases: each
+ * trace state is one defective message and the verdict on it, and the trace is
+ * only a sampling device.  That works because an RPC exchange is memoryless.
+ *
+ * Nothing about the core API is memoryless.  A one-shot fires once and then
+ * must not fire again; a deferral armed twice runs once; a doorbell retired
+ * from inside its own callback must not be called back afterwards.  Every one
+ * of those is a statement about a SEQUENCE, so here a trace is not a bag of
+ * cases -- it is a PROGRAM, and the C driver is an interpreter for it.
+ *
+ * Each program is a run of ops against a freshly created evpl, bracketed by
+ * OpReset.  What travels with the program is not a predicted return value --
+ * an asynchronous API has none to predict -- but the set of callbacks the
+ * library then owes, which OpQuiesce is where the driver collects.
+ *
+ * Three rules carry most of the weight:
+ *
+ *   1. Every callback the model says is owed must arrive within the quiesce
+ *      window.  A window that closes with an obligation outstanding is the
+ *      "completion that never came" bug, which is silent in production and
+ *      presents as a hang.
+ *
+ *   2. Every callback that arrives must be owed.  An event with no expectation
+ *      covering it fails the program, which is what makes "the removed timer
+ *      stopped firing" and "the one-shot did not refire" checkable at all --
+ *      they are absences, and an absence is only observed by waiting for it.
+ *
+ *   3. A quiesce runs its FULL window, never stopping early at satisfaction.
+ *      Rule 2 is worthless otherwise: an early exit observes no absence.
+ *
+ * This model encodes the SPECIFICATION -- what the header comments in
+ * include/evpl promise -- not what libevpl currently does.  Where the two
+ * disagree the driver records a divergence, reviewed as a candidate bug.
+ *
+ *   quint test core.qnt
+ *   quint run core.qnt --invariant=safety
+ */
+module evpl_core {
+
+    // ------------------------------------------------------------------
+    // Object slots
+    //
+    // Small and fixed: the driver owns a static array per kind and the model
+    // traffics in indices.  Two of each is enough for every property here --
+    // the ones that need a second object (timer ordering, one deferral armed
+    // while another is not) need exactly two.
+    // ------------------------------------------------------------------
+
+    /// Four timers, not two: evpl_timer_insert/evpl_pop_timer keep a binary
+    /// heap, and a heap of two never takes its sift-down branches.  Four is
+    /// the smallest size that gives the head two children and a grandchild to
+    /// move past.
+    pure val NUM_TIMER = 4
+    pure val NUM_DEFERRAL = 2
+    pure val NUM_DOORBELL = 2
+    pure val NUM_CONN = 2
+
+    pure val TIMER_SLOTS = 0.to(NUM_TIMER - 1)
+    pure val DEFERRAL_SLOTS = 0.to(NUM_DEFERRAL - 1)
+    pure val DOORBELL_SLOTS = 0.to(NUM_DOORBELL - 1)
+    pure val CONN_SLOTS = 0.to(NUM_CONN - 1)
+
+    /// A connection has two ends and both are observable from one evpl, so
+    /// events name an END rather than a connection.  Flattening the pair into
+    /// one index keeps the driver's event log a single (kind, slot) table
+    /// instead of growing a third dimension for one op family.
+    pure val SIDE_CLIENT = 0
+    pure val SIDE_SERVER = 1
+    pure val SIDES = Set(SIDE_CLIENT, SIDE_SERVER)
+
+    pure def sideSlot(c: int, side: int): int = c * 2 + side
+    pure def peer(side: int): int = 1 - side
+
+    pure val END_SLOTS = CONN_SLOTS.map(c => SIDES.map(s => sideSlot(c, s))).flatten()
+
+    /// Ops per program, not counting the OpReset that opens it.  Short on
+    /// purpose: a failure at step 380 of a 400-step program is not
+    /// debuggable, so this buys coverage with many short programs rather than
+    /// a few long ones.
+    pure val PROGRAM_LEN = 12
+
+    // ------------------------------------------------------------------
+    // Model time
+    //
+    // The model keeps a millisecond clock that advances ONLY inside a
+    // quiesce, by exactly that quiesce's budget.
+    //
+    // That clock is not an approximation of wall-clock time -- it IS
+    // libevpl's clock.  The driver puts the library on a virtual clock
+    // (evpl_global_config_set_virtual_clock) and advances it a millisecond at
+    // a time with evpl_virtual_clock_advance, so a deadline the model places
+    // at 50ms is a deadline the event loop places at 50ms, exactly, on any
+    // machine under any load.
+    //
+    // Everything about this model that concerns time therefore reduces to
+    // integer arithmetic on both sides.  There is no guard band around a
+    // window edge, no tolerance for a descheduled millisecond, and nothing to
+    // retry: a test whose verdict depended on how busy the machine was would
+    // be a test of the machine.  What remains genuinely asynchronous -- when
+    // a queued payload becomes visible to its peer -- is not time-dependent
+    // and is settled by driving the loop until it stops producing events.
+    //
+    // The clock is also what makes "must not have fired yet" a sound claim
+    // across more than one quiesce.  Deciding it per-quiesce instead -- "is
+    // this budget longer than that delay" -- is wrong the moment a program
+    // has two short quiesces in a row, because a timer's deadline is measured
+    // from when it was armed and not from when the window opened.
+    // ------------------------------------------------------------------
+
+    type DelayCls = | DFast | DSlow
+    type Budget = | QShort | QLong
+
+    pure def delayMs(d: DelayCls): int =
+        match d {
+            | DFast => 1
+            | DSlow => 50
+        }
+
+    pure def budgetMs(b: Budget): int =
+        match b {
+            | QShort => 10
+            | QLong => 100
+        }
+
+    /// Order is only claimed between deadlines at least this far apart.  Two
+    /// timers due within a millisecond of each other are ordered by the heap's
+    /// tie-breaking, which is not something the API promises.
+    pure val ORDER_GAP_MS = 10
+
+    // ------------------------------------------------------------------
+    // Ops
+    //
+    // Modelled after values.qnt's Case: one flat record whose fields are only
+    // meaningful for the ops that read them.  Keeping the arguments out of
+    // the variant payloads is what lets the generated C row be a fixed struct
+    // rather than a tagged union.
+    // ------------------------------------------------------------------
+
+    type OpKind =
+        /* Program boundary.  Not an op the driver runs: it creates a fresh
+         * evpl and clears its object table. */
+        | OpReset
+
+        /* --- timers (evpl_timer.h) ------------------------------------- */
+        | OpAddTimer
+        | OpRemoveTimer
+
+        /* --- deferrals (evpl_deferral.h) ------------------------------- */
+        | OpDefer
+        /* Two evpl_defer() calls back to back.  The `armed` flag is supposed
+         * to coalesce them into one callback; a deferral that ran twice would
+         * run application bookkeeping twice per arming. */
+        | OpDeferTwice
+        /* The callback re-arms itself once.  Distinguishes "coalesces while
+         * armed" from "cannot be re-armed at all". */
+        | OpDeferReentrant
+        /* Disarm one that is armed: its callback is cancelled and must not
+         * run.  Rule 2 is what checks that -- nothing expects it, so a
+         * callback that arrives anyway fails the window. */
+        | OpRemoveDeferral
+        /* And on one that is not armed, which the API documents as a no-op.
+         * A separate op because "harmless" is a claim about a different state
+         * and the driver reaches a different branch for it. */
+        | OpRemoveDeferralIdle
+
+        /* --- doorbells (evpl_doorbell.h) ------------------------------- */
+        | OpAddDoorbell
+        | OpRingDoorbell
+        /* Two rings before the loop runs.  An eventfd counts, but a doorbell
+         * is a wakeup and not a queue, so one callback is enough -- hence
+         * "at least once" rather than twice. */
+        | OpRingDoorbellTwice
+        | OpRemoveDoorbell
+        /* Retire from inside the doorbell's own callback.  The header
+         * explicitly permits this ("including from inside the doorbell's own
+         * callback"), and it is where a dispatch loop that keeps indexing an
+         * array it just mutated goes wrong. */
+        | OpRemoveDoorbellInCallback
+
+        /* --- the transport (evpl_bind.h, evpl_endpoint.h) -------------- */
+        /* Create a listener, attach it to this evpl, and listen on an
+         * in-process name.  One op rather than three: a listener that is
+         * created but never attached or never listened on has no observable
+         * behaviour to state. */
+        | OpListen
+        | OpStopListen
+        /* Bind both ends of a UDP pair.  One op rather than two because an
+         * unconnected bind has no peer and no handshake: the pair exists as
+         * soon as both ends do, and nothing is notified about it.  Modelling
+         * each bind separately would add a state with no observable
+         * behaviour attached to it. */
+        | OpBindPair
+        | OpConnect
+        | OpSend
+        /* evpl_close: drop the connection.  Only ever generated with nothing
+         * in flight, because whether a close delivers what was already queued
+         * is exactly the question evpl_finish exists to answer differently --
+         * modelling close as "may or may not deliver" would state nothing. */
+        | OpClose
+        /* evpl_finish: close once everything queued has been sent.  What is
+         * queued must therefore still arrive, which is the obligation that
+         * separates the two. */
+        | OpFinish
+
+        /* --- poll mode (evpl_poll.h) ----------------------------------- */
+        /* A poll runs on every pass of the loop while the thread is spinning,
+         * and the thread stops spinning after spin_ns without activity.  The
+         * enter and exit callbacks bracket that, so between them they say
+         * exactly when the loop was in poll mode -- which is the only part of
+         * this an application can observe. */
+        /* Ask for EVPL_NOTIFY_SENT on this end.  Nothing is notified until it
+         * is asked for, so this is the op that turns a send into an
+         * obligation in the other direction. */
+        | OpRequestSendNotify
+
+        /* Per-iteration hooks (evpl_set_loop_hooks).  Install and clear;
+         * while installed, each of the three must be called. */
+        | OpSetLoopHooks
+        | OpClearLoopHooks
+
+        | OpAddPoll
+        | OpRemovePoll
+        /* Report activity, which restarts the spin window and so brings the
+         * loop back into poll mode.  This is how a framework that polls a
+         * ring keeps the thread spinning. */
+        | OpActivity
+        /* Pin the thread into poll mode regardless of the spin window, and
+         * release it.  Refcounted, so the model tracks a count rather than a
+         * flag. */
+        | OpPollPin
+        | OpPollUnpin
+
+        /* --- the loop -------------------------------------------------- */
+        | OpQuiesce
+
+    /// A one-shot fires once; a periodic keeps firing until removed; a
+    /// re-armer is a one-shot whose callback arms it a second time, which is
+    /// only legal because the loop pops a one-shot BEFORE calling it.
+    ///
+    /// Periodic and re-arming timers are held to DFast so that a window
+    /// always contains a firing of the one and both firings of the other.
+    /// Allowing them to be slow would mean predicting WHICH windows of a
+    /// repeating series contain a deadline, which buys no new code path in
+    /// libevpl and a great deal of arithmetic here.
+    type TimerKind = | TOneshot | TPeriodic | TRearm
+
+    /// Payload sizes, as classes.  Tiny and Small stay inside one buffer;
+    /// Medium and Large are chosen to span several, so the send and receive
+    /// paths have to gather and scatter rather than hand over a single iovec.
+    ///
+    /// The driver maps them to 1, 100, 8192 and 131072 bytes.
+    type SizeCls = | SzTiny | SzSmall | SzMedium | SzLarge
+
+    pure def sizeBytes(s: SizeCls): int =
+        match s {
+            | SzTiny => 1
+            | SzSmall => 100
+            | SzMedium => 8192
+            | SzLarge => 131072
+        }
+
+    /// How the sending end hands its bytes over.  All five must put the same
+    /// byte stream on the wire, so the model states one obligation and the
+    /// driver varies the call -- the same shape as DrainMode below.
+    ///
+    /// The two iovec forms differ in who owns the references afterwards, and
+    /// that is the point of having both: without EVPL_SEND_FLAG_TAKE_REF the
+    /// send path clones and the caller must release its own, with it the send
+    /// path takes them over and the caller must not.  Getting it backwards is
+    /// a leak one way and a double free the other, and evpl_allocator_destroy
+    /// fails the program either way.
+    type SendMode =
+        | SendBuf        /* evpl_send: the library bounces the bytes      */
+        | SendV          /* evpl_sendv, caller keeps its references       */
+        | SendVTakeRef   /* evpl_sendv, references handed over            */
+        /* Addressed by endpoint rather than by the bind's peer.  Declared
+         * but NOT generated: evpl_sendtoep and evpl_sendtoepv resolve the
+         * endpoint for a +1 reference and hand it to evpl_sendto/evpl_sendtov,
+         * which treat the address as borrowed and keep the pointer in the
+         * queued dgram until the flush -- so nobody releases it and every call
+         * leaks a reference.  Releasing it in the wrapper is not the fix: on
+         * an INET endpoint the cache is re-resolved on a timer and the old
+         * address freed, so the queued dgram would be left pointing at freed
+         * memory (confirmed -- it turns the UDP tests into use-after-free).
+         * The fix is for the send path to take a reference of its own and
+         * every transport to release it on completion, which is a change
+         * across all of them; until then generating these would only mean
+         * choosing which failure to have. */
+        | SendToEp
+        | SendToEpV
+        /* evpl_iovec_reserve + evpl_iovec_commit: take space, fill it, then
+         * tell the allocator how much was actually used.  A distinct path
+         * from evpl_iovec_alloc, and the only one that hands the unused tail
+         * of a buffer back for the next allocation. */
+        | SendReserveCommit
+        /* evpl_iovec_alloc_global: one whole registered buffer whose lifetime
+         * the caller owns outright.  The library's own refcount operations on
+         * it are no-ops, so what is being tested is that a borrow taken by the
+         * send path neither frees it nor keeps it alive: the driver holds the
+         * single owning reference until the program is over. */
+        | SendGlobal
+
+    /// How the receiving end takes its bytes off the bind.  All three must be
+    /// interchangeable -- the byte stream is the same however it is drained --
+    /// so the model treats them as one obligation and the driver varies the
+    /// call.  evpl_peek/evpl_consume and evpl_recvv have no other coverage.
+    /// evpl_peekv is the odd one out and is here because of it: unlike
+    /// evpl_recvv it does NOT clone, so the iovecs it hands back are borrowed
+    /// views that must not be released, and it does not consume either.  That
+    /// asymmetry is documented nowhere, and a receiver that gets it wrong
+    /// double-frees.
+    type DrainMode =
+        | DrainRecv
+        | DrainRecvV
+        | DrainPeek        /* evpl_peek + evpl_consume, copying    */
+        | DrainPeekV       /* evpl_peekv + evpl_consume, borrowing */
+
+    /// A connection is CConnecting until the quiesce in which both ends see
+    /// EVPL_NOTIFY_CONNECTED, and CClosing until the one in which both see
+    /// EVPL_NOTIFY_DISCONNECTED.  Neither transition is instantaneous, and a
+    /// model that treated them as such would let a program use a bind that
+    /// does not exist yet.
+    type ConnSt = | CFree | CConnecting | CUp | CClosing
+
+    /// Which in-process transport a program runs over.  Chosen per program
+    /// rather than per connection, because it is fixed at listen and connect
+    /// and the two ends must agree.
+    ///
+    /// The difference that matters is the one the model states: a stream
+    /// preserves bytes and a datagram preserves MESSAGES.  A stream may
+    /// deliver what was sent in any number of pieces, so only the byte total
+    /// is owed; a datagram owes exactly one delivery per send, which is the
+    /// whole point of it and the only thing that distinguishes the two.
+    type TransportKind =
+        | TStreamInproc
+        | TDatagramInproc
+        | TStreamTcp
+        | TStreamUnix
+        | TDatagramUdp
+
+    /// What the transport owes: bytes, or whole messages.
+    pure def isDatagram(k: TransportKind): bool =
+        k == TDatagramInproc or k == TDatagramUdp
+
+    /// Whether it has a connection at all.  UDP does not: it is bind-only --
+    /// no listen, no connect, no CONNECTED -- so it needs a lifecycle of its
+    /// own rather than a variation on the connected one.
+    pure def isConnected(k: TransportKind): bool = k != TDatagramUdp
+
+    /// Addressed by a filesystem path rather than a port or a private name.
+    /// The driver has to supply one; libevpl owns it from there, including
+    /// removing it at teardown and stepping over a stale predecessor.
+    pure def isLocal(k: TransportKind): bool = k == TStreamUnix
+
+    type Step = {
+        op: OpKind,
+        slot: int,
+        timerKind: TimerKind,
+        delay: DelayCls,
+        budget: Budget,
+        conn: int,
+        side: int,
+        transport: TransportKind,
+        size: SizeCls,
+        send: SendMode,
+        drain: DrainMode,
+        /* Model time at the END of this step.  Only a quiesce advances it;
+         * the driver uses it as the absolute deadline to run that quiesce
+         * to. */
+        atMs: int
+    }
+
+    pure val NOP_STEP: Step = {
+        op: OpReset, slot: 0, timerKind: TOneshot, delay: DFast,
+        budget: QShort, conn: 0, side: SIDE_CLIENT, transport: TStreamInproc,
+        size: SzTiny,
+        send: SendBuf, drain: DrainRecv, atMs: 0
+    }
+
+    // ------------------------------------------------------------------
+    // Observations
+    //
+    // The event log the driver keeps, and the shape of a claim about it.
+    // Everything asserted here is reachable through the public headers; the
+    // model may not talk about anything that needs a peek inside struct evpl.
+    // ------------------------------------------------------------------
+
+    /// EvRecv is the one event whose obligation counts BYTES rather than
+    /// callbacks: how many notifications a stream is delivered in is the
+    /// transport's business, but how many bytes come out of it is not.
+    type EventKind =
+        | EvTimer
+        | EvDeferral
+        | EvDoorbell
+        | EvConnected
+        | EvDisconnected
+        | EvRecv
+        /* The loop entered or left poll mode.  EvPoll is the poll callback
+         * itself, which fires on every pass while spinning -- the driver logs
+         * only its first firing in a window, since an event per pass would
+         * mean the loop never looked settled. */
+        | EvPollEnter
+        | EvPollExit
+        | EvPoll
+        /* Bytes reported sent on an end that asked to be told.  Counted in
+         * bytes for the same reason EvRecv is: how many notifications the
+         * transport batches them into is its business. */
+        /* One delivery.  Only a datagram owes these -- see TransportKind --
+         * and it owes exactly one per send. */
+        | EvRecvMsg
+        | EvSent
+        /* One of the three loop hooks ran; the slot says which.  Logged once
+         * per window, like EvPoll, since they fire on every pass. */
+        | EvHook
+
+    /// MExactly is a closed claim, MAtLeast an open one.  The distinction is
+    /// not laziness: a periodic timer's firing count over a wall-clock window
+    /// is genuinely unspecified, and a doorbell's is genuinely allowed to
+    /// coalesce, so demanding a number there would be demanding a guarantee
+    /// the API does not make.
+    type Mult = | MExactly | MAtLeast
+
+    type Expect = { kind: EventKind, slot: int, mult: Mult, count: int }
+
+    /// First occurrence of `first` must precede first occurrence of `then`.
+    type Order = {
+        firstKind: EventKind, firstSlot: int,
+        thenKind: EventKind, thenSlot: int
+    }
+
+    // ------------------------------------------------------------------
+    // World
+    // ------------------------------------------------------------------
+
+    /// TFired is distinct from TUnused because removing a timer that has
+    /// already fired is documented as a harmless no-op, and that is worth an
+    /// op; removing one that was never added is not a documented operation at
+    /// all, so the model never generates it.
+    type TimerSt = | TUnused | TArmed | TFired
+
+    type DeferralSt = | DIdle | DArmed
+
+    /// BRetiring is the state a doorbell is in between the op that asks its
+    /// callback to remove it and the quiesce in which that callback runs.  It
+    /// is neither present nor free: the storage is still registered, so
+    /// re-adding it would open a second wakeup over the first and register
+    /// the same event twice, which is a bug in the caller rather than a test
+    /// of anything.
+    type DoorbellSt = | BAbsent | BPresent | BRetiring
+
+    /// A poll is registered (PIdle) or registered and being called on every
+    /// pass of the loop (PSpinning).  The loop spins while there has been
+    /// activity within spin_ns or while something has pinned it, and falls
+    /// back to event mode otherwise; the enter and exit callbacks bracket
+    /// exactly that, and are the only part of it an application can see.
+    type PollSt = | PAbsent | PIdle | PSpinning
+
+    var current: Step
+    var expects: Set[Expect]
+    var orders: Set[Order]
+
+    var programStep: int
+    var elapsedMs: int
+
+    var timerSt: int -> TimerSt
+    var timerKindOf: int -> TimerKind
+    /// Model time at which an armed timer's FIRST firing is due.
+    var timerDueAt: int -> int
+
+    var deferralSt: int -> DeferralSt
+    var deferralOwes: int -> int
+
+    var doorbellSt: int -> DoorbellSt
+    var doorbellOwes: int -> int
+    /// Rung and awaiting its callback; the count is not tracked because a
+    /// doorbell's obligation is "at least one", never a number.
+    var doorbellRung: int -> bool
+
+    /// Which prologue this program opens with; see `step`.
+    type Shape =
+        | ShapeMixed
+        | ShapeTransport
+        /* As ShapeTransport, but asks for send notifications before sending.
+         * A separate shape rather than a coin flip inside one, so that both
+         * "nothing is notified until asked" and "everything is once asked"
+         * are generated rather than one crowding out the other. */
+        | ShapeTransportNotify
+        /* UDP: two unconnected binds sending to each other by endpoint.  A
+         * shape of its own because none of listen, connect, close or finish
+         * applies to it. */
+        | ShapeUdp
+        | ShapeTimers
+
+    var shape: Shape
+
+    /// spin_ns as the driver configures it, in milliseconds.  The loop leaves
+    /// poll mode once this much time has passed with no activity, so with
+    /// windows an order of magnitude longer a poll that is not pinned always
+    /// enters and exits inside the same window.
+    pure val SPIN_MS = 1
+
+    var pollSt: PollSt
+    /// evpl_poll_pin is refcounted, so this is a count and not a flag.
+    var pollPins: int
+    /// Model time of the last activity.  evpl_create starts the spin window,
+    /// so a program begins as though activity had just been reported.
+    var lastActivityMs: int
+    var activityPending: bool
+    /// Re-adding a poll after removing one does not emit another enter
+    /// callback, because evpl_remove_poll leaves the loop's poll_mode flag
+    /// set; the model never generates that rather than encoding it.
+    var pollEverAdded: bool
+
+    /// Ends that have asked for send notifications, and the bytes each is
+    /// owed a notification for.
+    var sentNotify: int -> bool
+    var pendingSent: int -> int
+
+    /// The three loop hooks, installed or not.  Slots 0, 1 and 2 are
+    /// iteration_end, pre_wait and post_wait.
+    pure val HOOK_SLOTS = 0.to(2)
+    var hooksInstalled: bool
+
+    /// The transport this program runs over, and the deliveries each end is
+    /// owed under it.
+    var transport: TransportKind
+    var pendingMsgs: int -> int
+
+    var listening: bool
+    var connSt: int -> ConnSt
+    /// Bytes sent to an end and not yet required to have arrived.  Indexed by
+    /// end, not by connection: the two directions are independent.
+    var pendingBytes: int -> int
+
+    pure val ALL_TIMERS_UNUSED = TIMER_SLOTS.mapBy(_ => TUnused)
+    pure val ALL_TIMER_KINDS = TIMER_SLOTS.mapBy(_ => TOneshot)
+    pure val ALL_TIMERS_DUE_ZERO = TIMER_SLOTS.mapBy(_ => 0)
+    pure val ALL_DEFERRALS_IDLE = DEFERRAL_SLOTS.mapBy(_ => DIdle)
+    pure val ALL_DEFERRALS_ZERO = DEFERRAL_SLOTS.mapBy(_ => 0)
+    pure val ALL_DOORBELLS_ABSENT = DOORBELL_SLOTS.mapBy(_ => BAbsent)
+    pure val ALL_DOORBELLS_UNRUNG = DOORBELL_SLOTS.mapBy(_ => false)
+    pure val ALL_DOORBELLS_ZERO = DOORBELL_SLOTS.mapBy(_ => 0)
+    pure val ALL_CONNS_FREE = CONN_SLOTS.mapBy(_ => CFree)
+    pure val ALL_ENDS_DRAINED = END_SLOTS.mapBy(_ => 0)
+    pure val ALL_ENDS_UNNOTIFIED = END_SLOTS.mapBy(_ => false)
+
+    // ------------------------------------------------------------------
+    // The specification: what a quiesce window is owed
+    // ------------------------------------------------------------------
+
+    /// evpl_add_oneshot_timer: "fires once, delay_us from now, and is then
+    /// removed automatically".  Once, not at-least-once -- and only in the
+    /// window its deadline actually falls in.  A window that closes before
+    /// the deadline owes nothing, which by rule 2 is the requirement that the
+    /// timer did not fire early.
+    ///
+    /// evpl_add_timer: "fires every interval_us until evpl_remove_timer".  A
+    /// count over a wall-clock window is not something the API promises, so
+    /// the claim is at-least-once -- still enough to catch a periodic that
+    /// stopped re-arming, which is the failure that matters.
+    ///
+    /// A re-armer owes two: the first firing plus the one its callback arms.
+    pure def timerExpect(
+        s: int, st: TimerSt, k: TimerKind, due: int, windowEnd: int
+    ): Set[Expect] =
+        if (st != TArmed) Set()
+        else match k {
+            | TPeriodic => Set({ kind: EvTimer, slot: s, mult: MAtLeast, count: 1 })
+            /* `due <= windowEnd`, not `<`: the driver advances the clock a
+             * millisecond at a time and a deadline landing exactly on the
+             * last tick of a window is due on that tick.  With an exact clock
+             * the boundary is reachable, so it has to be decided rather than
+             * left to a tolerance. */
+            | TOneshot =>
+                if (due <= windowEnd)
+                    Set({ kind: EvTimer, slot: s, mult: MExactly, count: 1 })
+                else Set()
+            | TRearm =>
+                if (due <= windowEnd)
+                    Set({ kind: EvTimer, slot: s, mult: MExactly, count: 2 })
+                else Set()
+        }
+
+    /// Deferrals run on the next pass of the loop whatever the budget: the
+    /// loop forces its wait to zero while any are armed, so there is no
+    /// deadline to reason about.
+    pure def deferralExpect(s: int, st: DeferralSt, owes: int): Set[Expect] =
+        if (st != DArmed) Set()
+        else Set({ kind: EvDeferral, slot: s, mult: MExactly, count: owes })
+
+    /// Both ends of a connection learn of it, and each learns exactly once.
+    /// A second CONNECTED on one bind would be an application told twice
+    /// about one connection; none at all is an application that never learns
+    /// its connect succeeded.
+    pure def connExpect(c: int, st: ConnSt): Set[Expect] =
+        match st {
+            | CConnecting =>
+                SIDES.map(s => { kind: EvConnected, slot: sideSlot(c, s),
+                                 mult: MExactly, count: 1 })
+            /* Taking one end down takes the other with it, and each end is
+             * told once.  Applications free their per-connection state here,
+             * so a second notification is a double free and a missing one is
+             * a leak. */
+            | CClosing =>
+                SIDES.map(s => { kind: EvDisconnected, slot: sideSlot(c, s),
+                                 mult: MExactly, count: 1 })
+            | _ => Set()
+        }
+
+    /// Every byte handed to evpl_send must come out of the peer's bind, and
+    /// exactly once.  The count is bytes rather than notifications: a stream
+    /// may deliver them in any number of pieces, and requiring a particular
+    /// number would be requiring a guarantee the API does not make.
+    pure def recvExpect(e: int, bytes: int): Set[Expect] =
+        if (bytes == 0) Set()
+        else Set({ kind: EvRecv, slot: e, mult: MExactly, count: bytes })
+
+    /// A datagram owes one delivery per send, no more and no fewer: coalescing
+    /// two sends into one delivery, or splitting one across two, are both
+    /// failures and both invisible to a byte count.
+    pure def recvMsgExpect(k: TransportKind, e: int, msgs: int): Set[Expect] =
+        if (not(isDatagram(k)) or msgs == 0) Set()
+        else Set({ kind: EvRecvMsg, slot: e, mult: MExactly, count: msgs })
+
+    /// Every byte an end has queued must be reported back to it, once, if it
+    /// has asked to be told.  An end that never asked is owed nothing, so
+    /// rule 2 turns a notification it did not ask for into a failure.
+    ///
+    /// Whether it asked is read at the point the queue is FLUSHED, not at the
+    /// point of the send -- and since no op runs the loop, everything queued
+    /// between two quiesces is flushed together, after all of them.  So the
+    /// order of a send and a request inside one window does not matter, which
+    /// is why this takes the flag as it stands at the end of the window
+    /// rather than as it stood at each send.
+    pure def sentExpect(e: int, notified: bool, bytes: int): Set[Expect] =
+        if (not(notified) or bytes == 0) Set()
+        else Set({ kind: EvSent, slot: e, mult: MExactly, count: bytes })
+
+    pure def doorbellExpect(s: int, rung: bool, owes: int): Set[Expect] =
+        if (not(rung)) Set()
+        else if (owes == 0)
+            /* Rung repeatedly: a wakeup may coalesce, so one callback
+             * discharges it. */
+            Set({ kind: EvDoorbell, slot: s, mult: MAtLeast, count: 1 })
+        else
+            /* Retires itself from the callback, so it cannot fire twice. */
+            Set({ kind: EvDoorbell, slot: s, mult: MExactly, count: owes })
+
+    /// A timer due earlier must fire before one due later.  Claimed on
+    /// deadlines rather than on delay classes, because a slow timer armed
+    /// early is genuinely due before a fast one armed late; and only across
+    /// ORDER_GAP_MS, so the claim is about the heap ordering deadlines rather
+    /// than about the scheduler's luck between two near-simultaneous ones.
+    ///
+    /// Periodic timers are left out: one armed long ago is due immediately in
+    /// every window, so its deadline says nothing about where its first
+    /// firing in THIS window lands.
+    pure def orderPairs(
+        exp: Set[Expect], tk: int -> TimerKind, due: int -> int
+    ): Set[Order] = {
+        val ordered = exp.filter(e => e.kind == EvTimer and tk.get(e.slot) != TPeriodic)
+                          .map(e => e.slot)
+        tuples(ordered, ordered)
+            .filter(p => due.get(p._1) + ORDER_GAP_MS <= due.get(p._2))
+            .map(p => {
+                firstKind: EvTimer, firstSlot: p._1,
+                thenKind: EvTimer, thenSlot: p._2
+            })
+    }
+
+    // ------------------------------------------------------------------
+    // Ops: preconditions and effects
+    //
+    // Preconditions are in the actions rather than filtered afterwards, so
+    // the simulator only ever emits a legal program.  An illegal one is not a
+    // test of anything: adding the same evpl_timer twice puts one struct in
+    // the heap twice, which is a bug in the caller and not in libevpl.
+    // ------------------------------------------------------------------
+
+    action doReset(sh: Shape, k: TransportKind): bool = all {
+        shape' = sh,
+        current' = NOP_STEP.with("op", OpReset),
+        expects' = Set(),
+        orders' = Set(),
+        programStep' = 0,
+        elapsedMs' = 0,
+        timerSt' = ALL_TIMERS_UNUSED,
+        timerKindOf' = ALL_TIMER_KINDS,
+        timerDueAt' = ALL_TIMERS_DUE_ZERO,
+        deferralSt' = ALL_DEFERRALS_IDLE,
+        deferralOwes' = ALL_DEFERRALS_ZERO,
+        doorbellSt' = ALL_DOORBELLS_ABSENT,
+        doorbellOwes' = ALL_DOORBELLS_ZERO,
+        doorbellRung' = ALL_DOORBELLS_UNRUNG,
+        listening' = false,
+        connSt' = ALL_CONNS_FREE,
+        pendingBytes' = ALL_ENDS_DRAINED,
+        pollSt' = PAbsent,
+        pollPins' = 0,
+        lastActivityMs' = 0,
+        activityPending' = false,
+        pollEverAdded' = false,
+        transport' = k,
+        pendingMsgs' = ALL_ENDS_DRAINED,
+        sentNotify' = ALL_ENDS_UNNOTIFIED,
+        pendingSent' = ALL_ENDS_DRAINED,
+        hooksInstalled' = false,
+    }
+
+    /// Fields the ops below never touch, gathered so each action states only
+    /// what it changes.
+    action keepTimers = all {
+        timerSt' = timerSt, timerKindOf' = timerKindOf, timerDueAt' = timerDueAt,
+    }
+
+    action keepTransport = all {
+        listening' = listening, connSt' = connSt, pendingBytes' = pendingBytes,
+        sentNotify' = sentNotify, pendingSent' = pendingSent,
+        pendingMsgs' = pendingMsgs,
+    }
+
+    action keepHooks = all {
+        hooksInstalled' = hooksInstalled,
+    }
+
+    action keepPolls = all {
+        pollSt' = pollSt, pollPins' = pollPins,
+        lastActivityMs' = lastActivityMs, activityPending' = activityPending,
+        pollEverAdded' = pollEverAdded,
+    }
+
+    action keepDeferrals = all {
+        deferralSt' = deferralSt, deferralOwes' = deferralOwes,
+    }
+
+    action keepDoorbells = all {
+        doorbellSt' = doorbellSt, doorbellOwes' = doorbellOwes,
+        doorbellRung' = doorbellRung,
+    }
+
+    /// Ops other than a quiesce do not run the loop, so no callback can fire
+    /// during one and the clock does not move.
+    action emit(s: Step): bool = all {
+        current' = s.with("atMs", elapsedMs).with("transport", transport),
+        expects' = Set(),
+        orders' = Set(),
+        programStep' = programStep + 1,
+        elapsedMs' = elapsedMs,
+        shape' = shape,
+        transport' = transport,
+    }
+
+    action addTimer(s: int, k: TimerKind, d: DelayCls): bool = all {
+        timerSt.get(s) != TArmed,
+        k != TOneshot implies d == DFast,
+        emit(NOP_STEP.with("op", OpAddTimer).with("slot", s)
+                 .with("timerKind", k).with("delay", d)),
+        timerSt' = timerSt.set(s, TArmed),
+        timerKindOf' = timerKindOf.set(s, k),
+        timerDueAt' = timerDueAt.set(s, elapsedMs + delayMs(d)),
+        keepDeferrals,
+        keepDoorbells,
+        keepTransport,
+        keepPolls,
+        keepHooks,
+    }
+
+    /// Legal on an armed timer (it stops firing) and on one that has already
+    /// fired (documented no-op).  Never on one that was never added.
+    action removeTimer(s: int): bool = all {
+        timerSt.get(s) != TUnused,
+        emit(NOP_STEP.with("op", OpRemoveTimer).with("slot", s)),
+        timerSt' = timerSt.set(s, TFired),
+        timerKindOf' = timerKindOf,
+        timerDueAt' = timerDueAt,
+        keepDeferrals,
+        keepDoorbells,
+        keepTransport,
+        keepPolls,
+        keepHooks,
+    }
+
+    action defer(s: int, kind: OpKind, owes: int): bool = all {
+        deferralSt.get(s) == DIdle,
+        emit(NOP_STEP.with("op", kind).with("slot", s)),
+        deferralSt' = deferralSt.set(s, DArmed),
+        deferralOwes' = deferralOwes.set(s, owes),
+        keepTimers,
+        keepDoorbells,
+        keepTransport,
+        keepPolls,
+        keepHooks,
+    }
+
+    action addDoorbell(s: int): bool = all {
+        doorbellSt.get(s) == BAbsent,
+        emit(NOP_STEP.with("op", OpAddDoorbell).with("slot", s)),
+        doorbellSt' = doorbellSt.set(s, BPresent),
+        doorbellOwes' = doorbellOwes.set(s, 0),
+        doorbellRung' = doorbellRung.set(s, false),
+        keepTimers,
+        keepDeferrals,
+        keepTransport,
+        keepPolls,
+        keepHooks,
+    }
+
+    action ringDoorbell(s: int, kind: OpKind): bool = all {
+        doorbellSt.get(s) == BPresent,
+        /* owes stays 0: however many times it is rung, one callback is a
+         * legal answer. */
+        doorbellOwes.get(s) == 0,
+        emit(NOP_STEP.with("op", kind).with("slot", s)),
+        doorbellSt' = doorbellSt,
+        doorbellOwes' = doorbellOwes,
+        doorbellRung' = doorbellRung.set(s, true),
+        keepTimers,
+        keepDeferrals,
+        keepTransport,
+        keepPolls,
+        keepHooks,
+    }
+
+    action removeDoorbell(s: int): bool = all {
+        doorbellSt.get(s) == BPresent,
+        /* Retiring one with a callback still owed would make the obligation
+         * unresolvable rather than testing anything: the header requires the
+         * library to hold no reference once remove returns, so a callback
+         * after it is a failure and a callback before it is a race. */
+        not(doorbellRung.get(s)),
+        emit(NOP_STEP.with("op", OpRemoveDoorbell).with("slot", s)),
+        doorbellSt' = doorbellSt.set(s, BAbsent),
+        doorbellOwes' = doorbellOwes,
+        doorbellRung' = doorbellRung,
+        keepTimers,
+        keepDeferrals,
+        keepTransport,
+        keepPolls,
+        keepHooks,
+    }
+
+    /// Ring once, and have the callback retire the doorbell.  Exactly one
+    /// callback: it cannot fire again once it has removed itself, and it must
+    /// not fail to fire the first time.
+    ///
+    /// The slot goes to BRetiring rather than straight to BAbsent: the
+    /// removal happens inside the callback, which does not run until the next
+    /// quiesce, so until then the storage is still registered and re-adding
+    /// it would be a double registration.
+    action removeDoorbellInCallback(s: int): bool = all {
+        doorbellSt.get(s) == BPresent,
+        not(doorbellRung.get(s)),
+        emit(NOP_STEP.with("op", OpRemoveDoorbellInCallback).with("slot", s)),
+        doorbellSt' = doorbellSt.set(s, BRetiring),
+        doorbellOwes' = doorbellOwes.set(s, 1),
+        doorbellRung' = doorbellRung.set(s, true),
+        keepTimers,
+        keepDeferrals,
+        keepTransport,
+        keepPolls,
+        keepHooks,
+    }
+
+    /// Cancel an armed deferral.  Nothing is owed afterwards, so rule 2 is
+    /// what checks the cancellation: a callback that arrives anyway has no
+    /// expectation covering it and fails the window.
+    action removeDeferral(s: int): bool = all {
+        deferralSt.get(s) == DArmed,
+        emit(NOP_STEP.with("op", OpRemoveDeferral).with("slot", s)),
+        deferralSt' = deferralSt.set(s, DIdle),
+        deferralOwes' = deferralOwes.set(s, 0),
+        keepTimers,
+        keepDoorbells,
+        keepTransport,
+        keepPolls,
+        keepHooks,
+    }
+
+    /// The documented no-op: removing one that is not armed, which a caller
+    /// tearing down state does without knowing whether it armed anything.
+    action removeDeferralIdle(s: int): bool = all {
+        deferralSt.get(s) == DIdle,
+        emit(NOP_STEP.with("op", OpRemoveDeferralIdle).with("slot", s)),
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepTransport,
+        keepPolls,
+        keepHooks,
+    }
+
+    /// Loop hooks fire on every pass, so like a poll callback the driver logs
+    /// only the first of each in a window; what is claimed is that each of
+    /// the three ran, not how often.
+    action setLoopHooks = all {
+        not(hooksInstalled),
+        emit(NOP_STEP.with("op", OpSetLoopHooks)),
+        hooksInstalled' = true,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepTransport,
+        keepPolls,
+    }
+
+    action clearLoopHooks = all {
+        hooksInstalled,
+        emit(NOP_STEP.with("op", OpClearLoopHooks)),
+        hooksInstalled' = false,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepTransport,
+        keepPolls,
+    }
+
+    // ------------------------------------------------------------------
+    // Poll ops
+    //
+    // Adding a poll does not by itself put the loop into poll mode: the loop
+    // spins while there has been activity within spin_ns or while something
+    // has pinned it, and falls back otherwise.  So these ops are about the
+    // spin window, and the enter/exit callbacks are how it is observed.
+    // ------------------------------------------------------------------
+
+    action addPoll = all {
+        pollSt == PAbsent,
+        /* Once only per program; see pollEverAdded. */
+        not(pollEverAdded),
+        emit(NOP_STEP.with("op", OpAddPoll)),
+        pollSt' = PIdle,
+        pollPins' = pollPins,
+        lastActivityMs' = lastActivityMs,
+        activityPending' = activityPending,
+        pollEverAdded' = true,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepTransport,
+        keepHooks,
+    }
+
+    action removePoll = all {
+        pollSt != PAbsent,
+        emit(NOP_STEP.with("op", OpRemovePoll)),
+        pollSt' = PAbsent,
+        pollPins' = pollPins,
+        lastActivityMs' = lastActivityMs,
+        activityPending' = activityPending,
+        pollEverAdded' = pollEverAdded,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepTransport,
+        keepHooks,
+    }
+
+    /// Legal with no poll registered -- it only bumps a counter -- so the
+    /// model does not require one.
+    action activity = all {
+        emit(NOP_STEP.with("op", OpActivity)),
+        pollSt' = pollSt,
+        pollPins' = pollPins,
+        lastActivityMs' = lastActivityMs,
+        activityPending' = true,
+        pollEverAdded' = pollEverAdded,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepTransport,
+        keepHooks,
+    }
+
+    action pollPin = all {
+        /* Bounded so the state space stays finite; the point is that it
+         * counts rather than how high it counts. */
+        pollPins < 2,
+        emit(NOP_STEP.with("op", OpPollPin)),
+        pollSt' = pollSt,
+        pollPins' = pollPins + 1,
+        lastActivityMs' = lastActivityMs,
+        activityPending' = activityPending,
+        pollEverAdded' = pollEverAdded,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepTransport,
+        keepHooks,
+    }
+
+    action pollUnpin = all {
+        pollPins > 0,
+        emit(NOP_STEP.with("op", OpPollUnpin)),
+        pollSt' = pollSt,
+        pollPins' = pollPins - 1,
+        lastActivityMs' = lastActivityMs,
+        activityPending' = activityPending,
+        pollEverAdded' = pollEverAdded,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepTransport,
+        keepHooks,
+    }
+
+    // ------------------------------------------------------------------
+    // Transport ops
+    //
+    // Everything here is over the in-process transport.  It is addressed by a
+    // name private to the process and needs no kernel transport at all, which
+    // is what makes a whole connection lifecycle -- both ends of it --
+    // reachable from a single evpl and a single thread, with no port to
+    // collide on and nothing left behind by a crash.
+    // ------------------------------------------------------------------
+
+    action listen = all {
+        not(listening),
+        isConnected(transport),
+        emit(NOP_STEP.with("op", OpListen)),
+        listening' = true,
+        connSt' = connSt,
+        pendingBytes' = pendingBytes,
+        sentNotify' = sentNotify,
+        pendingSent' = pendingSent,
+        pendingMsgs' = pendingMsgs,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepHooks,
+        keepPolls,
+    }
+
+    /// Only with no connection outstanding.  Whether tearing down a listener
+    /// takes the connections it accepted with it is a real question, but it is
+    /// one the headers do not answer, and a model may not invent an answer it
+    /// would then report libevpl for failing.
+    action stopListen = all {
+        listening,
+        CONN_SLOTS.forall(c => connSt.get(c) == CFree),
+        emit(NOP_STEP.with("op", OpStopListen)),
+        listening' = false,
+        connSt' = connSt,
+        pendingBytes' = pendingBytes,
+        sentNotify' = sentNotify,
+        pendingSent' = pendingSent,
+        pendingMsgs' = pendingMsgs,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepHooks,
+        keepPolls,
+    }
+
+    /// Both ends of an unconnected pair, in one step.  There is no handshake
+    /// to wait for and nothing to notify, so the connection is up as soon as
+    /// the op returns -- which is why it owes nothing at the next quiesce
+    /// while connect owes two CONNECTED.
+    action bindPair(c: int): bool = all {
+        not(isConnected(transport)),
+        connSt.get(c) == CFree,
+        emit(NOP_STEP.with("op", OpBindPair).with("conn", c)),
+        connSt' = connSt.set(c, CUp),
+        listening' = listening,
+        pendingBytes' = pendingBytes,
+        sentNotify' = sentNotify,
+        pendingSent' = pendingSent,
+        pendingMsgs' = pendingMsgs,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepPolls,
+        keepHooks,
+    }
+
+    /// At most one connect may be in flight at a time.  Not a property of
+    /// libevpl -- it accepts as many as are offered -- but of the harness: the
+    /// accept callback hands the driver a bind with nothing on it that says
+    /// which connect it answers, so two in flight at once could be attributed
+    /// the wrong way round and the model would be checking the wrong end.
+    action connect(c: int, d: DrainMode): bool = all {
+        listening,
+        isConnected(transport),
+        connSt.get(c) == CFree,
+        CONN_SLOTS.forall(o => connSt.get(o) != CConnecting),
+        emit(NOP_STEP.with("op", OpConnect).with("conn", c).with("drain", d)),
+        connSt' = connSt.set(c, CConnecting),
+        listening' = listening,
+        pendingBytes' = pendingBytes,
+        sentNotify' = sentNotify,
+        pendingSent' = pendingSent,
+        pendingMsgs' = pendingMsgs,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepHooks,
+        keepPolls,
+    }
+
+    /// Ask to be told what this end sends.  Sends made before it are not
+    /// notified; sends after it are.
+    action requestSendNotify(c: int, side: int): bool = all {
+        isConnected(transport),
+        connSt.get(c) == CUp,
+        not(sentNotify.get(sideSlot(c, side))),
+        emit(NOP_STEP.with("op", OpRequestSendNotify).with("conn", c)
+                 .with("side", side)),
+        sentNotify' = sentNotify.set(sideSlot(c, side), true),
+        pendingSent' = pendingSent,
+        pendingMsgs' = pendingMsgs,
+        connSt' = connSt,
+        listening' = listening,
+        pendingBytes' = pendingBytes,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepPolls,
+        keepHooks,
+    }
+
+    action send(c: int, side: int, sz: SizeCls, mode: SendMode): bool = all {
+        connSt.get(c) == CUp,
+        /* Both of these are limited to one buffer's worth, and the driver
+         * configures a buffer smaller than the largest payload class.
+         *
+         * For SendGlobal that is by definition -- a global iovec IS one
+         * buffer.  For SendReserveCommit it is a limitation of
+         * evpl_iovec_reserve, which discards a buffer that cannot hold the
+         * whole remaining length and asks for another; when a fresh buffer
+         * cannot either, it does that forever.  Asking for more than one
+         * buffer's worth is an infinite loop rather than a short return, and
+         * nothing in evpl_memory.h says so. */
+        (mode == SendGlobal or mode == SendReserveCommit) implies sz != SzLarge,
+        /* A datagram is one message and the transport caps one at
+         * max_datagram_size; the driver leaves that at its default, which the
+         * largest payload class exceeds. */
+        isDatagram(transport) implies sz != SzLarge,
+        /* An unconnected bind has no peer to send to, so it must name one;
+         * a connected one has no endpoint the model tracks, and the
+         * endpoint-addressed calls leak on every transport that does not
+         * release the address they hand over -- which today is all of them
+         * bar UDP.  So the two forms are exactly complementary. */
+        isConnected(transport) implies
+            (mode != SendToEp and mode != SendToEpV),
+        not(isConnected(transport)) implies
+            (mode == SendToEp or mode == SendToEpV),
+        emit(NOP_STEP.with("op", OpSend).with("conn", c).with("side", side)
+                 .with("size", sz).with("send", mode)),
+        pendingBytes' = pendingBytes.set(sideSlot(c, peer(side)),
+                                         pendingBytes.get(sideSlot(c, peer(side)))
+                                             + sizeBytes(sz)),
+        sentNotify' = sentNotify,
+        /* Queued, whether or not this end has asked yet; see sentExpect. */
+        pendingSent' = pendingSent.set(sideSlot(c, side),
+                                       pendingSent.get(sideSlot(c, side))
+                                           + sizeBytes(sz)),
+        pendingMsgs' = pendingMsgs.set(sideSlot(c, peer(side)),
+                                       pendingMsgs.get(sideSlot(c, peer(side))) + 1),
+        connSt' = connSt,
+        listening' = listening,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepHooks,
+        keepPolls,
+    }
+
+    /// close() is only generated with both directions quiet; see OpClose.
+    action close(c: int, side: int): bool = all {
+        isConnected(transport),
+        connSt.get(c) == CUp,
+        SIDES.forall(s => pendingBytes.get(sideSlot(c, s)) == 0),
+        SIDES.forall(s => not(sentNotify.get(sideSlot(c, s))) or
+                          pendingSent.get(sideSlot(c, s)) == 0),
+        emit(NOP_STEP.with("op", OpClose).with("conn", c).with("side", side)),
+        connSt' = connSt.set(c, CClosing),
+        listening' = listening,
+        pendingBytes' = pendingBytes,
+        sentNotify' = sentNotify,
+        pendingSent' = pendingSent,
+        pendingMsgs' = pendingMsgs,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepHooks,
+        keepPolls,
+    }
+
+    /// finish() leaves whatever THIS side queued owed: the peer must still
+    /// receive every byte handed over before it, and only then see the
+    /// disconnect.  This is the op that catches a transport dropping its send
+    /// ring on the way out.
+    ///
+    /// The other direction gets no such promise, and the precondition below is
+    /// what keeps the model honest about that.  evpl_finish is not a
+    /// half-close: it closes the bind outright once the send ring drains, so
+    /// bytes a peer had already put in flight TOWARD this side are lost with
+    /// it.  Requiring their delivery would be requiring a shutdown(SHUT_WR)
+    /// that this API does not offer.
+    action finish(c: int, side: int): bool = all {
+        isConnected(transport),
+        connSt.get(c) == CUp,
+        pendingBytes.get(sideSlot(c, side)) == 0,
+        /* Whether a send notification survives the close that follows it is a
+         * real question and not one the headers answer, so the model declines
+         * to have an opinion: an end that has asked to be told must have
+         * nothing queued.  An end that has not asked is free to send and
+         * finish in one breath, which is what evpl_finish is for. */
+        SIDES.forall(s => not(sentNotify.get(sideSlot(c, s))) or
+                          pendingSent.get(sideSlot(c, s)) == 0),
+        emit(NOP_STEP.with("op", OpFinish).with("conn", c).with("side", side)),
+        connSt' = connSt.set(c, CClosing),
+        listening' = listening,
+        pendingBytes' = pendingBytes,
+        sentNotify' = sentNotify,
+        pendingSent' = pendingSent,
+        pendingMsgs' = pendingMsgs,
+        keepTimers,
+        keepDeferrals,
+        keepDoorbells,
+        keepHooks,
+        keepPolls,
+    }
+
+    /// Run the loop to the end of this window and collect what fell out.  The
+    /// obligations are computed here, at the point where they are checked,
+    /// and travel in the trace: the C driver consumes the trace, not the
+    /// model, so the prediction has to be in it.
+    action quiesce(b: Budget): bool = {
+        val windowEnd = elapsedMs + budgetMs(b)
+
+        /* Poll mode over this window, mirroring the loop.  The spin window is
+         * an order of magnitude shorter than the shortest window, so a poll
+         * that is not pinned always both enters and leaves inside one --
+         * there is no case where the model has to guess which window a
+         * transition lands in.
+         *
+         * `elapsedMs <= lastActivityMs` is the loop's own test written out:
+         * the first tick of the window is at elapsedMs + 1, and it stays in
+         * poll mode while that is no more than SPIN_MS past the last
+         * activity.  It is true at the start of a program because
+         * evpl_create starts the spin window, and false thereafter unless
+         * something reported activity. */
+        val pollPresent = pollSt != PAbsent
+        val pollSpinning = pollSt == PSpinning
+        val pollEnters = pollPresent and not(pollSpinning) and
+            (pollPins > 0 or activityPending or elapsedMs <= lastActivityMs)
+        val pollActive = pollPresent and (pollSpinning or pollEnters)
+        val pollExits = pollActive and pollPins == 0
+
+        val pollExpects =
+            (if (pollEnters) Set({ kind: EvPollEnter, slot: 0, mult: MExactly, count: 1 }) else Set())
+                .union(if (pollActive) Set({ kind: EvPoll, slot: 0, mult: MExactly, count: 1 }) else Set())
+                .union(if (pollExits) Set({ kind: EvPollExit, slot: 0, mult: MExactly, count: 1 }) else Set())
+
+        val exp =
+            TIMER_SLOTS.map(s => timerExpect(s, timerSt.get(s), timerKindOf.get(s),
+                                             timerDueAt.get(s), windowEnd)).flatten()
+                .union(DEFERRAL_SLOTS.map(s =>
+                    deferralExpect(s, deferralSt.get(s), deferralOwes.get(s))).flatten())
+                .union(DOORBELL_SLOTS.map(s =>
+                    doorbellExpect(s, doorbellRung.get(s), doorbellOwes.get(s))).flatten())
+                .union(CONN_SLOTS.map(c => connExpect(c, connSt.get(c))).flatten())
+                .union(END_SLOTS.map(e => recvExpect(e, pendingBytes.get(e))).flatten())
+                .union(END_SLOTS.map(e =>
+                    recvMsgExpect(transport, e, pendingMsgs.get(e))).flatten())
+                .union(END_SLOTS.map(e =>
+                    sentExpect(e, sentNotify.get(e), pendingSent.get(e))).flatten())
+                .union(pollExpects)
+                .union(if (hooksInstalled)
+                           HOOK_SLOTS.map(h => { kind: EvHook, slot: h,
+                                                 mult: MExactly, count: 1 })
+                       else Set())
+
+        /* A doorbell whose callback retires it is absent once that callback
+         * has run, which is inside this window. */
+        val dbSt = DOORBELL_SLOTS.mapBy(s =>
+            if (doorbellSt.get(s) == BRetiring) BAbsent else doorbellSt.get(s))
+
+        all {
+            current' = NOP_STEP.with("op", OpQuiesce).with("budget", b)
+                           .with("atMs", windowEnd),
+            expects' = exp,
+            orders' = orderPairs(exp, timerKindOf, timerDueAt),
+            programStep' = programStep + 1,
+            elapsedMs' = windowEnd,
+            shape' = shape,
+
+            /* A one-shot whose deadline was in this window has fired and is
+             * gone; a periodic stays armed; one whose deadline is still ahead
+             * is untouched and still owes its callback to a later window. */
+            timerSt' = TIMER_SLOTS.mapBy(s =>
+                if (timerSt.get(s) == TArmed and timerKindOf.get(s) != TPeriodic
+                    and timerDueAt.get(s) <= windowEnd) TFired
+                else timerSt.get(s)),
+            timerKindOf' = timerKindOf,
+            timerDueAt' = timerDueAt,
+
+            deferralSt' = ALL_DEFERRALS_IDLE,
+            deferralOwes' = ALL_DEFERRALS_ZERO,
+
+            doorbellSt' = dbSt,
+            doorbellOwes' = ALL_DOORBELLS_ZERO,
+            doorbellRung' = ALL_DOORBELLS_UNRUNG,
+
+            /* A connection is established or gone by the end of the window in
+             * which its notifications were due; a slot whose connection has
+             * gone is free to carry another. */
+            listening' = listening,
+            connSt' = CONN_SLOTS.mapBy(c =>
+                match connSt.get(c) {
+                    | CConnecting => CUp
+                    | CClosing => CFree
+                    | _ => connSt.get(c)
+                }),
+            pendingBytes' = ALL_ENDS_DRAINED,
+            pendingMsgs' = ALL_ENDS_DRAINED,
+            transport' = transport,
+            sentNotify' = sentNotify,
+            pendingSent' = ALL_ENDS_DRAINED,
+            hooksInstalled' = hooksInstalled,
+
+            pollSt' = if (not(pollPresent)) PAbsent
+                      else if (pollActive and pollPins > 0) PSpinning
+                      else PIdle,
+            pollPins' = pollPins,
+            /* The loop observes a reported activity on the window's first
+             * tick, and dates the spin window from there -- but ONLY while a
+             * poll is registered.  With none, evpl_continue skips the block
+             * that syncs its activity counter, so an activity reported before
+             * any poll existed is still pending whenever one is added, however
+             * long afterwards, and brings the loop straight into poll mode.
+             * Modelled rather than fixed: it is defensible ("something asked
+             * to spin, and now there is something to spin on"), and quietly
+             * dropping it would be a behaviour change on the frameworks that
+             * report activity. */
+            lastActivityMs' = if (pollPresent and activityPending) elapsedMs + 1
+                              else lastActivityMs,
+            activityPending' = if (pollPresent) false else activityPending,
+            pollEverAdded' = pollEverAdded,
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Program generation
+    // ------------------------------------------------------------------
+
+    action pickOp = {
+        nondet ts = TIMER_SLOTS.oneOf()
+        nondet tk = Set(TOneshot, TPeriodic, TRearm).oneOf()
+        nondet td = Set(DFast, DSlow).oneOf()
+        nondet ds = DEFERRAL_SLOTS.oneOf()
+        nondet bs = DOORBELL_SLOTS.oneOf()
+        nondet b = Set(QShort, QLong).oneOf()
+        nondet cs = CONN_SLOTS.oneOf()
+        nondet sd = SIDES.oneOf()
+        nondet sz = Set(SzTiny, SzSmall, SzMedium, SzLarge).oneOf()
+        nondet dm = Set(DrainRecv, DrainRecvV, DrainPeek, DrainPeekV).oneOf()
+        /* SendToEp and SendToEpV are deliberately not generated; see
+         * SendMode.  They are declared because the model should say what the
+         * API offers, and excluded because exercising them leaks. */
+        nondet sm = Set(SendBuf, SendV, SendVTakeRef, SendReserveCommit,
+                        SendGlobal).oneOf()
+        any {
+            addTimer(ts, tk, td),
+            removeTimer(ts),
+            defer(ds, OpDefer, 1),
+            defer(ds, OpDeferTwice, 1),
+            defer(ds, OpDeferReentrant, 2),
+            addDoorbell(bs),
+            ringDoorbell(bs, OpRingDoorbell),
+            ringDoorbell(bs, OpRingDoorbellTwice),
+            removeDoorbell(bs),
+            removeDoorbellInCallback(bs),
+            bindPair(cs),
+            send(cs, sd, sz, SendToEp),
+            send(cs, sd, sz, SendToEpV),
+            requestSendNotify(cs, sd),
+            setLoopHooks,
+            clearLoopHooks,
+            removeDeferral(ds),
+            removeDeferralIdle(ds),
+            addPoll,
+            removePoll,
+            activity,
+            pollPin,
+            pollUnpin,
+            listen,
+            stopListen,
+            connect(cs, dm),
+            send(cs, sd, sz, sm),
+            close(cs, sd),
+            finish(cs, sd),
+            quiesce(b),
+        }
+    }
+
+    /// Any legal send on the prologue's connection.
+    action sendAny = {
+        nondet sz = Set(SzTiny, SzSmall, SzMedium, SzLarge).oneOf()
+        nondet sd = SIDES.oneOf()
+        nondet sm = Set(SendBuf, SendV, SendVTakeRef, SendReserveCommit,
+                        SendGlobal).oneOf()
+        send(0, sd, sz, sm)
+    }
+
+    /// The UDP form: addressed by endpoint, because there is no connection.
+    action sendAnyEp = {
+        nondet sz = Set(SzTiny, SzSmall, SzMedium).oneOf()
+        nondet sd = SIDES.oneOf()
+        nondet sm = Set(SendToEp, SendToEpV).oneOf()
+        send(0, sd, sz, sm)
+    }
+
+    action requestSendNotifyAny = {
+        nondet sd = SIDES.oneOf()
+        requestSendNotify(0, sd)
+    }
+
+    action connectAny = {
+        nondet d = Set(DrainRecv, DrainRecvV, DrainPeek, DrainPeekV).oneOf()
+        connect(0, d)
+    }
+
+    action resetUdp = doReset(ShapeUdp, TDatagramUdp)
+
+    action resetAny = {
+        nondet sh = Set(ShapeMixed, ShapeTransport, ShapeTransportNotify,
+                        ShapeTimers).oneOf()
+        nondet k = Set(TStreamInproc, TDatagramInproc, TStreamTcp,
+                       TStreamUnix).oneOf()
+        doReset(if (sh == ShapeUdp) ShapeMixed else sh, k)
+    }
+
+    /// Arm one timer, any kind and delay the model allows.
+    action addTimerAny(s: int): bool = {
+        nondet k = Set(TOneshot, TPeriodic, TRearm).oneOf()
+        nondet d = Set(DFast, DSlow).oneOf()
+        addTimer(s, k, d)
+    }
+
+    /// Deterministic on purpose, where `step`'s resets are not: quint samples
+    /// a nondeterministic init on every scenario test, which turns each of
+    /// the runs below into ten thousand and the model's own test suite from a
+    /// tenth of a second into eleven.  Generation loses nothing by it -- only
+    /// the very first program of a trace is pinned, and every reset after it
+    /// still chooses.
+    action init = doReset(ShapeMixed, TStreamInproc)
+
+    /*
+     * Program shape.
+     *
+     * Half the programs open with a three-op prologue that leaves a live
+     * connection, because a uniform random walk over the op set almost never
+     * builds one: send, close and finish all need a connection that is up,
+     * which takes listen, connect and a quiesce to reach, and the odds of
+     * drawing that sequence out of seventeen enabled actions inside a
+     * twelve-op program are negligible.  The converter's op-coverage check
+     * fails generation outright when that happens, which is how this was
+     * found -- but the fix belongs here, in what the model generates, rather
+     * than in ever-longer traces.
+     *
+     * A third opens by arming three timers, for the same reason in the other
+     * direction: the timer set is a binary heap, and its sift-down only runs
+     * once the heap is deeper than a pair.  A uniform walk over twenty-five
+     * enabled actions arms three timers at once about as often as it builds a
+     * connection, which is to say almost never -- and unlike a missing op,
+     * a heap that never sifts does not fail generation, it just quietly stops
+     * being tested.  This is what the coverage report is for.
+     *
+     * The rest exercise the event-loop primitives with neither in the way, and
+     * can still reach any of it on their own.
+     *
+     * Every program ends with a long quiesce, so that none leaves an
+     * obligation for the next to inherit and every teardown runs from a
+     * settled loop.
+     */
+    /// The closing quiesce is only as long as it needs to be.  Every program
+    /// has one, so making it unconditionally long would put the suite's
+    /// wall-clock floor at one long window per program for the sake of the
+    /// minority that have a slow timer still outstanding.
+    action finalQuiesce =
+        if (TIMER_SLOTS.exists(s => timerSt.get(s) == TArmed and
+                                    timerDueAt.get(s) >= elapsedMs + budgetMs(QShort)))
+            quiesce(QLong)
+        else quiesce(QShort)
+
+    val isTransportShape = shape == ShapeTransport or shape == ShapeTransportNotify
+
+    action step =
+        if (programStep >= PROGRAM_LEN) any { resetAny, resetUdp }
+        else if (programStep == PROGRAM_LEN - 1) finalQuiesce
+        else if (isTransportShape and programStep == 0) listen
+        else if (isTransportShape and programStep == 1) connectAny
+        else if (isTransportShape and programStep == 2) quiesce(QShort)
+        else if (shape == ShapeTransportNotify and programStep == 3)
+            requestSendNotifyAny
+        else if (shape == ShapeTransportNotify and programStep == 4) sendAny
+        else if (shape == ShapeTransportNotify and programStep == 5) quiesce(QShort)
+        else if (shape == ShapeTransport and programStep == 3) sendAny
+        else if (shape == ShapeTransport and programStep == 4) quiesce(QShort)
+        else if (shape == ShapeUdp and programStep == 0) bindPair(0)
+        else if (shape == ShapeUdp and programStep == 1) sendAnyEp
+        else if (shape == ShapeUdp and programStep == 2) quiesce(QShort)
+        else if (shape == ShapeTimers and programStep < 3) addTimerAny(programStep)
+        else pickOp
+
+    // ------------------------------------------------------------------
+    // Invariants
+    // ------------------------------------------------------------------
+
+    /// Totality: every op the model can emit needs an arm in the converter
+    /// and in the C driver.  Quint's match is exhaustive, so a new OpKind
+    /// without a rule fails to typecheck; this catches the reverse mistake.
+    val opIsKnown = match current.op {
+        | OpReset => true
+        | OpAddTimer => true
+        | OpRemoveTimer => true
+        | OpDefer => true
+        | OpDeferTwice => true
+        | OpDeferReentrant => true
+        | OpAddDoorbell => true
+        | OpRingDoorbell => true
+        | OpRingDoorbellTwice => true
+        | OpRemoveDoorbell => true
+        | OpRemoveDoorbellInCallback => true
+        | OpRemoveDeferral => true
+        | OpRemoveDeferralIdle => true
+        | OpAddPoll => true
+        | OpRemovePoll => true
+        | OpActivity => true
+        | OpPollPin => true
+        | OpPollUnpin => true
+        | OpRequestSendNotify => true
+        | OpSetLoopHooks => true
+        | OpClearLoopHooks => true
+        | OpListen => true
+        | OpStopListen => true
+        | OpBindPair => true
+        | OpConnect => true
+        | OpSend => true
+        | OpClose => true
+        | OpFinish => true
+        | OpQuiesce => true
+    }
+
+    /// Obligations are only ever attached to the op that checks them; a
+    /// non-quiesce step carrying an expectation would be one the driver
+    /// silently drops.
+    val expectationsOnlyAtQuiesce =
+        (expects.size() > 0 or orders.size() > 0) implies current.op == OpQuiesce
+
+    /// A closed claim of zero callbacks is not a claim -- rule 2 already
+    /// requires that anything unexpected fails -- and would let a bug through
+    /// as a satisfied expectation.
+    val expectationsAreSubstantive =
+        expects.forall(e => e.count >= 1)
+
+    /// An order pair may only mention events the same quiesce expects;
+    /// otherwise the driver would be asked to order something that never
+    /// happened.
+    val ordersReferenceExpectedEvents =
+        orders.forall(o =>
+            expects.exists(e => e.kind == o.firstKind and e.slot == o.firstSlot) and
+            expects.exists(e => e.kind == o.thenKind and e.slot == o.thenSlot))
+
+    /// The clock only advances inside a quiesce, and every quiesce carries the
+    /// absolute deadline the driver runs it to.  A step that moved the clock
+    /// without the driver knowing would put model and real time out of step
+    /// for the rest of the program.
+    val clockIsCarried =
+        current.atMs == elapsedMs
+
+    /// A repeating timer is always fast; see TimerKind.
+    val repeatingTimersAreFast =
+        TIMER_SLOTS.forall(s =>
+            (timerSt.get(s) == TArmed and timerKindOf.get(s) != TOneshot)
+                implies timerDueAt.get(s) <= elapsedMs + delayMs(DFast))
+
+    /// Bytes are only ever in flight to an end of a connection that exists.
+    /// Owing a payload to a bind that was never created, or has already gone,
+    /// would be an obligation the driver has nowhere to check.
+    val bytesOnlyFlowOnLiveConnections =
+        CONN_SLOTS.forall(c =>
+            (connSt.get(c) == CFree or connSt.get(c) == CConnecting) implies
+                SIDES.forall(s => pendingBytes.get(sideSlot(c, s)) == 0))
+
+    /// Only one connect outstanding; see the connect action.
+    val atMostOneConnectInFlight =
+        CONN_SLOTS.filter(c => connSt.get(c) == CConnecting).size() <= 1
+
+    /// On a connected transport, a connection can only exist where something
+    /// is listening for it.  It may outlive the listener in principle, but the
+    /// model never generates that, so an established connection with no
+    /// listener would mean stopListen's precondition had leaked.
+    ///
+    /// An unconnected pair has no listener by construction, which is the whole
+    /// difference between the two lifecycles.
+    val connectionsImplyAListener =
+        not(isConnected(transport)) or
+        CONN_SLOTS.forall(c => connSt.get(c) == CFree) or listening
+
+    val safety =
+        opIsKnown and expectationsOnlyAtQuiesce and expectationsAreSubstantive and
+        ordersReferenceExpectedEvents and clockIsCarried and
+        repeatingTimersAreFast and bytesOnlyFlowOnLiveConnections and
+        atMostOneConnectInFlight and connectionsImplyAListener
+
+    // ------------------------------------------------------------------
+    // Scenario tests: the obligations most likely to be got wrong
+    // ------------------------------------------------------------------
+
+    /// The property timer_oneshot.c checks by hand, stated as a model: a
+    /// one-shot owes exactly one callback, and the quiesce after it owes
+    /// none -- so a refiring one-shot fails on the second quiesce, where
+    /// nothing expects it.
+    run oneshotFiresOnceTest =
+        init
+            .then(addTimer(0, TOneshot, DFast))
+            .then(quiesce(QShort))
+            .expect(expects == Set({ kind: EvTimer, slot: 0, mult: MExactly, count: 1 }))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+
+    /// A re-armer owes two, and the loop popping it before the callback is
+    /// the only reason the second arming is legal.
+    run rearmedOneshotFiresTwiceTest =
+        init
+            .then(addTimer(1, TRearm, DFast))
+            .then(quiesce(QShort))
+            .expect(expects == Set({ kind: EvTimer, slot: 1, mult: MExactly, count: 2 }))
+
+    /// A timer must not fire early -- and "early" is measured from when it was
+    /// armed, not from when the window opened.  A 50ms deadline is not due
+    /// inside any of the first four 10ms windows; it is due on the last tick
+    /// of the fifth.  A model that compared the delay against one budget at a
+    /// time would wrongly forbid the firing forever.
+    run slowTimerFiresInTheWindowItIsDueTest =
+        init
+            .then(addTimer(0, TOneshot, DSlow))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+            .then(quiesce(QShort))
+            .expect(expects == Set({ kind: EvTimer, slot: 0, mult: MExactly, count: 1 }))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+
+    /// The same timer under one long window is due inside it.
+    run slowTimerFiresUnderALongWindowTest =
+        init
+            .then(addTimer(0, TOneshot, DSlow))
+            .then(quiesce(QLong))
+            .expect(expects == Set({ kind: EvTimer, slot: 0, mult: MExactly, count: 1 }))
+
+    /// Removing an armed timer retires the obligation with it; removing it
+    /// again afterwards is the documented no-op.
+    run removedTimerStopsFiringTest =
+        init
+            .then(addTimer(0, TPeriodic, DFast))
+            .then(quiesce(QShort))
+            .expect(expects == Set({ kind: EvTimer, slot: 0, mult: MAtLeast, count: 1 }))
+            .then(removeTimer(0))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+            .then(removeTimer(0))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+
+    /// The heap has to order two deadlines, and the only way to observe that
+    /// is a pair far enough apart to be sure.
+    run timerOrderFollowsDeadlineTest =
+        init
+            .then(addTimer(0, TOneshot, DSlow))
+            .then(addTimer(1, TOneshot, DFast))
+            .then(quiesce(QLong))
+            .expect(orders == Set({
+                firstKind: EvTimer, firstSlot: 1,
+                thenKind: EvTimer, thenSlot: 0
+            }))
+
+    /// Arming twice coalesces; re-arming from the callback does not.  Both
+    /// are closed claims, because a deferral that runs an extra time runs the
+    /// application's bookkeeping an extra time.
+    run deferralCoalescesTest =
+        init
+            .then(defer(0, OpDeferTwice, 1))
+            .then(quiesce(QShort))
+            .expect(expects == Set({ kind: EvDeferral, slot: 0, mult: MExactly, count: 1 }))
+            .then(defer(0, OpDeferReentrant, 2))
+            .then(quiesce(QShort))
+            .expect(expects == Set({ kind: EvDeferral, slot: 0, mult: MExactly, count: 2 }))
+
+    /// A wakeup may coalesce, so two rings owe at least one callback -- but
+    /// a doorbell that retires itself from its callback owes exactly one, and
+    /// the quiesce after it owes none at all.
+    run doorbellRingIsAWakeupTest =
+        init
+            .then(addDoorbell(0))
+            .then(ringDoorbell(0, OpRingDoorbellTwice))
+            .then(quiesce(QShort))
+            .expect(expects == Set({ kind: EvDoorbell, slot: 0, mult: MAtLeast, count: 1 }))
+            .then(removeDoorbellInCallback(0))
+            .then(quiesce(QShort))
+            .expect(expects == Set({ kind: EvDoorbell, slot: 0, mult: MExactly, count: 1 }))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+
+    /// Both ends learn of the connection, and each learns once.
+    run bothEndsSeeTheConnectionTest =
+        init
+            .then(listen)
+            .then(connect(0, DrainRecv))
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvConnected, slot: sideSlot(0, SIDE_CLIENT), mult: MExactly, count: 1 },
+                { kind: EvConnected, slot: sideSlot(0, SIDE_SERVER), mult: MExactly, count: 1 }))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+
+    /// Every byte sent arrives at the peer, and only at the peer: the sender's
+    /// own end owes nothing, so an implementation that looped a payload back
+    /// fails on rule 2 rather than needing a check of its own.
+    run bytesArriveAtThePeerTest =
+        init
+            .then(listen)
+            .then(connect(0, DrainPeek))
+            .then(quiesce(QShort))
+            .then(send(0, SIDE_CLIENT, SzMedium, SendBuf))
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvRecv, slot: sideSlot(0, SIDE_SERVER),
+                  mult: MExactly, count: 8192 }))
+
+    /// Sends in both directions are independent, and both are owed in full.
+    run bothDirectionsAreIndependentTest =
+        init
+            .then(listen)
+            .then(connect(1, DrainRecvV))
+            .then(quiesce(QShort))
+            .then(send(1, SIDE_CLIENT, SzTiny, SendV))
+            .then(send(1, SIDE_SERVER, SzLarge, SendVTakeRef))
+            .then(quiesce(QLong))
+            .expect(expects == Set(
+                { kind: EvRecv, slot: sideSlot(1, SIDE_SERVER), mult: MExactly, count: 1 },
+                { kind: EvRecv, slot: sideSlot(1, SIDE_CLIENT), mult: MExactly, count: 131072 }))
+
+    /// The distinction between the two ways of ending a connection: what was
+    /// queued before a finish must still arrive, and the disconnect must
+    /// arrive too.  A transport that dropped its send ring on the way out
+    /// satisfies the second half and fails the first.
+    run finishDeliversWhatWasQueuedTest =
+        init
+            .then(listen)
+            .then(connect(0, DrainRecv))
+            .then(quiesce(QShort))
+            .then(send(0, SIDE_CLIENT, SzSmall, SendGlobal))
+            .then(finish(0, SIDE_CLIENT))
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvRecv, slot: sideSlot(0, SIDE_SERVER), mult: MExactly, count: 100 },
+                { kind: EvDisconnected, slot: sideSlot(0, SIDE_CLIENT), mult: MExactly, count: 1 },
+                { kind: EvDisconnected, slot: sideSlot(0, SIDE_SERVER), mult: MExactly, count: 1 }))
+            /* And the slot is free again afterwards, with nothing owed. */
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+
+    /// Closing one end takes the other down with it, and each end is told
+    /// exactly once -- a second notification would be a double free in an
+    /// application that frees its connection state there.
+    run closeTakesDownBothEndsTest =
+        init
+            .then(listen)
+            .then(connect(0, DrainRecv))
+            .then(quiesce(QShort))
+            .then(close(0, SIDE_SERVER))
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvDisconnected, slot: sideSlot(0, SIDE_CLIENT), mult: MExactly, count: 1 },
+                { kind: EvDisconnected, slot: sideSlot(0, SIDE_SERVER), mult: MExactly, count: 1 }))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+
+    /// A connection slot is reusable once its connection has gone, and the
+    /// second connection is a connection in its own right.
+    run slotsAreReusableTest =
+        init
+            .then(listen)
+            .then(connect(0, DrainRecv))
+            .then(quiesce(QShort))
+            .then(close(0, SIDE_CLIENT))
+            .then(quiesce(QShort))
+            .then(connect(0, DrainRecvV))
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvConnected, slot: sideSlot(0, SIDE_CLIENT), mult: MExactly, count: 1 },
+                { kind: EvConnected, slot: sideSlot(0, SIDE_SERVER), mult: MExactly, count: 1 }))
+
+    /// Cancelling an armed deferral owes nothing -- and the point is that
+    /// nothing is owed: rule 2 turns the callback arriving anyway into a
+    /// failure, which is the only way to observe a cancellation.
+    run removedDeferralDoesNotRunTest =
+        init
+            .then(defer(0, OpDefer, 1))
+            .then(removeDeferral(0))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+            /* And the documented no-op leaves it that way. */
+            .then(removeDeferralIdle(0))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+            /* Still usable afterwards: cancelling is not disabling. */
+            .then(defer(0, OpDefer, 1))
+            .then(quiesce(QShort))
+            .expect(expects == Set({ kind: EvDeferral, slot: 0, mult: MExactly, count: 1 }))
+
+    /// The loop spins while there has been recent activity and falls back
+    /// afterwards, and the enter/exit pair brackets exactly that.  A program
+    /// begins inside the spin window because evpl_create starts it, so the
+    /// first window both enters and leaves; the next owes nothing at all
+    /// until something reports activity.
+    run pollEntersAndLeavesTest =
+        init
+            .then(addPoll)
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvPollEnter, slot: 0, mult: MExactly, count: 1 },
+                { kind: EvPoll, slot: 0, mult: MExactly, count: 1 },
+                { kind: EvPollExit, slot: 0, mult: MExactly, count: 1 }))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+            .then(activity)
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvPollEnter, slot: 0, mult: MExactly, count: 1 },
+                { kind: EvPoll, slot: 0, mult: MExactly, count: 1 },
+                { kind: EvPollExit, slot: 0, mult: MExactly, count: 1 }))
+
+    /// A pin holds the loop in poll mode across windows however quiet it is,
+    /// and releasing it lets the spin window expire.  This is the property
+    /// the pin exists for: a completion that can only be reaped by polling is
+    /// lost if the loop falls back while it is outstanding.
+    run pinnedPollKeepsSpinningTest =
+        init
+            .then(addPoll)
+            .then(pollPin)
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvPollEnter, slot: 0, mult: MExactly, count: 1 },
+                { kind: EvPoll, slot: 0, mult: MExactly, count: 1 }))
+            .then(quiesce(QLong))
+            .expect(expects == Set(
+                { kind: EvPoll, slot: 0, mult: MExactly, count: 1 }))
+            .then(pollUnpin)
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvPoll, slot: 0, mult: MExactly, count: 1 },
+                { kind: EvPollExit, slot: 0, mult: MExactly, count: 1 }))
+
+    /// Nothing is notified about a send until an end asks; once it has, every
+    /// byte it hands over is reported back to it, and only to it.
+    run sendNotificationsAreOptInTest =
+        init
+            .then(listen)
+            .then(connect(0, DrainRecv))
+            .then(quiesce(QShort))
+            /* Before asking: the peer is owed the bytes, this end is owed
+             * nothing. */
+            .then(send(0, SIDE_CLIENT, SzSmall, SendBuf))
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvRecv, slot: sideSlot(0, SIDE_SERVER), mult: MExactly, count: 100 }))
+            /* After asking, both. */
+            .then(requestSendNotify(0, SIDE_CLIENT))
+            .then(send(0, SIDE_CLIENT, SzSmall, SendReserveCommit))
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvRecv, slot: sideSlot(0, SIDE_SERVER), mult: MExactly, count: 100 },
+                { kind: EvSent, slot: sideSlot(0, SIDE_CLIENT), mult: MExactly, count: 100 }))
+
+    /// While hooks are installed all three run on every window, and once
+    /// cleared none of them does -- which rule 2 is what checks.
+    run loopHooksRunWhileInstalledTest =
+        init
+            .then(setLoopHooks)
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvHook, slot: 0, mult: MExactly, count: 1 },
+                { kind: EvHook, slot: 1, mult: MExactly, count: 1 },
+                { kind: EvHook, slot: 2, mult: MExactly, count: 1 }))
+            .then(clearLoopHooks)
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+
+    /// The property that separates the two transports.  Three sends of
+    /// different sizes owe three deliveries totalling their sum on a
+    /// datagram; on a stream only the sum is owed, because a stream is free
+    /// to deliver it in any number of pieces.
+    ///
+    /// A byte count alone cannot tell the two apart, which is why EvRecvMsg
+    /// exists: coalescing two datagrams into one delivery, or splitting one
+    /// across two, both keep the total and both are failures.
+    run datagramPreservesMessageBoundariesTest =
+        init
+            .then(doReset(ShapeMixed, TDatagramInproc))
+            .then(listen)
+            .then(connect(0, DrainRecv))
+            .then(quiesce(QShort))
+            .then(send(0, SIDE_CLIENT, SzTiny, SendBuf))
+            .then(send(0, SIDE_CLIENT, SzSmall, SendV))
+            .then(send(0, SIDE_CLIENT, SzMedium, SendBuf))
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvRecv, slot: sideSlot(0, SIDE_SERVER),
+                  mult: MExactly, count: 1 + 100 + 8192 },
+                { kind: EvRecvMsg, slot: sideSlot(0, SIDE_SERVER),
+                  mult: MExactly, count: 3 }))
+
+    /// The same three sends over a stream owe the bytes and nothing about how
+    /// they are divided up.
+    run streamOwesBytesAndNotMessagesTest =
+        init
+            .then(listen)
+            .then(connect(0, DrainRecv))
+            .then(quiesce(QShort))
+            .then(send(0, SIDE_CLIENT, SzTiny, SendBuf))
+            .then(send(0, SIDE_CLIENT, SzSmall, SendV))
+            .then(send(0, SIDE_CLIENT, SzMedium, SendBuf))
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvRecv, slot: sideSlot(0, SIDE_SERVER),
+                  mult: MExactly, count: 1 + 100 + 8192 }))
+
+    /// UDP has no connection: both ends are bound and address each other by
+    /// endpoint.  Nothing is notified about the pair coming up, which is what
+    /// distinguishes this from connect -- and the message-boundary obligation
+    /// is the same as any other datagram's.
+    run udpPairNeedsNoConnectionTest =
+        init
+            .then(resetUdp)
+            .then(bindPair(0))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+            .then(send(0, SIDE_CLIENT, SzSmall, SendToEp))
+            .then(send(0, SIDE_SERVER, SzTiny, SendToEpV))
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvRecv, slot: sideSlot(0, SIDE_SERVER), mult: MExactly, count: 100 },
+                { kind: EvRecvMsg, slot: sideSlot(0, SIDE_SERVER), mult: MExactly, count: 1 },
+                { kind: EvRecv, slot: sideSlot(0, SIDE_CLIENT), mult: MExactly, count: 1 },
+                { kind: EvRecvMsg, slot: sideSlot(0, SIDE_CLIENT), mult: MExactly, count: 1 }))
+}

--- a/src/core/tests/quint/generate_core_cases.sh
+++ b/src/core/tests/quint/generate_core_cases.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Ben Jarvis
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# generate_core_cases.sh - turn core.qnt into the C program table
+#
+# Usage: generate_core_cases.sh QUINT PYTHON SRC_DIR WORK_DIR OUT_HEADER
+#
+# Driven by CMake as a build step, so everything it produces -- the ITF traces
+# as well as the header -- is a build artifact under WORK_DIR rather than
+# something checked in.  Run it by hand the same way if you want to inspect
+# the traces.
+#
+# Generation is deliberately lean: it does not re-check the model, because the
+# quint_core_model test does that and a build is the wrong place to discover a
+# broken specification.
+#
+# The seeds are fixed, so a given quint version always yields the same
+# programs.  Different quint versions may sample differently; that is the
+# tradeoff for generating rather than checking in, and is why the devcontainer
+# pins one.
+
+set -euo pipefail
+
+QUINT="${1:?usage: generate_core_cases.sh QUINT PYTHON SRC_DIR WORK_DIR OUT_HEADER}"
+PYTHON="${2:?}"
+SRC_DIR="${3:?}"
+WORK_DIR="${4:?}"
+OUT_HEADER="${5:?}"
+
+mkdir -p "${WORK_DIR}"
+
+# Unlike the RPC2 models, these traces are not a bag of independent cases that
+# de-duplicate down to a taxonomy: each program is distinct, so breadth comes
+# from generating more of them rather than from longer traces.
+#
+# Generous, because a program costs almost nothing to run.  Its windows are
+# advances of libevpl's virtual clock rather than sleeps, so a 100ms window is
+# a few hundred non-blocking passes of the event loop and the whole suite runs
+# in well under a second.  On a real clock this many programs would be minutes.
+SEEDS=(0xe1 0xe2 0xe3 0xe4 0xe5 0xe6 0xe7 0xe8 0xe9 0xea)
+STEPS=260
+
+# The seeds are independent, so they run concurrently -- serially this is the
+# slowest step of the build by an order of magnitude, and it is pure waiting on
+# a simulator that uses about one and a half cores.
+TRACES=()
+PIDS=()
+
+for s in "${SEEDS[@]}"; do
+    f="${WORK_DIR}/core-${s}.itf.json"
+    "${QUINT}" run "${SRC_DIR}/core.qnt" \
+        --seed="$s" --max-steps="${STEPS}" --out-itf="$f" > /dev/null &
+    PIDS+=($!)
+    TRACES+=("$f")
+done
+
+for pid in "${PIDS[@]}"; do
+    wait "$pid" || { echo "quint run failed" >&2; exit 1; }
+done
+
+"${PYTHON}" "${SRC_DIR}/itf_to_core_cases.py" "${OUT_HEADER}" "${TRACES[@]}"

--- a/src/core/tests/quint/itf_to_core_cases.py
+++ b/src/core/tests/quint/itf_to_core_cases.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Ben Jarvis
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+"""Convert Quint ITF traces of core.qnt into the C program table.
+
+The RPC2 converters turn a trace into a set of independent cases.  This one
+turns it into a set of PROGRAMS: core.qnt's states are the steps of a
+sequence, delimited by OpReset, and the C driver in core_conformance.c is an
+interpreter for them.  The obligations a quiesce carries travel in side tables
+that each step indexes, so a step stays a fixed-size struct.
+
+Every tag the model can emit must appear in the tables below.  An unknown tag
+is a hard error rather than a silently skipped step: if the model gains an op,
+the driver needs an arm for it, and failing loudly here is what forces that.
+
+The op-coverage check at the end is the other half of that.  A trace is a
+sample, so a seed bump or a quint release that samples differently could drop
+an operation entirely and leave a smaller suite that still looks green; an op
+the model declares but no program exercises fails generation instead.
+"""
+
+import json
+import sys
+
+OPS = [
+    "OpReset",
+    "OpAddTimer",
+    "OpRemoveTimer",
+    "OpDefer",
+    "OpDeferTwice",
+    "OpDeferReentrant",
+    "OpAddDoorbell",
+    "OpRingDoorbell",
+    "OpRingDoorbellTwice",
+    "OpRemoveDoorbell",
+    "OpRemoveDoorbellInCallback",
+    "OpRemoveDeferral",
+    "OpRemoveDeferralIdle",
+    "OpRequestSendNotify",
+    "OpSetLoopHooks",
+    "OpClearLoopHooks",
+    "OpAddPoll",
+    "OpRemovePoll",
+    "OpActivity",
+    "OpPollPin",
+    "OpPollUnpin",
+    "OpListen",
+    "OpStopListen",
+    "OpBindPair",
+    "OpConnect",
+    "OpSend",
+    "OpClose",
+    "OpFinish",
+    "OpQuiesce",
+]
+
+TIMER_KINDS = ["TOneshot", "TPeriodic", "TRearm"]
+DELAYS = ["DFast", "DSlow"]
+BUDGETS = ["QShort", "QLong"]
+SIZES = ["SzTiny", "SzSmall", "SzMedium", "SzLarge"]
+DRAINS = ["DrainRecv", "DrainRecvV", "DrainPeek", "DrainPeekV"]
+TRANSPORTS = ["TStreamInproc", "TDatagramInproc", "TStreamTcp", "TStreamUnix",
+              "TDatagramUdp"]
+SENDS = ["SendBuf", "SendV", "SendVTakeRef", "SendToEp", "SendToEpV",
+         "SendReserveCommit", "SendGlobal"]
+EVENTS = ["EvTimer", "EvDeferral", "EvDoorbell",
+          "EvConnected", "EvDisconnected", "EvRecv",
+          "EvPollEnter", "EvPollExit", "EvPoll", "EvRecvMsg", "EvSent",
+          "EvHook"]
+MULTS = ["MExactly", "MAtLeast"]
+
+# OpReset is the program delimiter, not something the driver runs, so it is
+# excluded from the coverage requirement below along with nothing else: every
+# other op must be reached by some program.
+# SendToEp/SendToEpV are declared by the model but deliberately not generated
+# (see SendMode in core.qnt), so send-mode coverage is not required the way op
+# coverage is.
+COVERAGE_EXEMPT = {"OpReset"}
+
+
+class TagError(Exception):
+    pass
+
+
+def tag_of(v):
+    if not isinstance(v, dict) or "tag" not in v:
+        raise TagError("expected a tagged variant, got %r" % (v,))
+    return v["tag"]
+
+
+def index_of(table, tag, what):
+    try:
+        return table.index(tag)
+    except ValueError:
+        raise TagError("unknown %s tag %r; add it to itf_to_core_cases.py "
+                       "and to the C driver" % (what, tag))
+
+
+def itf_int(v):
+    if isinstance(v, dict) and "#bigint" in v:
+        return int(v["#bigint"])
+    if isinstance(v, int):
+        return v
+    raise TagError("expected an integer, got %r" % (v,))
+
+
+def itf_set(v):
+    if not isinstance(v, dict) or "#set" not in v:
+        raise TagError("expected a set, got %r" % (v,))
+    return v["#set"]
+
+
+def read_expects(state):
+    """Expectations, canonically ordered.
+
+    Quint emits a set, whose serialized order is not something to depend on.
+    Sorting makes two structurally identical programs compare equal, which is
+    what the de-duplication below relies on.
+    """
+    out = []
+    for e in itf_set(state["expects"]):
+        out.append((index_of(EVENTS, tag_of(e["kind"]), "event"),
+                    itf_int(e["slot"]),
+                    index_of(MULTS, tag_of(e["mult"]), "multiplicity"),
+                    itf_int(e["count"])))
+    return sorted(out)
+
+
+def read_orders(state):
+    out = []
+    for o in itf_set(state["orders"]):
+        out.append((index_of(EVENTS, tag_of(o["firstKind"]), "event"),
+                    itf_int(o["firstSlot"]),
+                    index_of(EVENTS, tag_of(o["thenKind"]), "event"),
+                    itf_int(o["thenSlot"])))
+    return sorted(out)
+
+
+def read_step(state):
+    cur = state["current"]
+    op = tag_of(cur["op"])
+
+    return (op,
+            index_of(OPS, op, "op"),
+            itf_int(cur["slot"]),
+            index_of(TIMER_KINDS, tag_of(cur["timerKind"]), "timer kind"),
+            index_of(DELAYS, tag_of(cur["delay"]), "delay class"),
+            index_of(BUDGETS, tag_of(cur["budget"]), "budget"),
+            itf_int(cur["conn"]),
+            itf_int(cur["side"]),
+            index_of(TRANSPORTS, tag_of(cur["transport"]), "transport"),
+            index_of(SIZES, tag_of(cur["size"]), "size class"),
+            index_of(SENDS, tag_of(cur["send"]), "send mode"),
+            index_of(DRAINS, tag_of(cur["drain"]), "drain mode"),
+            itf_int(cur["atMs"]),
+            tuple(read_expects(state)),
+            tuple(read_orders(state)))
+
+
+def collect(paths):
+    """Split the traces into programs, de-duplicated structurally.
+
+    A program is everything between one OpReset and the next.  Trailing steps
+    after the last reset are kept: the model forces a long quiesce as the last
+    op of every program, so a truncated tail is still a program that ends
+    discharged.
+    """
+    seen, programs = set(), []
+
+    for path in paths:
+        with open(path) as f:
+            trace = json.load(f)
+
+        current = []
+        for state in trace["states"]:
+            step = read_step(state)
+            if step[0] == "OpReset":
+                if current:
+                    key = tuple(current)
+                    if key not in seen:
+                        seen.add(key)
+                        programs.append(current)
+                current = []
+            else:
+                current.append(step)
+
+        if current:
+            key = tuple(current)
+            if key not in seen:
+                seen.add(key)
+                programs.append(current)
+
+    return programs
+
+
+def emit_enum(out, name, prefix, tags):
+    out.append("enum %s {" % name)
+    for i, t in enumerate(tags):
+        out.append("    %s_%s = %d," % (prefix, t.upper(), i))
+    out.append("};")
+    out.append("")
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("usage: %s <out.h> <traces...>" % sys.argv[0], file=sys.stderr)
+        return 2
+
+    out_path = sys.argv[1]
+    programs = collect(sys.argv[2:])
+
+    if not programs:
+        print("error: no programs in the traces", file=sys.stderr)
+        return 1
+
+    # Side tables, shared across steps: the expectation lists repeat heavily
+    # (most quiesces owe the same one or two callbacks), so interning them
+    # keeps the generated header a fraction of the size it would otherwise be.
+    expect_rows, expect_index = [], {}
+    order_rows, order_index = [], {}
+
+    def intern(rows, index, items):
+        if not items:
+            return 0, 0
+        if items in index:
+            return index[items], len(items)
+        first = len(rows)
+        rows.extend(items)
+        index[items] = first
+        return first, len(items)
+
+    steps, prog_rows = [], []
+    reached = set()
+
+    for prog in programs:
+        first_step = len(steps)
+        for (op_tag, op, slot, tk, delay, budget, conn, side, transport, size,
+             send, drain, at_ms, exps, ords) in prog:
+            reached.add(op_tag)
+            ef, ec = intern(expect_rows, expect_index, exps)
+            of, oc = intern(order_rows, order_index, ords)
+            steps.append((op, slot, tk, delay, budget, conn, side, transport,
+                          size, send, drain, at_ms, ef, ec, of, oc))
+        prog_rows.append((first_step, len(steps) - first_step))
+
+    missing = sorted(set(OPS) - COVERAGE_EXEMPT - reached)
+    if missing:
+        print("error: no generated program exercises: %s\n"
+              "       widen the seeds or lengthen the traces in "
+              "generate_core_cases.sh" % ", ".join(missing), file=sys.stderr)
+        return 1
+
+    o = []
+    # The header written into the GENERATED file.  Fenced off because reuse
+    # otherwise reads these string literals as this script's own license tags.
+    # REUSE-IgnoreStart
+    o.append("/* SPDX-FileCopyrightText: 2026 Ben Jarvis")
+    o.append(" *")
+    o.append(" * SPDX-License-Identifier: LGPL-2.1-only")
+    # REUSE-IgnoreEnd
+    o.append(" *")
+    o.append(" * GENERATED FILE -- DO NOT EDIT.")
+    o.append(" *")
+    o.append(" * Produced by quint/generate_core_cases.sh from the Quint model")
+    o.append(" * in quint/core.qnt.  Each program is a run of SDK operations")
+    o.append(" * against a fresh evpl; core_conformance.c interprets them and")
+    o.append(" * checks the callbacks that arrive against the ones each")
+    o.append(" * quiesce is owed.")
+    o.append(" */")
+    o.append("")
+    o.append("#pragma once")
+    o.append("")
+    o.append("#include <stdint.h>")
+    o.append("")
+
+    emit_enum(o, "core_op", "COP", OPS)
+    emit_enum(o, "core_timer_kind", "CTK", TIMER_KINDS)
+    emit_enum(o, "core_delay", "CDLY", DELAYS)
+    emit_enum(o, "core_budget", "CBUD", BUDGETS)
+    emit_enum(o, "core_transport", "CTR", TRANSPORTS)
+    emit_enum(o, "core_size", "CSZ", SIZES)
+    emit_enum(o, "core_send", "CSND", SENDS)
+    emit_enum(o, "core_drain", "CDRN", DRAINS)
+    emit_enum(o, "core_event", "CEV", EVENTS)
+
+    # The driver indexes per-event-kind arrays by this, so it is emitted
+    # rather than restated there: a count that has to be kept in step by hand
+    # is one that eventually is not, and the failure mode is writing past the
+    # end of the check tables.
+    o.append("#define CORE_NUM_EVENT_KIND %d" % len(EVENTS))
+    o.append("")
+    emit_enum(o, "core_mult", "CMUL", MULTS)
+
+    o.append("/* One obligation: `count` occurrences of (kind, slot), exactly")
+    o.append(" * or at least.  For CEV_EVRECV an occurrence is a BYTE and not")
+    o.append(" * a callback, so `count` is wide enough for a payload. */")
+    o.append("struct core_expect {")
+    o.append("    uint8_t  kind;")
+    o.append("    uint8_t  slot;")
+    o.append("    uint8_t  mult;")
+    o.append("    uint32_t count;")
+    o.append("};")
+    o.append("")
+
+    o.append("/* First occurrence of (first_kind, first_slot) must precede the")
+    o.append(" * first occurrence of (then_kind, then_slot). */")
+    o.append("struct core_order {")
+    o.append("    uint8_t first_kind;")
+    o.append("    uint8_t first_slot;")
+    o.append("    uint8_t then_kind;")
+    o.append("    uint8_t then_slot;")
+    o.append("};")
+    o.append("")
+
+    o.append("struct core_step {")
+    o.append("    uint8_t  op;")
+    o.append("    uint8_t  slot;")
+    o.append("    uint8_t  timer_kind;  /* OpAddTimer only */")
+    o.append("    uint8_t  delay;       /* OpAddTimer only */")
+    o.append("    uint8_t  budget;      /* OpQuiesce only, for reporting  */")
+    o.append("    uint8_t  conn;        /* transport ops only */")
+    o.append("    uint8_t  side;        /* transport ops only */")
+    o.append("    /* Which in-process transport this program runs over; the")
+    o.append("     * same on every step of a program. */")
+    o.append("    uint8_t  transport;")
+    o.append("    uint8_t  size;        /* OpSend only    */")
+    o.append("    uint8_t  send;        /* OpSend only    */")
+    o.append("    uint8_t  drain;       /* OpConnect only */")
+    o.append("    /* Model time in milliseconds at the end of this step,")
+    o.append("     * measured from the start of the program.  A quiesce runs")
+    o.append("     * to this as an ABSOLUTE deadline, so real and model time")
+    o.append("     * cannot drift apart cumulatively over a program. */")
+    o.append("    uint32_t at_ms;")
+    o.append("    uint16_t expect_first;")
+    o.append("    uint16_t expect_count;")
+    o.append("    uint16_t order_first;")
+    o.append("    uint16_t order_count;")
+    o.append("};")
+    o.append("")
+
+    o.append("struct core_program {")
+    o.append("    uint16_t first_step;")
+    o.append("    uint16_t nsteps;")
+    o.append("};")
+    o.append("")
+
+    o.append("static const struct core_expect core_expects[] = {")
+    if not expect_rows:
+        o.append("    { 0, 0, 0, 0 },")
+    for kind, slot, mult, count in expect_rows:
+        o.append("    { %d, %d, %d, %d }," % (kind, slot, mult, count))
+    o.append("};")
+    o.append("")
+
+    o.append("static const struct core_order core_orders[] = {")
+    if not order_rows:
+        o.append("    { 0, 0, 0, 0 },")
+    for fk, fs, tk, ts in order_rows:
+        o.append("    { %d, %d, %d, %d }," % (fk, fs, tk, ts))
+    o.append("};")
+    o.append("")
+
+    o.append("static const struct core_step core_steps[] = {")
+    for (op, slot, tk, delay, budget, conn, side, transport, size, send, drain,
+         at_ms, ef, ec, of, oc) in steps:
+        o.append("    { %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d },"
+                 % (op, slot, tk, delay, budget, conn, side, transport, size,
+                    send, drain, at_ms, ef, ec, of, oc))
+    o.append("};")
+    o.append("")
+
+    o.append("static const struct core_program core_programs[] = {")
+    for first, n in prog_rows:
+        o.append("    { %d, %d }," % (first, n))
+    o.append("};")
+    o.append("")
+    o.append("#define CORE_NUM_PROGRAMS "
+             "(sizeof(core_programs) / sizeof(core_programs[0]))")
+    o.append("")
+
+    with open(out_path, "w") as f:
+        f.write("\n".join(o))
+
+    print("%s: %d programs, %d steps, %d obligations" %
+          (out_path, len(prog_rows), len(steps), len(expect_rows)))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except TagError as e:
+        print("error: %s" % e, file=sys.stderr)
+        sys.exit(1)

--- a/src/core/vfio/vfio.c
+++ b/src/core/vfio/vfio.c
@@ -155,9 +155,6 @@ struct evpl_vfio_device {
     pthread_mutex_t             lock;
 };
 
-void evpl_remove_deferral(
-    struct evpl          *evpl,
-    struct evpl_deferral *deferral);
 
 static uint64_t
 evpl_vfio_now_ms(void)


### PR DESCRIPTION
A Quint model of libevpl's core SDK and a C interpreter for the programs it
generates, plus the seven fixes it turned up along the way.

Each fix is its own commit and stands on its own; the harness is last.

## The fixes

| Commit | What was wrong |
|---|---|
| `evpl: stop firing timers before their deadline` | The timer scan only broke out when the head of the heap had less time remaining than the thread's `wait_ms`; otherwise it fell through and fired the timer early. A periodic timer in that state re-armed and re-fired without bound inside one `evpl_continue()`. Hidden by the default `wait_ms` of -1, which takes the branch that behaved correctly. |
| `evpl_recv: advance the destination pointer between iovecs` | Every buffered iovec after the first was copied over the top of the first at offset zero. The correct length was returned, so the caller had no way to tell. Reachable whenever a payload arrives split. |
| `iovec: place an allocation larger than one buffer instead of spinning` | `evpl_iovec_alloc`/`evpl_iovec_reserve` discarded a buffer too small for the request and asked for another of the same size — forever, when the buffer was already fresh. The code below them that places a request across several iovecs was unreachable. Hidden by the 2 MiB default `buffer_size`. |
| `evpl: start the poll-mode spin window when the thread is created` | `last_activity_ticks` was left at zero, so inactivity was measured from process init. Any thread created more than `spin_ns` later never entered poll mode, making `evpl_thread_config_set_poll_mode()` a no-op on every thread but the first. |
| `evpl: export evpl_get_hf_monotonic_time` | Declared in `evpl_core.h`, built without `SYMBOL_EXPORT`. Any consumer calling it failed to link. |
| `evpl: drop the evpl_config() declaration, which has no definition` | No such function; the implementation is `evpl_get_config(void)`, differing in name and signature. |
| `recv: remove evpl_recv_peek_iovec` | Dead — no declaration, no callers — and its body is `do { } while (left);`. |

Two commits are neither fixes nor harness. The virtual clock is a new API and
a prerequisite for the tests, but useful on its own. The deferral commit is
now just documentation plus a tidy-up: #134 made `evpl_remove_deferral`
public while this branch was open, which leaves `vfio.c` carrying a local
prototype for a function that is now declared in the header, and leaves
`evpl_defer` undocumented next to it.

Rebased onto #134. The only overlap was the `evpl_remove_deferral`
declaration, which we had both added; the resolution keeps that comment and
folds in the two facts this branch's version stated and it did not.

## The harness

`quint/core.qnt` models the core API as a state machine; a build step turns
generated traces into a C table; `core_conformance.c` interprets them.

The RPC2 models next door enumerate independent cases, which works because an
RPC exchange is memoryless. Nothing about the core API is: a one-shot fires
once and then must not fire again, a deferral armed twice runs once, a
doorbell retired from inside its own callback must not be called back
afterwards. So a trace here is a *program*, and the driver interprets it.

The oracle is the event log, since an asynchronous API has no return value to
check. Each quiesce runs the loop to the end of a window and checks three
things: every obligation discharged, nothing arriving that was not owed, and
ordered callbacks in that order. The second is what makes an absence
observable, and is why a window always runs to its end.

Time comes from the virtual clock, so the timing claims are integer arithmetic
on both sides and the answer is the same under any load. On a real clock the
same programs took 14 seconds and disagreed with themselves about once in five
runs; they now take about 60ms and are deterministic across mechanisms.

174 programs over five transports — both in-process ones, TCP, AF_UNIX and UDP
— covering timers, deferrals, doorbells, poll mode, loop hooks, the connection
lifecycle, send notifications, and a data plane checked by content rather than
length across five send modes and four drain modes.

The test is registered only when quint and python3 are on PATH; without them
nothing changes. It binds ports, so it is registered like the other networked
tests rather than the parallel name-addressed ones.

## Notes for review

- The model states the **specification**, not current behaviour — that is what
  found the fixes above. Reviewed, deferred divergences go in
  `known_divergences[]`; anything else fails.
- `CORE_CONFORMANCE.md` documents what it covers, what it does not, and five
  open questions it raised that are **not** fixed here. The one worth a look
  is the address ownership on `evpl_sendtoep`/`evpl_sendtoepv`: they hand
  `evpl_sendtov` a +1 reference that only `udp.c` and `rdmacm.c` ever release,
  so the same public call is balanced on one transport and leaks on the
  others. Releasing it in the wrapper is not the fix — it turns the UDP tests
  into use-after-free — and the real one touches every transport.
- Coverage from this test alone: 202 of 238 core functions (84.9%), lines
  73.5%, branches 54.7%. Fourteen modules at 100% function coverage.
