### PR TITLE
http: trailer fields in both directions

### DIFF
--- a/include/evpl/evpl_http.h
+++ b/include/evpl/evpl_http.h
@@ -77,6 +77,24 @@ enum evpl_http_version {
                                * require "h2" via ALPN on TLS) */
 };
 
+/* The protocol a request is actually travelling over, as distinct from the
+ * enum above, which is what a client asked for before the connection knew. */
+enum evpl_http_protocol {
+    EVPL_HTTP_PROTOCOL_HTTP1,
+    EVPL_HTTP_PROTOCOL_HTTP2,
+};
+
+/*
+ * Which protocol carries this request.  Meaningful from the moment the
+ * request reaches the application (dispatch on a server, create on a client
+ * whose connection has settled its version), for callers whose behaviour
+ * depends on the transport's capabilities -- a gRPC endpoint, say, which
+ * exists only over HTTP/2.
+ */
+enum evpl_http_protocol
+evpl_http_request_protocol(
+    struct evpl_http_request *request);
+
 enum evpl_http_request_type {
     EVPL_HTTP_REQUEST_TYPE_UNKNOWN,
     EVPL_HTTP_REQUEST_TYPE_GET,
@@ -166,6 +184,56 @@ typedef void (*evpl_http_request_header_cb_t)(
 
 void
 evpl_http_request_header_iterate(
+    struct evpl_http_request     *request,
+    evpl_http_request_header_cb_t callback,
+    void                         *private_data);
+
+/*
+ * Stage a trailer field on the outbound message (the response on a server
+ * connection, the request on a client connection).  Trailers are fields that
+ * travel after the content instead of before it (RFC 9110 section 6.5), for
+ * values that are not known until the content has been produced -- a checksum,
+ * a signature, a final status.
+ *
+ * All trailers must be staged before the end of the content is signalled with
+ * evpl_http_request_add_datav(request, NULL, 0) (or, for a length-delimited
+ * message, before the final bytes of the declared length are staged): the
+ * trailer section travels with the last piece of the message, so a trailer
+ * added after that has nothing left to travel with.  Returns -1 with the
+ * trailer not added once the message is finished, and under the same two
+ * refusals as evpl_http_request_add_header -- the accounting limit and the
+ * field grammar.
+ *
+ * Where the trailer section lands depends on the message's framing, which is
+ * the library's to decide:
+ *
+ *   - HTTP/2: a trailing HEADERS frame, on any message.
+ *   - HTTP/1.x chunked: the trailer section of RFC 9112 section 7.1.2.
+ *   - HTTP/1.x with a Content-Length (or close-delimited): the coding has no
+ *     place for trailers, so staged ones are not sent.  A caller that needs
+ *     trailers on HTTP/1.x asks for a chunked message.
+ */
+int
+evpl_http_request_add_trailer(
+    struct evpl_http_request *request,
+    const char               *name,
+    const char               *value);
+
+/*
+ * The value of a trailer field received from the peer (the response's trailers
+ * on a client connection, the request's on a server connection), or NULL if
+ * the peer sent no such trailer.  Trailers arrive with the end of the content,
+ * so they are complete once EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE has fired and
+ * not before.  A peer speaking HTTP/1.x only carries them on a chunked
+ * message; HTTP/2 carries them on any.
+ */
+const char *
+evpl_http_request_trailer(
+    struct evpl_http_request *request,
+    const char               *name);
+
+void
+evpl_http_request_trailer_iterate(
     struct evpl_http_request     *request,
     evpl_http_request_header_cb_t callback,
     void                         *private_data);

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -515,6 +515,55 @@ evpl_http_parse_chunk_size(
 } /* evpl_http_parse_chunk_size */
 
 /*
+ * Keep one line of an inbound HTTP/1.x trailer section (RFC 9112 section
+ * 7.1.2), which has the field-line form of a header.  A line that does not
+ * parse as one, or a field past the max_header_size accounting, is consumed
+ * without being kept -- see the trailer loop in evpl_http_handle_body for why
+ * that is tolerance rather than an error.
+ */
+static void
+evpl_http_store_trailer_line(
+    struct evpl_http_request *request,
+    char                     *line)
+{
+    struct evpl_http_agent          *agent = request->conn->agent;
+    struct evpl_http_request_header *header;
+    char                            *name, *value, *saveptr;
+    unsigned int                     line_bytes;
+
+    name = strtok_r(line, ":", &saveptr);
+
+    if (!name) {
+        return;
+    }
+
+    value = strtok_r(NULL, "", &saveptr);
+
+    if (!value) {
+        return;
+    }
+
+    while (*value == ' ') {
+        value++;
+    }
+
+    line_bytes = strlen(name) + strlen(value) + 4;
+
+    if (request->recv_trailer_bytes + line_bytes > agent->max_header_size) {
+        return;
+    }
+
+    request->recv_trailer_bytes += line_bytes;
+
+    header = evpl_http_request_header_alloc(agent);
+
+    strncpy(header->name, name, sizeof(header->name) - 1);
+    strncpy(header->value, value, sizeof(header->value) - 1);
+
+    DL_APPEND(request->recv_trailers, header);
+} /* evpl_http_store_trailer_line */
+
+/*
  * Parse content (Content-Length or chunked) from the wire into
  * request->recv_ring and emit RECEIVE_DATA / RECEIVE_COMPLETE notifications.
  * Shared by the server (request content) and client (response content)
@@ -643,16 +692,25 @@ evpl_http_handle_body(
                 if (request->request_flags & EVPL_HTTP_REQUEST_IN_TRAILER) {
                     /* RFC 9112 section 7.1.2's trailer section: zero or more
                      * field lines, then the empty one that ends the coding.
-                     * Consuming it is not optional even though nothing here
-                     * reads it -- a trailer left in the stream is read as the
+                     * Consuming it is not optional even where nothing reads
+                     * it -- a trailer left in the stream is read as the
                      * start of the next request on a connection HTTP/1.1
-                     * keeps open by default.  The fields themselves are
-                     * discarded: section 6.5 says a recipient MAY do that, and
-                     * there is no API to surface them through. */
+                     * keeps open by default.
+                     *
+                     * Fields that parse are kept, for the application to read
+                     * back through evpl_http_request_trailer once receive
+                     * completes.  Lines that are not field lines are consumed
+                     * without becoming fields, as are fields past the
+                     * accounting limit: section 6.5 allows a recipient to
+                     * discard trailers, and a malformed line here -- unlike
+                     * one in the header block -- delimits nothing, so
+                     * tolerating it loses only the field it failed to be. */
                     if (line[0] == '\0') {
                         request->request_state = EVPL_HTTP_REQUEST_STATE_COMPLETE;
                         break;
                     }
+
+                    evpl_http_store_trailer_line(request, line);
                     continue;
                 }
 
@@ -2674,17 +2732,39 @@ evpl_http_send_body(
         }
 
         if (request->request_flags & EVPL_HTTP_REQUEST_RESPONSE_FINISHED) {
-            niov = evpl_iovec_alloc(evpl, 5, 0, 1, 0, &iov);
+            /* The last-chunk, then the trailer section if one was staged --
+            * RFC 9112 section 7.1.2 puts its field lines between the
+            * last-chunk and the CRLF that ends the coding.  The staged
+            * fields were validated and accounted (send_trailer_bytes is
+            * their exact emitted size) by evpl_http_request_add_trailer. */
+            struct evpl_http_request_header *trailer;
+            char                            *p;
+            unsigned int                     term_bytes;
+
+            term_bytes = 3 + request->send_trailer_bytes + 2;
+
+            niov = evpl_iovec_alloc(evpl, term_bytes, 0, 1, 0, &iov);
 
             evpl_http_abort_if(niov < 0, "failed to allocate iovec");
 
-            ((char *) iov.data)[0] = '0';
-            ((char *) iov.data)[1] = '\r';
-            ((char *) iov.data)[2] = '\n';
-            ((char *) iov.data)[3] = '\r';
-            ((char *) iov.data)[4] = '\n';
+            p    = iov.data;
+            *p++ = '0';
+            *p++ = '\r';
+            *p++ = '\n';
 
-            evpl_sendv(evpl, bind, &iov, 1, 5, EVPL_SEND_FLAG_TAKE_REF);
+            DL_FOREACH(request->send_trailers, trailer)
+            {
+                p += snprintf(p, term_bytes - (p - (char *) iov.data),
+                              "%s: %s\r\n", trailer->name, trailer->value);
+            }
+
+            *p++ = '\r';
+            *p++ = '\n';
+
+            evpl_http_abort_if((unsigned int) (p - (char *) iov.data) != term_bytes,
+                               "chunked terminator accounting mismatch");
+
+            evpl_sendv(evpl, bind, &iov, 1, term_bytes, EVPL_SEND_FLAG_TAKE_REF);
 
             return 1;
         }
@@ -3083,6 +3163,56 @@ evpl_http_request_add_header(
     return evpl_http_request_add_header_common(request, name, value, 1);
 } /* evpl_http_request_add_header */
 
+SYMBOL_EXPORT int
+evpl_http_request_add_trailer(
+    struct evpl_http_request *request,
+    const char               *name,
+    const char               *value)
+{
+    struct evpl_http_agent          *agent = request->conn->agent;
+    struct evpl_http_request_header *header;
+    unsigned int                     line_bytes;
+
+    /* The section travels with the last piece of the message, so once the
+     * application has said there is nothing more to send there is nothing
+     * for a trailer to travel with. */
+    if (unlikely(request->request_flags & EVPL_HTTP_REQUEST_RESPONSE_FINISHED)) {
+        evpl_http_error("refusing trailer '%s': the message is already finished",
+                        name);
+        return -1;
+    }
+
+    /* The same grammar rules as a header, for the same reason: a field the
+     * peer would read as something else is an injection point, and a trailer
+     * section is made of field lines like any other. */
+    if (unlikely(!evpl_http_field_name_is_token(name) ||
+                 !evpl_http_field_value_is_safe(value))) {
+        evpl_http_error("refusing to emit trailer '%s': "
+                        "not a field name and value", name);
+        return -1;
+    }
+
+    header = evpl_http_request_header_alloc(agent);
+
+    strncpy(header->name, name, sizeof(header->name) - 1);
+    strncpy(header->value, value, sizeof(header->value) - 1);
+
+    /* accounted as emitted: "<name>: <value>\r\n", using the stored
+     * (possibly truncated) field lengths */
+    line_bytes = strlen(header->name) + strlen(header->value) + 4;
+
+    if (request->send_trailer_bytes + line_bytes > agent->max_header_size) {
+        evpl_http_request_header_free(agent, header);
+        return -1;
+    }
+
+    request->send_trailer_bytes += line_bytes;
+
+    DL_APPEND(request->send_trailers, header);
+
+    return 0;
+} /* evpl_http_request_add_trailer */
+
 SYMBOL_EXPORT void
 evpl_http_request_add_datav(
     struct evpl_http_request *request,
@@ -3342,6 +3472,44 @@ evpl_http_response_header_iterate(
         callback(header->name, header->value, private_data);
     }
 } /* evpl_http_response_header_iterate */
+
+SYMBOL_EXPORT const char *
+evpl_http_request_trailer(
+    struct evpl_http_request *request,
+    const char               *name)
+{
+    struct evpl_http_request_header *header;
+
+    DL_FOREACH(request->recv_trailers, header)
+    {
+        if (strncasecmp(header->name, name, sizeof(header->name) - 1) == 0) {
+            return header->value;
+        }
+    }
+
+    return NULL;
+} /* evpl_http_request_trailer */
+
+SYMBOL_EXPORT void
+evpl_http_request_trailer_iterate(
+    struct evpl_http_request     *request,
+    evpl_http_request_header_cb_t callback,
+    void                         *private_data)
+{
+    struct evpl_http_request_header *header;
+
+    DL_FOREACH(request->recv_trailers, header)
+    {
+        callback(header->name, header->value, private_data);
+    }
+} /* evpl_http_request_trailer_iterate */
+
+SYMBOL_EXPORT enum evpl_http_protocol
+evpl_http_request_protocol(struct evpl_http_request *request)
+{
+    return request->conn->proto == EVPL_HTTP_PROTO_H2 ?
+           EVPL_HTTP_PROTOCOL_HTTP2 : EVPL_HTTP_PROTOCOL_HTTP1;
+} /* evpl_http_request_protocol */
 
 SYMBOL_EXPORT uint64_t
 evpl_http_request_get_data_avail(struct evpl_http_request *request)

--- a/src/http/http2.c
+++ b/src/http/http2.c
@@ -116,6 +116,53 @@ evpl_http2_notify(
 
 /* ----- outbound DATA: zero-copy from request->send_ring ----- */
 
+/*
+ * Submit the staged trailer section as the stream's trailing HEADERS frame.
+ * Called from inside the data provider once the body is done, which is the
+ * pattern nghttp2 documents for trailers: the provider marks its final frame
+ * NGHTTP2_DATA_FLAG_NO_END_STREAM so the END_STREAM travels on the HEADERS
+ * submitted here instead.
+ */
+static void
+evpl_http2_submit_trailers(
+    nghttp2_session          *session,
+    struct evpl_http_request *request)
+{
+    struct evpl_http_request_header *trailer;
+    nghttp2_nv                       nva[64];
+    size_t                           nvlen = 0;
+    int                              rc;
+
+    if (request->h2.trailers_submitted) {
+        return;
+    }
+
+    request->h2.trailers_submitted = 1;
+
+    DL_FOREACH(request->send_trailers, trailer)
+    {
+        evpl_http2_lower(trailer->name);
+
+        if (nvlen >= 64) {
+            break;
+        }
+
+        nva[nvlen].name     = (uint8_t *) trailer->name;
+        nva[nvlen].namelen  = strlen(trailer->name);
+        nva[nvlen].value    = (uint8_t *) trailer->value;
+        nva[nvlen].valuelen = strlen(trailer->value);
+        nva[nvlen].flags    = NGHTTP2_NV_FLAG_NONE;
+        nvlen++;
+    }
+
+    rc = nghttp2_submit_trailer(session, request->h2.stream_id, nva, nvlen);
+
+    if (rc != 0) {
+        evpl_http_error("nghttp2 submit_trailer error: %s",
+                        nghttp2_strerror(rc));
+    }
+} /* evpl_http2_submit_trailers */
+
 static ssize_t
 evpl_http2_data_read(
     nghttp2_session     *session,
@@ -135,6 +182,12 @@ evpl_http2_data_read(
     if (avail == 0) {
         if (request->h2.eof || (!chunked && request->response_left == 0)) {
             *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+
+            if (request->send_trailers) {
+                *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+                evpl_http2_submit_trailers(session, request);
+            }
+
             return 0;
         }
 
@@ -155,6 +208,11 @@ evpl_http2_data_read(
     if ((chunked && request->h2.eof && n == avail) ||
         (!chunked && n == request->response_left)) {
         *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+
+        if (request->send_trailers) {
+            *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+            evpl_http2_submit_trailers(session, request);
+        }
     }
 
     return (ssize_t) n;
@@ -264,6 +322,25 @@ evpl_http2_on_begin_headers(
         nghttp2_session_set_stream_user_data(session, frame->hd.stream_id, request);
     }
 
+    /* Decide here, once per frame, whether its fields are trailers.  An
+     * HCAT_HEADERS frame is one that opens nothing: on a server every such
+     * frame is the request's trailer section, and on a client it is the
+     * response's -- unless the response so far is an interim 1xx, in which
+     * case nghttp2 files the *final* response HEADERS in this category too,
+     * and only the status already parsed before this frame tells the two
+     * apart.  Deciding per frame matters for exactly that case: by the time
+     * the final response's regular fields arrive, its own :status has
+     * already overwritten the interim one, so a per-field test would take
+     * them for trailers. */
+    if (frame->headers.cat == NGHTTP2_HCAT_HEADERS) {
+        request = nghttp2_session_get_stream_user_data(session,
+                                                       frame->hd.stream_id);
+
+        if (request && (conn->is_server || request->status >= 200)) {
+            request->h2.in_trailers = 1;
+        }
+    }
+
     return 0;
 } /* evpl_http2_on_begin_headers */
 
@@ -327,6 +404,14 @@ evpl_http2_on_header(
     memcpy(header->value, value, n);
     header->value[n] = '\0';
 
+    /* Routing decided per frame in on_begin_headers -- see the comment
+     * there.  Trailer fields carry no framing, so the content-length
+     * bookkeeping below is for real header blocks alone. */
+    if (request->h2.in_trailers) {
+        DL_APPEND(request->recv_trailers, header);
+        return 0;
+    }
+
     if (conn->is_server) {
         DL_APPEND(request->request_headers, header);
     } else {
@@ -368,7 +453,10 @@ evpl_http2_on_frame_recv(
                                                 &request->notify_data,
                                                 conn->server->private_data);
             }
-        } else {
+        } else if (!request->h2.in_trailers) {
+            /* Not for a trailer frame: those end the response rather than
+             * announce it, and the END_STREAM they carry is what fires
+             * RECEIVE_COMPLETE below. */
             evpl_http2_notify(request, EVPL_HTTP_NOTIFY_RESPONSE_HEADERS);
         }
     }
@@ -652,9 +740,14 @@ evpl_http2_submit_response(struct evpl_http_request *request)
         nvlen++;
     }
 
+    /* Staged trailers force a data provider even on a bodiless message: the
+     * provider is where the trailing HEADERS is submitted, so without one the
+     * initial HEADERS would carry END_STREAM and the section could never
+     * follow. */
     has_body = (request->response_transfer_encoding ==
                 EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED) ||
-        request->response_left > 0;
+        request->response_left > 0 ||
+        request->send_trailers != NULL;
 
     if (has_body) {
         prd.source.ptr    = request;
@@ -752,9 +845,12 @@ evpl_http2_submit_request(struct evpl_http_request *request)
         nvlen++;
     }
 
+    /* Staged trailers force a data provider even on a bodiless message --
+     * same reasoning as in evpl_http2_submit_response. */
     has_body = (request->response_transfer_encoding ==
                 EVPL_HTTP_REQUEST_TRANSFER_ENCODING_CHUNKED) ||
-        request->response_left > 0;
+        request->response_left > 0 ||
+        request->send_trailers != NULL;
 
     if (has_body) {
         prd.source.ptr    = request;
@@ -780,6 +876,15 @@ void
 evpl_http2_dispatch(struct evpl_http_request *request)
 {
     struct evpl_http_conn *conn = request->conn;
+
+    /* A body finished with add_datav(NULL, 0) before the connection had
+     * settled on h2 recorded that only in the protocol-independent flag: the
+     * h2 branch of add_datav was not taken because conn->proto was still
+     * UNKNOWN.  Carry it over now, or the data provider waits forever for an
+     * end it was already given. */
+    if (request->request_flags & EVPL_HTTP_REQUEST_RESPONSE_FINISHED) {
+        request->h2.eof = 1;
+    }
 
     if (conn->is_server) {
         evpl_http2_submit_response(request);

--- a/src/http/http_internal.h
+++ b/src/http/http_internal.h
@@ -110,10 +110,12 @@ struct evpl_http_request_header {
  * when request->conn->proto == EVPL_HTTP_PROTO_H2. */
 struct evpl_http2_stream {
     int32_t stream_id;
-    int     headers_submitted;  /* nghttp2_submit_response/request already done */
-    int     deferred;           /* data provider returned NGHTTP2_ERR_DEFERRED  */
-    int     want_data;          /* provider needs more body; fire WANT_DATA      */
-    int     eof;                /* outgoing body finished (add_datav(NULL,0))    */
+    int     headers_submitted;   /* nghttp2_submit_response/request already done */
+    int     deferred;            /* data provider returned NGHTTP2_ERR_DEFERRED  */
+    int     want_data;           /* provider needs more body; fire WANT_DATA      */
+    int     eof;                 /* outgoing body finished (add_datav(NULL,0))    */
+    int     trailers_submitted;  /* nghttp2_submit_trailer already done          */
+    int     in_trailers;         /* inbound HEADERS now carry trailer fields     */
 };
 
 struct evpl_http_request {
@@ -141,11 +143,24 @@ struct evpl_http_request {
      * request line at create time (client) or 0 (server response) and
      * grows as headers are added. */
     unsigned int                             header_bytes;
+    /* Wire bytes of each trailer section, counted like header_bytes but
+     * against their own limits: the outbound section is staged while
+     * header_bytes may already be accounting the outbound header block, and
+     * the inbound one arrives after that repurposing, so neither can share
+     * the counter. */
+    unsigned int                             send_trailer_bytes;
+    unsigned int                             recv_trailer_bytes;
     struct evpl_http_conn                   *conn;
     struct evpl_iovec_ring                   send_ring;
     struct evpl_iovec_ring                   recv_ring;
     struct evpl_http_request_header         *request_headers;
     struct evpl_http_request_header         *response_headers;
+    /* Trailer fields by direction: send_trailers is the outbound message's
+     * section (the response's on a server, the request's on a client), staged
+     * by evpl_http_request_add_trailer; recv_trailers is the peer's, read
+     * back through evpl_http_request_trailer once receive completes. */
+    struct evpl_http_request_header         *send_trailers;
+    struct evpl_http_request_header         *recv_trailers;
     struct evpl_http2_stream                 h2;
     struct evpl_http_request                *prev;
     struct evpl_http_request                *next;
@@ -269,10 +284,14 @@ evpl_http_request_alloc(struct evpl_http_agent *agent)
     request->status                     = 0;
     request->uri_len                    = 0;
     request->header_bytes               = 0;
+    request->send_trailer_bytes         = 0;
+    request->recv_trailer_bytes         = 0;
     request->notify_callback            = NULL;
     request->notify_data                = NULL;
     request->request_headers            = NULL;
     request->response_headers           = NULL;
+    request->send_trailers              = NULL;
+    request->recv_trailers              = NULL;
     memset(&request->h2, 0, sizeof(request->h2));
     return request;
 } /* evpl_http_request_alloc */
@@ -293,6 +312,18 @@ evpl_http_request_free(
     while (request->response_headers) {
         header = request->response_headers;
         DL_DELETE(request->response_headers, header);
+        evpl_http_request_header_free(agent, header);
+    }
+
+    while (request->send_trailers) {
+        header = request->send_trailers;
+        DL_DELETE(request->send_trailers, header);
+        evpl_http_request_header_free(agent, header);
+    }
+
+    while (request->recv_trailers) {
+        header = request->recv_trailers;
+        DL_DELETE(request->recv_trailers, header);
         evpl_http_request_header_free(agent, header);
     }
 

--- a/src/http/tests/CMakeLists.txt
+++ b/src/http/tests/CMakeLists.txt
@@ -18,6 +18,11 @@ target_link_libraries(http_client evpl_http)
 unit_test(http max_headers http_max_headers.c)
 target_link_libraries(http_max_headers evpl_http)
 
+# Trailer fields in both directions over HTTP/1.1 chunked framing (the h2
+# variant of the same file is registered below with the other nghttp2 tests)
+unit_test(http trailers http_trailers.c)
+target_link_libraries(http_trailers evpl_http)
+
 # ---------------------------------------------------------------------------
 # Model-based HTTP/1.x conformance test
 #
@@ -105,6 +110,10 @@ if (HAVE_NGHTTP2)
 
     unit_test(http h2_client_tls http2_client_tls.c)
     target_link_libraries(http_h2_client_tls evpl_http)
+
+    # the http_trailers exchanges over h2c: trailing HEADERS frames
+    unit_test(http h2_trailers http2_trailers.c)
+    target_link_libraries(http_h2_trailers evpl_http)
 
     # libevpl HTTP/2 server driven by libcurl (reference client)
     unit_test(http h2_basic http2_basic.c)

--- a/src/http/tests/http2_trailers.c
+++ b/src/http/tests/http2_trailers.c
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * The http_trailers exchanges over HTTP/2 (h2c prior-knowledge), where the
+ * trailer section is a trailing HEADERS frame -- including on the
+ * Content-Length exchange that HTTP/1.x must drop it from.
+ */
+
+#define TEST_VERSION EVPL_HTTP_VERSION_HTTP2
+#define TEST_PORT    8086
+
+#include "http_trailers.c"

--- a/src/http/tests/http_trailers.c
+++ b/src/http/tests/http_trailers.c
@@ -1,0 +1,491 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Trailer fields in both directions, over the evpl client <-> evpl server
+ * harness of http1_client:
+ *
+ *   - a chunked POST carrying request trailers, answered by a chunked
+ *     response carrying response trailers, each end reading the other's
+ *     section back through evpl_http_request_trailer after receive completes;
+ *   - a bodiless chunked response that is nothing but trailers;
+ *   - a Content-Length response with trailers staged, which HTTP/1.x must
+ *     drop (the coding has no place for them) and HTTP/2 must deliver --
+ *     the one place the two protocols are documented to diverge.
+ *
+ * The requests run in order on one connection, so the HTTP/1.x variant also
+ * proves the parser leaves a clean stream behind a trailer section on a
+ * kept-alive connection.  http2_trailers runs the same file over h2c.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+
+#ifndef TEST_VERSION
+#define TEST_VERSION EVPL_HTTP_VERSION_HTTP1
+#endif /* ifndef TEST_VERSION */
+
+#ifndef TEST_PORT
+#define TEST_PORT    8085
+#endif /* ifndef TEST_PORT */
+
+static const char response_body[] = "hello world";
+
+/* ------------------------------------------------------------------ server */
+
+struct test_server {
+    pthread_t            thread;
+    volatile int         run;
+    struct evpl_doorbell doorbell;
+};
+
+static void
+server_wake(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+} /* server_wake */
+
+static void
+server_check_request_trailers(struct evpl_http_request *request)
+{
+    const char *value = evpl_http_request_trailer(request, "X-Req-Trailer");
+
+    if (!value || strcmp(value, "reqval") != 0) {
+        fprintf(stderr, "server: request trailer X-Req-Trailer '%s'\n",
+                value ? value : "(missing)");
+        exit(1);
+    }
+
+    value = evpl_http_request_trailer(request, "X-Req-Sum");
+
+    if (!value || strcmp(value, "42") != 0) {
+        fprintf(stderr, "server: request trailer X-Req-Sum '%s'\n",
+                value ? value : "(missing)");
+        exit(1);
+    }
+} /* server_check_request_trailers */
+
+static void
+server_notify(
+    struct evpl                *evpl,
+    struct evpl_http_agent     *agent,
+    struct evpl_http_request   *request,
+    enum evpl_http_notify_type  notify_type,
+    enum evpl_http_request_type request_type,
+    const char                 *uri,
+    void                       *notify_data,
+    void                       *private_data)
+{
+    struct evpl_iovec iov;
+
+    switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
+
+            if (evpl_http_request_protocol(request) !=
+                (TEST_VERSION == EVPL_HTTP_VERSION_HTTP2 ?
+                 EVPL_HTTP_PROTOCOL_HTTP2 : EVPL_HTTP_PROTOCOL_HTTP1)) {
+                fprintf(stderr, "server: unexpected request protocol\n");
+                exit(1);
+            }
+
+            if (strcmp(uri, "/echo") == 0) {
+                /* the chunked POST carried trailers; read them back */
+                server_check_request_trailers(request);
+
+                evpl_http_server_set_response_chunked(request);
+                evpl_http_server_dispatch_default(request, 200);
+            } else if (strcmp(uri, "/trailers-only") == 0) {
+                /* a response that is nothing but its trailer section */
+                evpl_http_server_set_response_chunked(request);
+
+                if (evpl_http_request_add_trailer(request, "X-Only", "solo")) {
+                    fprintf(stderr, "server: add_trailer refused\n");
+                    exit(1);
+                }
+
+                evpl_http_request_add_datav(request, NULL, 0);
+                evpl_http_server_dispatch_default(request, 200);
+            } else {
+                /* /length: fixed Content-Length with trailers staged */
+                evpl_iovec_alloc(evpl, sizeof(response_body) - 1, 0, 1, 0, &iov);
+                memcpy(iov.data, response_body, sizeof(response_body) - 1);
+                iov.length = sizeof(response_body) - 1;
+
+                evpl_http_server_set_response_length(request,
+                                                     sizeof(response_body) - 1);
+
+                if (evpl_http_request_add_trailer(request, "X-Length", "framed")) {
+                    fprintf(stderr, "server: add_trailer refused\n");
+                    exit(1);
+                }
+
+                evpl_http_request_add_datav(request, &iov, 1);
+                evpl_http_server_dispatch_default(request, 200);
+            }
+            break;
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+            /* the /echo chunked response: stream the body, stage the
+             * trailers, then finish -- the section must be complete before
+             * the end of the content is signalled */
+            evpl_iovec_alloc(evpl, sizeof(response_body) - 1, 0, 1, 0, &iov);
+            memcpy(iov.data, response_body, sizeof(response_body) - 1);
+            iov.length = sizeof(response_body) - 1;
+            evpl_http_request_add_datav(request, &iov, 1);
+
+            if (evpl_http_request_add_trailer(request, "X-Resp-Trailer", "respval")) {
+                fprintf(stderr, "server: add_trailer refused\n");
+                exit(1);
+            }
+
+            evpl_http_request_add_datav(request, NULL, 0);
+
+            /* too late now: the message is finished */
+            if (evpl_http_request_add_trailer(request, "X-Late", "no") == 0) {
+                fprintf(stderr, "server: trailer accepted after finish\n");
+                exit(1);
+            }
+            break;
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+        case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
+            break;
+        case EVPL_HTTP_NOTIFY_FAILED:
+            /* A clean exchange: nothing here should ever be abandoned. */
+            fprintf(stderr, "request failed unexpectedly (%d)\n",
+                    evpl_http_request_status(request));
+            exit(1);
+    } /* switch */
+} /* server_notify */
+
+static void
+server_dispatch(
+    struct evpl                 *evpl,
+    struct evpl_http_agent      *agent,
+    struct evpl_http_request    *request,
+    evpl_http_notify_callback_t *notify_callback,
+    void                       **notify_data,
+    void                        *private_data)
+{
+    *notify_callback = server_notify;
+    *notify_data     = NULL;
+} /* server_dispatch */
+
+static void *
+server_function(void *ptr)
+{
+    struct test_server      *server_ctx = ptr;
+    struct evpl_http_server *server;
+    struct evpl             *evpl;
+    struct evpl_endpoint    *endpoint;
+    struct evpl_listener    *listener;
+    struct evpl_http_agent  *agent;
+
+    evpl = evpl_create(NULL);
+
+    evpl_add_doorbell(evpl, &server_ctx->doorbell, server_wake);
+
+    agent = evpl_http_init(evpl);
+
+    endpoint = evpl_endpoint_create("0.0.0.0", TEST_PORT);
+
+    listener = evpl_listener_create();
+
+    server = evpl_http_attach(agent, listener, server_dispatch, NULL);
+
+    if (evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint)) {
+        fprintf(stderr, "failed to listen\n");
+        exit(1);
+    }
+
+    __sync_synchronize();
+
+    server_ctx->run = 1;
+
+    while (server_ctx->run) {
+        evpl_continue(evpl);
+    }
+
+    evpl_http_server_destroy(agent, server);
+    evpl_http_destroy(agent);
+
+    evpl_listener_destroy(listener);
+    evpl_destroy(evpl);
+
+    return NULL;
+} /* server_function */
+
+/* ------------------------------------------------------------------ client */
+
+/* what one exchange expects of the response's trailer section */
+struct trailer_expect {
+    const char *name;   /* NULL: expect no trailers at all */
+    const char *value;
+};
+
+struct req_ctx {
+    int                          done;
+    int                          status;
+    int                          body_len;
+    char                         body[256];
+    const struct trailer_expect *expect;
+};
+
+static void
+client_drain(
+    struct evpl              *evpl,
+    struct evpl_http_request *request,
+    struct req_ctx           *rc)
+{
+    struct evpl_iovec iov[8];
+    uint64_t          avail;
+    int               niov, i;
+
+    avail = evpl_http_request_get_data_avail(request);
+
+    while (avail > 0) {
+        niov = evpl_http_request_get_datav(evpl, request, iov, (int) avail);
+
+        for (i = 0; i < niov; i++) {
+            memcpy(rc->body + rc->body_len, iov[i].data, iov[i].length);
+            rc->body_len += iov[i].length;
+            evpl_iovec_release(evpl, &iov[i]);
+        }
+
+        avail = evpl_http_request_get_data_avail(request);
+    }
+} /* client_drain */
+
+static void
+count_trailer(
+    const char *name,
+    const char *value,
+    void       *private_data)
+{
+    int *count = private_data;
+
+    (*count)++;
+} /* count_trailer */
+
+static void
+client_notify(
+    struct evpl                *evpl,
+    struct evpl_http_agent     *agent,
+    struct evpl_http_request   *request,
+    enum evpl_http_notify_type  notify_type,
+    enum evpl_http_request_type request_type,
+    const char                 *uri,
+    void                       *notify_data,
+    void                       *private_data)
+{
+    struct req_ctx *rc = notify_data;
+
+    switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+            rc->status = evpl_http_request_status(request);
+
+            /* nothing has finished arriving yet: the section must be empty */
+            if (evpl_http_request_trailer(request, "X-Resp-Trailer") ||
+                evpl_http_request_trailer(request, "X-Only")) {
+                fprintf(stderr, "client: trailer visible before complete\n");
+                exit(1);
+            }
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+            client_drain(evpl, request, rc);
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
+        {
+            const struct trailer_expect *expect = rc->expect;
+            const char                  *value;
+            int                          count = 0;
+
+            client_drain(evpl, request, rc);
+
+            evpl_http_request_trailer_iterate(request, count_trailer, &count);
+
+            if (expect->name) {
+                value = evpl_http_request_trailer(request, expect->name);
+
+                if (!value || strcmp(value, expect->value) != 0) {
+                    fprintf(stderr, "client: %s trailer %s = '%s', wanted '%s'\n",
+                            uri, expect->name,
+                            value ? value : "(missing)", expect->value);
+                    exit(1);
+                }
+
+                if (count != 1) {
+                    fprintf(stderr, "client: %s carried %d trailers, wanted 1\n",
+                            uri, count);
+                    exit(1);
+                }
+            } else if (count != 0) {
+                fprintf(stderr, "client: %s carried %d trailers, wanted none\n",
+                        uri, count);
+                exit(1);
+            }
+
+            rc->done = 1;
+            break;
+        }
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+        case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
+            break;
+        case EVPL_HTTP_NOTIFY_FAILED:
+            /* A clean exchange: nothing here should ever be abandoned. */
+            fprintf(stderr, "response failed unexpectedly (%d)\n",
+                    evpl_http_request_status(request));
+            exit(1);
+    } /* switch */
+} /* client_notify */
+
+static int
+do_request(
+    struct evpl                 *evpl,
+    struct evpl_http_conn       *conn,
+    const char                  *url,
+    int                          chunked_with_trailers,
+    int                          expect_body,
+    const struct trailer_expect *expect)
+{
+    struct evpl_http_request *request;
+    struct req_ctx            rc;
+    struct evpl_iovec         iov;
+    static const char         request_body[] = "streamed";
+
+    memset(&rc, 0, sizeof(rc));
+    rc.expect = expect;
+
+    request = evpl_http_request_create(conn,
+                                       chunked_with_trailers ?
+                                       EVPL_HTTP_REQUEST_TYPE_POST :
+                                       EVPL_HTTP_REQUEST_TYPE_GET, url);
+
+    evpl_http_request_add_header(request, "Host", "localhost");
+
+    if (chunked_with_trailers) {
+        evpl_http_client_set_request_chunked(request);
+
+        evpl_iovec_alloc(evpl, sizeof(request_body) - 1, 0, 1, 0, &iov);
+        memcpy(iov.data, request_body, sizeof(request_body) - 1);
+        iov.length = sizeof(request_body) - 1;
+        evpl_http_request_add_datav(request, &iov, 1);
+
+        if (evpl_http_request_add_trailer(request, "X-Req-Trailer", "reqval") ||
+            evpl_http_request_add_trailer(request, "X-Req-Sum", "42")) {
+            fprintf(stderr, "client: add_trailer refused\n");
+            return 1;
+        }
+
+        /* the grammar refusals apply to trailers as they do to headers */
+        if (evpl_http_request_add_trailer(request, "bad name", "x") == 0 ||
+            evpl_http_request_add_trailer(request, "X-Evil", "a\r\nb") == 0) {
+            fprintf(stderr, "client: malformed trailer accepted\n");
+            return 1;
+        }
+
+        evpl_http_request_add_datav(request, NULL, 0);
+    } else {
+        evpl_http_client_set_request_length(request, 0);
+    }
+
+    evpl_http_request_dispatch(request, client_notify, &rc);
+
+    while (!rc.done) {
+        evpl_continue(evpl);
+    }
+
+    if (rc.status != 200) {
+        fprintf(stderr, "%s: bad status %d\n", url, rc.status);
+        return 1;
+    }
+
+    if (expect_body) {
+        if (rc.body_len != (int) (sizeof(response_body) - 1) ||
+            memcmp(rc.body, response_body, rc.body_len) != 0) {
+            fprintf(stderr, "%s: bad body '%.*s' (%d bytes)\n",
+                    url, rc.body_len, rc.body, rc.body_len);
+            return 1;
+        }
+    } else if (rc.body_len != 0) {
+        fprintf(stderr, "%s: unexpected body (%d bytes)\n", url, rc.body_len);
+        return 1;
+    }
+
+    fprintf(stderr, "%s: ok (status %d, %d bytes)\n", url, rc.status, rc.body_len);
+
+    return 0;
+} /* do_request */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct test_server         server;
+    struct evpl               *evpl;
+    struct evpl_http_agent    *agent;
+    struct evpl_endpoint      *endpoint;
+    struct evpl_http_conn     *conn;
+    struct evpl_global_config *config;
+    struct trailer_expect      expect_echo   = { "X-Resp-Trailer", "respval" };
+    struct trailer_expect      expect_only   = { "X-Only", "solo" };
+    struct trailer_expect      expect_length = { "X-Length", "framed" };
+    struct trailer_expect      expect_none   = { NULL, NULL };
+    int                        rc            = 0;
+
+    config = evpl_global_config_init();
+    evpl_init(config);
+
+    server.run = 0;
+
+    pthread_create(&server.thread, NULL, server_function, &server);
+
+    while (!server.run) {
+        __sync_synchronize();
+    }
+
+    evpl = evpl_create(NULL);
+
+    agent = evpl_http_init(evpl);
+
+    endpoint = evpl_endpoint_create("127.0.0.1", TEST_PORT);
+
+    /* All three exchanges share one connection: the HTTP/1.x variant then
+     * also proves the stream is clean behind each trailer section. */
+    conn = evpl_http_client_connect(agent, EVPL_STREAM_SOCKET_TCP, endpoint,
+                                    TEST_VERSION, NULL);
+
+    rc |= do_request(evpl, conn, "/echo", 1, 1, &expect_echo);
+    rc |= do_request(evpl, conn, "/trailers-only", 0, 0, &expect_only);
+
+    /* HTTP/1.x cannot carry trailers on a Content-Length message; HTTP/2
+     * carries them on any */
+    rc |= do_request(evpl, conn, "/length", 0, 1,
+                     TEST_VERSION == EVPL_HTTP_VERSION_HTTP2 ?
+                     &expect_length : &expect_none);
+
+    evpl_http_client_close(agent, conn);
+
+    evpl_http_destroy(agent);
+    evpl_destroy(evpl);
+
+    server.run = 0;
+    __sync_synchronize();
+    evpl_ring_doorbell(&server.doorbell);
+    pthread_join(server.thread, NULL);
+
+    if (rc == 0) {
+        fprintf(stderr, "all requests ok\n");
+    }
+
+    return rc;
+} /* main */


### PR DESCRIPTION
Trailer fields over both protocols and in both directions: a server's response trailers, a client's request trailers, and read-back of the peer's section on the receiving side. First of three HTTP-layer PRs preparing the transport for a gRPC layer (whose `grpc-status`/`grpc-message` travel as HTTP/2 trailers), though nothing here is gRPC-specific.

**API**: `evpl_http_request_add_trailer` stages a field on the outbound message under the same grammar and accounting rules as `add_header`, and must be called before the end of the content is signalled. `evpl_http_request_trailer` / `_trailer_iterate` read the peer's section once `RECEIVE_COMPLETE` has fired. `evpl_http_request_protocol()` reports which protocol carries a request, for applications that exist only over one of them.

**HTTP/2**: the trailing HEADERS frame, produced the way nghttp2 documents — the data provider sets `NGHTTP2_DATA_FLAG_NO_END_STREAM` on its final frame and submits the trailer from inside the read callback, so END_STREAM travels on the trailer. A bodiless message with trailers staged gets a data provider solely so that submission point exists. Inbound frames are classified once per frame in `on_begin_headers`; the interim-1xx shape (nghttp2 files a final response after a 1xx in `HCAT_HEADERS` too) is what makes a per-field test wrong.

**HTTP/1.x**: the chunked coding's trailer section, emitted between the last-chunk and the final CRLF, and captured by the parse loop that previously consumed and discarded the fields "for want of an API to surface them through". A length-framed or close-delimited message has no place for a trailer section; staged trailers are dropped there, as documented.

The new tests surfaced two latent HTTP/2 defects, fixed here:

- a body finished with `add_datav(NULL, 0)` **before the connection had settled on h2** recorded the EOF only in the protocol-independent flag, so the data provider deferred forever waiting for an end it had already been given. Upstream tests never hit this because no existing test dispatches a chunked request first on a fresh connection.
- the client fired a **second RESPONSE_HEADERS notification** for the trailer HEADERS frame, since any HEADERS with END_HEADERS triggered it.

Tests: `http_trailers` (h1) and `http2_trailers` (h2c) share one source — a chunked POST with request trailers answered by a chunked response with response trailers, a trailers-only bodiless response, and the length-framed exchange where the two protocols are documented to diverge. All three run on one connection, so the h1 variant also proves the stream is clean behind a trailer section on a kept-alive connection.