### PR TITLE
core: public fd-event API for caller-owned descriptors

### DIFF
--- a/include/evpl/evpl.h
+++ b/include/evpl/evpl.h
@@ -13,6 +13,7 @@
 #include <evpl/evpl_endpoint.h>
 #include <evpl/evpl_deferral.h>
 #include <evpl/evpl_doorbell.h>
+#include <evpl/evpl_fd_event.h>
 #include <evpl/evpl_poll.h>
 #include <evpl/evpl_timer.h>
 #include <evpl/evpl_bind.h>

--- a/include/evpl/evpl_fd_event.h
+++ b/include/evpl/evpl_fd_event.h
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#ifndef EVPL_INCLUDED
+#error "Do not include evpl_fd_event.h directly, include evpl/evpl.h instead"
+#endif /* ifndef EVPL_INCLUDED */
+
+/*
+ * A caller-owned file descriptor as a first-class event source.
+ *
+ * Intended for descriptors evpl has no protocol for (device files such as
+ * /dev/fuse, inotify, signalfd, ...).  The fd must be non-blocking; evpl
+ * registers it with the event mechanism once and thereafter latches
+ * readiness, so the contract is uniform across epoll, kqueue, and select:
+ *
+ *  - Nothing is armed at add time; call evpl_fd_event_read_interest() (and,
+ *    if wanted, evpl_fd_event_write_interest()) to start delivery.  Arming
+ *    an interest requires the corresponding callback to have been supplied.
+ *
+ *  - Once the fd becomes readable, read_callback is invoked once per loop
+ *    pass -- without sleeping between passes -- until the callback consumes
+ *    the readiness: read until EAGAIN (or a short read) and then call
+ *    evpl_fd_event_mark_unreadable().  A callback may deliberately return
+ *    early without draining (for fairness with other work); it is simply
+ *    invoked again on the next pass.  Forgetting mark_unreadable() does not
+ *    lose events, but it keeps the loop from ever sleeping.
+ *
+ *  - mark_unreadable() with data still pending is portable only as a way to
+ *    end the current burst: an edge-triggered mechanism (epoll, kqueue)
+ *    stays quiet until new data arrives, but a level-triggered one (select)
+ *    re-reports the pending data by itself.  The uniform guarantee is
+ *    quiescence after draining to EAGAIN.
+ *
+ *  - evpl_fd_event_mark_readable() re-queues the event without a kernel
+ *    edge; use it to resume consumption that was deliberately parked while
+ *    data may still be pending, which no edge-triggered mechanism would
+ *    otherwise revisit.
+ *
+ *  - Write interest works symmetrically with mark_unwritable(); most
+ *    consumers of always-writable descriptors never arm it.
+ *
+ *  - error_callback (optional) fires when the mechanism reports an error or
+ *    hangup on the fd.  Device files may instead surface teardown through
+ *    read() failing (e.g. ENODEV); handle both.
+ *
+ * All calls must be made on the thread that owns the evpl.  Removal is
+ * legal from inside one of the event's own callbacks; once
+ * evpl_remove_fd_event() returns the library holds no further reference,
+ * so the caller may free the storage the event lives in.  The fd itself is
+ * never closed by evpl.
+ */
+
+struct evpl_fd_event;
+
+#ifndef EVPL_INTERNAL
+struct evpl_fd_event {
+    uint64_t opaque[10];
+};
+#endif /* ifndef EVPL_INTERNAL */
+
+typedef void (*evpl_fd_event_callback_t)(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event);
+
+void
+evpl_add_fd_event(
+    struct evpl             *evpl,
+    struct evpl_fd_event    *event,
+    int                      fd,
+    evpl_fd_event_callback_t read_callback,
+    evpl_fd_event_callback_t write_callback,
+    evpl_fd_event_callback_t error_callback);
+
+void
+evpl_remove_fd_event(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event);
+
+int
+evpl_fd_event_fd(
+    struct evpl_fd_event *event);
+
+void
+evpl_fd_event_read_interest(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event);
+
+void
+evpl_fd_event_read_disinterest(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event);
+
+void
+evpl_fd_event_write_interest(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event);
+
+void
+evpl_fd_event_write_disinterest(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event);
+
+void
+evpl_fd_event_mark_readable(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event);
+
+void
+evpl_fd_event_mark_unreadable(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event);
+
+void
+evpl_fd_event_mark_unwritable(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CORE_SRC
     logging.c
     memory.c
     doorbell.c
+    fd_event.c
     listen.c
     timer.c
     deferral.c

--- a/src/core/fd_event.c
+++ b/src/core/fd_event.c
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdint.h>
+
+#include "fd_event.h"
+#include "evpl/evpl.h"
+#include "macros.h"
+#include "logging.h"
+#include "event_fn.h"
+
+/* The public opaque struct is what consumers allocate; the real one must
+ * fit inside it. */
+_Static_assert(sizeof(struct evpl_fd_event) <= 10 * sizeof(uint64_t),
+               "struct evpl_fd_event exceeds its public opaque size");
+
+static void
+evpl_fd_event_read_trampoline(
+    struct evpl       *evpl,
+    struct evpl_event *event)
+{
+    struct evpl_fd_event *fd_event = container_of(event, struct evpl_fd_event, event);
+
+    fd_event->read_callback(evpl, fd_event);
+} /* evpl_fd_event_read_trampoline */
+
+static void
+evpl_fd_event_write_trampoline(
+    struct evpl       *evpl,
+    struct evpl_event *event)
+{
+    struct evpl_fd_event *fd_event = container_of(event, struct evpl_fd_event, event);
+
+    fd_event->write_callback(evpl, fd_event);
+} /* evpl_fd_event_write_trampoline */
+
+/* The dispatch loop invokes error_callback unconditionally when the event
+ * mechanism flags an error, whether or not the consumer asked for one, so
+ * the NULL check lives here rather than at add time. */
+static void
+evpl_fd_event_error_trampoline(
+    struct evpl       *evpl,
+    struct evpl_event *event)
+{
+    struct evpl_fd_event *fd_event = container_of(event, struct evpl_fd_event, event);
+
+    if (fd_event->error_callback) {
+        fd_event->error_callback(evpl, fd_event);
+    }
+} /* evpl_fd_event_error_trampoline */
+
+SYMBOL_EXPORT void
+evpl_add_fd_event(
+    struct evpl             *evpl,
+    struct evpl_fd_event    *event,
+    int                      fd,
+    evpl_fd_event_callback_t read_callback,
+    evpl_fd_event_callback_t write_callback,
+    evpl_fd_event_callback_t error_callback)
+{
+    event->read_callback  = read_callback;
+    event->write_callback = write_callback;
+    event->error_callback = error_callback;
+
+    evpl_add_event(evpl, &event->event, fd,
+                   evpl_fd_event_read_trampoline,
+                   evpl_fd_event_write_trampoline,
+                   evpl_fd_event_error_trampoline);
+} /* evpl_add_fd_event */
+
+SYMBOL_EXPORT void
+evpl_remove_fd_event(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event)
+{
+    evpl_remove_event(evpl, &event->event);
+} /* evpl_remove_fd_event */
+
+SYMBOL_EXPORT int
+evpl_fd_event_fd(struct evpl_fd_event *event)
+{
+    return event->event.fd;
+} /* evpl_fd_event_fd */
+
+SYMBOL_EXPORT void
+evpl_fd_event_read_interest(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event)
+{
+    evpl_core_abort_if(!event->read_callback,
+                       "evpl_fd_event_read_interest: no read callback supplied");
+
+    evpl_event_read_interest(evpl, &event->event);
+} /* evpl_fd_event_read_interest */
+
+SYMBOL_EXPORT void
+evpl_fd_event_read_disinterest(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event)
+{
+    evpl_event_read_disinterest(evpl, &event->event);
+} /* evpl_fd_event_read_disinterest */
+
+SYMBOL_EXPORT void
+evpl_fd_event_write_interest(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event)
+{
+    evpl_core_abort_if(!event->write_callback,
+                       "evpl_fd_event_write_interest: no write callback supplied");
+
+    evpl_event_write_interest(evpl, &event->event);
+} /* evpl_fd_event_write_interest */
+
+SYMBOL_EXPORT void
+evpl_fd_event_write_disinterest(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event)
+{
+    evpl_event_write_disinterest(evpl, &event->event);
+} /* evpl_fd_event_write_disinterest */
+
+SYMBOL_EXPORT void
+evpl_fd_event_mark_readable(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event)
+{
+    evpl_event_mark_readable(evpl, &event->event);
+} /* evpl_fd_event_mark_readable */
+
+SYMBOL_EXPORT void
+evpl_fd_event_mark_unreadable(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event)
+{
+    evpl_event_mark_unreadable(evpl, &event->event);
+} /* evpl_fd_event_mark_unreadable */
+
+SYMBOL_EXPORT void
+evpl_fd_event_mark_unwritable(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event)
+{
+    evpl_event_mark_unwritable(evpl, &event->event);
+} /* evpl_fd_event_mark_unwritable */

--- a/src/core/fd_event.h
+++ b/src/core/fd_event.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#define EVPL_INTERNAL 1
+#include "event.h"
+#include "evpl/evpl.h"
+
+struct evpl_fd_event {
+    struct evpl_event        event;
+    evpl_fd_event_callback_t read_callback;
+    evpl_fd_event_callback_t write_callback;
+    evpl_fd_event_callback_t error_callback;
+};

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -35,6 +35,18 @@ endforeach()
 # than through a protocol, since the waist is only advanced by the RDMA CM one.
 unit_test(core iovec_ring_resize iovec_ring_resize.c)
 
+# The public fd-event API against a pipe: latched readiness, quiescence after
+# drain, mark_readable without a kernel edge, and retiring an event from its
+# own callback.  Touches no network.  A regression that keeps a drained event
+# active shows up as a spin, one that strands it shows up as a hang; the
+# bounded timeout catches both.
+unit_test_all_mechs(core fd_event_pipe fd_event_pipe.c)
+
+foreach(mech ${EVPL_MECHANISMS})
+    set_tests_properties(libevpl/core/fd_event_pipe_${mech}
+                         PROPERTIES TIMEOUT 10)
+endforeach()
+
 # Local (AF_UNIX) endpoints: addressed by socket name, so no namespace needed.
 unit_test_local(core endpoint_local endpoint_local.c)
 

--- a/src/core/tests/fd_event_pipe.c
+++ b/src/core/tests/fd_event_pipe.c
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * The public fd-event API against a pipe.
+ *
+ * What matters here is the latched-readiness contract: once the kernel has
+ * reported the fd readable, the read callback must be re-invoked every loop
+ * pass -- with no further kernel edge -- until it drains to EAGAIN and calls
+ * evpl_fd_event_mark_unreadable(); after that the loop must leave it alone
+ * until new data arrives.  The callback below therefore reads one byte per
+ * invocation, so multi-byte writes prove the re-invocation half, and the
+ * post-drain checks prove the quiescence half.
+ *
+ * Also covered: mark_readable() re-queuing a parked event without a kernel
+ * edge, write interest on an always-writable fd, and retiring an event from
+ * inside its own callback and freeing its storage (meaningful under the
+ * Debug/AddressSanitizer build, like doorbell_remove).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include "evpl/evpl.h"
+#include "tests/test_common.h"
+
+static int failures;
+
+#define CHECK(cond, ...) \
+        do { \
+            if (!(cond)) { \
+                printf("FAIL: " __VA_ARGS__); printf("\n"); failures++; \
+            } else { \
+                printf("ok:   " __VA_ARGS__); printf("\n"); \
+            } \
+        } while (0)
+
+/* --- reader: one byte per invocation, mark unreadable on EAGAIN --- */
+
+static struct evpl_fd_event reader;
+static int                  reader_invocations;
+static int                  reader_bytes;
+static int                  reader_drained;
+static int                  reader_paused;
+
+static void
+reader_callback(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event)
+{
+    char    c;
+    ssize_t n;
+
+    reader_invocations++;
+
+    if (reader_paused) {
+        /* Park without consuming: the loop must not spin on us, and only an
+         * explicit mark_readable() may bring us back. */
+        evpl_fd_event_mark_unreadable(evpl, event);
+        return;
+    }
+
+    n = read(evpl_fd_event_fd(event), &c, 1);
+
+    if (n == 1) {
+        reader_bytes++;
+        return;
+    }
+
+    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        evpl_fd_event_mark_unreadable(evpl, event);
+        reader_drained = 1;
+        return;
+    }
+
+    printf("FAIL: unexpected read result %zd errno %d\n", n, errno);
+    failures++;
+} /* reader_callback */
+
+/* --- writer: always-writable fd, single shot --- */
+
+static struct evpl_fd_event writer;
+static int                  writer_fired;
+
+static void
+writer_callback(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event)
+{
+    writer_fired++;
+
+    evpl_fd_event_write_disinterest(evpl, event);
+    evpl_fd_event_mark_unwritable(evpl, event);
+} /* writer_callback */
+
+/* --- self-retiring heap-allocated event --- */
+
+static int self_fired;
+
+static void
+self_callback(
+    struct evpl          *evpl,
+    struct evpl_fd_event *event)
+{
+    char c;
+
+    while (read(evpl_fd_event_fd(event), &c, 1) == 1) {
+        /* drain */
+    }
+
+    self_fired++;
+
+    evpl_remove_fd_event(evpl, event);
+    free(event);
+} /* self_callback */
+
+/* --- doorbell used as a neutral wakeup so quiescence is observable --- */
+
+static int tick_fired;
+
+static void
+tick_callback(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    tick_fired++;
+} /* tick_callback */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct evpl          *evpl;
+    struct evpl_fd_event *self;
+    struct evpl_doorbell  tick;
+    int                   p[2], p2[2], baseline;
+
+    test_evpl_config();
+
+    evpl = evpl_create(NULL);
+
+    memset(&tick, 0, sizeof(tick));
+    evpl_add_doorbell(evpl, &tick, tick_callback);
+
+    if (pipe(p) || pipe(p2)) {
+        perror("pipe");
+        return 1;
+    }
+
+    fcntl(p[0], F_SETFL, O_NONBLOCK);
+    fcntl(p[1], F_SETFL, O_NONBLOCK);
+    fcntl(p2[0], F_SETFL, O_NONBLOCK);
+
+    memset(&reader, 0, sizeof(reader));
+    evpl_add_fd_event(evpl, &reader, p[0], reader_callback, NULL, NULL);
+    evpl_fd_event_read_interest(evpl, &reader);
+
+    CHECK(evpl_fd_event_fd(&reader) == p[0], "event reports its fd");
+
+    /* --- one kernel edge, three bytes: re-invoked until drained --- */
+
+    if (write(p[1], "abc", 3) != 3) {
+        perror("write");
+        return 1;
+    }
+
+    while (!reader_drained) {
+        evpl_continue(evpl);
+    }
+
+    CHECK(reader_bytes == 3, "all three bytes read one per invocation");
+    CHECK(reader_invocations == 4, "invoked per pass until EAGAIN (got %d)",
+          reader_invocations);
+
+    /* --- quiescent after the drain --- */
+
+    baseline = reader_invocations;
+
+    evpl_ring_doorbell(&tick);
+
+    while (!tick_fired) {
+        evpl_continue(evpl);
+    }
+
+    CHECK(reader_invocations == baseline, "no callbacks while drained");
+
+    /* --- a new write wakes it again --- */
+
+    reader_drained = 0;
+
+    if (write(p[1], "d", 1) != 1) {
+        perror("write");
+        return 1;
+    }
+
+    while (!reader_drained) {
+        evpl_continue(evpl);
+    }
+
+    CHECK(reader_bytes == 4, "delivery resumes on new data");
+
+    /* --- mark_readable requeues a parked event without a kernel edge --- */
+
+    reader_paused = 1;
+
+    if (write(p[1], "e", 1) != 1) {
+        perror("write");
+        return 1;
+    }
+
+    baseline = reader_invocations;
+
+    while (reader_invocations == baseline) {
+        evpl_continue(evpl);
+    }
+
+    /* The callback parked itself without consuming the byte.  How long it
+     * stays parked is backend-specific -- a level-triggered mechanism
+     * (select) re-reports the pending byte on its own, an edge-triggered one
+     * (epoll, kqueue) never will -- so the only portable claim is that
+     * mark_readable() brings it back everywhere.  Quiescence is asserted
+     * only in the drained-to-EAGAIN case above, which is uniform. */
+    reader_paused  = 0;
+    reader_drained = 0;
+
+    evpl_fd_event_mark_readable(evpl, &reader);
+
+    while (!reader_drained) {
+        evpl_continue(evpl);
+    }
+
+    CHECK(reader_bytes == 5, "mark_readable revives the event without an edge");
+
+    /* --- write interest on an always-writable fd --- */
+
+    memset(&writer, 0, sizeof(writer));
+    evpl_add_fd_event(evpl, &writer, p[1], NULL, writer_callback, NULL);
+    evpl_fd_event_write_interest(evpl, &writer);
+
+    while (!writer_fired) {
+        evpl_continue(evpl);
+    }
+
+    CHECK(writer_fired == 1, "write callback fired for writable fd");
+
+    /* --- prove it stays quiet after disinterest --- */
+
+    tick_fired = 0;
+
+    evpl_ring_doorbell(&tick);
+
+    while (!tick_fired) {
+        evpl_continue(evpl);
+    }
+
+    CHECK(writer_fired == 1, "write callback quiet after disinterest");
+
+    /* --- retire from inside the callback, storage freed there --- */
+
+    self = calloc(1, sizeof(*self));
+
+    evpl_add_fd_event(evpl, self, p2[0], self_callback, NULL, NULL);
+    evpl_fd_event_read_interest(evpl, self);
+
+    if (write(p2[1], "x", 1) != 1) {
+        perror("write");
+        return 1;
+    }
+
+    while (!self_fired) {
+        evpl_continue(evpl);
+    }
+
+    CHECK(self_fired == 1, "event retired and freed from its own callback");
+
+    /* --- delivery in general still works after the removal --- */
+
+    tick_fired = 0;
+
+    evpl_ring_doorbell(&tick);
+
+    while (!tick_fired) {
+        evpl_continue(evpl);
+    }
+
+    CHECK(tick_fired == 1, "delivery continues after the removal");
+
+    evpl_remove_fd_event(evpl, &reader);
+    evpl_remove_fd_event(evpl, &writer);
+    evpl_remove_doorbell(evpl, &tick);
+
+    close(p[0]);
+    close(p[1]);
+    close(p2[0]);
+    close(p2[1]);
+
+    evpl_destroy(evpl);
+
+    printf("\n%s (%d failures)\n", failures ? "FAILED" : "PASSED", failures);
+
+    return failures != 0;
+} /* main */


### PR DESCRIPTION
Expose a public wrapper over the internal evpl_event machinery so a consumer can register a non-blocking fd it owns (device files such as /dev/fuse, inotify, signalfd) as a first-class event source, with explicit read/write interest and readiness-latch control.

The immediate consumer is chimera's upcoming FUSE protocol server, which needs each /dev/fuse channel fd in the event loop with zero CPU cost when idle. Neither existing public primitive fits: evpl_add_poll callbacks only run while the loop is in poll mode (they stop when it falls back to epoll_wait after spin_ns of inactivity), and doorbells own their eventfd. The internal evpl_add_event is exactly right but cannot be exported as-is: the interest/readiness helpers are static inlines that mutate private struct evpl state, and exporting the raw struct evpl_event would freeze its layout as ABI.

So this follows the evpl_doorbell pattern instead: a caller-owned opaque struct (`uint64_t opaque[10]`, static-asserted against the real size) whose private definition embeds the internal event plus the user callbacks, with SYMBOL_EXPORT out-of-line wrappers and container_of trampolines. One trampoline subtlety: the dispatch loop invokes error callbacks unconditionally when the mechanism flags an error, whether or not the consumer supplied one, so the error trampoline tolerates NULL while read/write interest arming aborts without a matching callback.

The header documents the contract the consumer lives by: readiness is latched, so the read callback re-fires every loop pass — without sleeping between passes — until it drains to EAGAIN and calls mark_unreadable; returning early without draining is legal (fairness) and simply re-invokes next pass. mark_unreadable with data still pending is portable only as end-of-burst: edge-triggered mechanisms (epoll, kqueue) stay quiet until new data, level-triggered select re-reports on its own, so the uniform guarantee is quiescence after draining to EAGAIN, and mark_readable is the portable way to revive a deliberately parked event.

The pipe test pins all of that per mechanism (epoll, select, kqueue via unit_test_all_mechs): one kernel edge re-invoking one-byte reads until EAGAIN, quiescence after the drain observed across an unrelated doorbell wakeup, revival on new data, mark_readable without an edge, write interest on an always-writable fd going quiet after disinterest, and — like doorbell_remove, meaningful under the ASan build — retiring an event from inside its own callback and freeing its storage.