### PR TITLE
http: complete every abandoned request, and add evpl_http_request_cancel

### DIFF
--- a/include/evpl/evpl_http.h
+++ b/include/evpl/evpl_http.h
@@ -35,7 +35,9 @@ enum evpl_http_notify_type {
      *
      * Every request still outstanding on a connection is completed with this
      * when the connection goes down, so that a caller is never left waiting on
-     * a completion that can no longer happen.  Client-side it also covers a
+     * a completion that can no longer happen.  On HTTP/2 it also completes a
+     * request whose stream ended without it (reset by the peer, or refused by
+     * a GOAWAY) while the connection lives on, and client-side it covers a
      * response the library could not parse.
      *
      * Exactly one of RECEIVE_COMPLETE (client), RESPONSE_COMPLETE (server) or
@@ -68,6 +70,15 @@ enum evpl_http_notify_type {
  * peer will produce the same unparseable response.
  */
 #define EVPL_HTTP_ERROR_BAD_RESPONSE  (-2)
+
+/*
+ * HTTP/2 only: the request's stream ended without the request completing --
+ * the peer reset it (a client cancelled, a server refused), or the stream was
+ * refused by a GOAWAY -- while the connection itself remains usable.  Distinct
+ * from CONN_LOST because nothing else on the connection is affected: other
+ * requests proceed, and new ones may be dispatched.
+ */
+#define EVPL_HTTP_ERROR_STREAM_RESET  (-3)
 
 /* Protocol version selection for a client connection. */
 enum evpl_http_version {
@@ -254,6 +265,29 @@ evpl_http_request_add_datav(
     struct evpl_http_request *request,
     struct evpl_iovec        *iov,
     int                       niov);
+
+/*
+ * Abandon a request.  The caller is declaring it is done with the exchange:
+ * the request pointer is invalid once this returns, and no notification of
+ * any kind follows -- not even the EVPL_HTTP_NOTIFY_FAILED the teardown
+ * paths otherwise owe an abandoned request, since the caller abandoned it
+ * itself.
+ *
+ * On HTTP/2 the request's stream is reset (RST_STREAM with CANCEL) and the
+ * connection is untouched: other requests in flight proceed, and new ones
+ * may be dispatched.  The peer sees the reset and completes its side of the
+ * exchange with EVPL_HTTP_ERROR_STREAM_RESET.
+ *
+ * HTTP/1.x has no way to abandon one exchange within a connection -- the
+ * only wire action that can end a message early is ending the connection --
+ * so there the connection closes, and every other request outstanding on it
+ * is completed with EVPL_HTTP_NOTIFY_FAILED exactly as for a connection the
+ * peer closed.  A client request that was created but never dispatched is
+ * simply released, on either protocol.
+ */
+void
+evpl_http_request_cancel(
+    struct evpl_http_request *request);
 
 void
 evpl_http_server_set_response_length(

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -2298,10 +2298,15 @@ evpl_http_event(
              */
             DL_FOREACH_SAFE(http_conn->pending_requests, request, next)
             {
-                if (request->request_state ==
+                if (!http_conn->is_server &&
+                    request->request_state ==
                     EVPL_HTTP_REQUEST_STATE_COMPLETE) {
                     /* The close-delimited case just above: answered, not
-                     * abandoned. */
+                     * abandoned.  Client side only -- on a server, COMPLETE
+                     * says the request message arrived, not that the
+                     * exchange finished, and a request still on this list
+                     * has a response unfinished.  Its application is holding
+                     * it and has to hear that it is over. */
                     continue;
                 }
 
@@ -3250,6 +3255,43 @@ evpl_http_request_add_datav(
         evpl_defer(request->conn->agent->evpl, &request->conn->flush);
     }
 } /* evpl_http_request_add_datav */
+
+SYMBOL_EXPORT void
+evpl_http_request_cancel(struct evpl_http_request *request)
+{
+    struct evpl_http_conn  *conn  = request->conn;
+    struct evpl_http_agent *agent = conn->agent;
+
+    /* No notification of any kind follows a cancel: the caller has declared
+     * it is done with the request, so even the FAILED the teardown paths owe
+     * an abandoned request is not owed here. */
+    request->notify_callback = NULL;
+
+    /* A client request that was never dispatched is on no list and has no
+     * stream -- nothing on the wire or in the connection refers to it, so it
+     * is simply released. */
+    if (!conn->is_server &&
+        !(request->request_flags & EVPL_HTTP_REQUEST_RESPONSE_READY)) {
+        evpl_http_request_free(agent, request);
+        return;
+    }
+
+#ifdef HAVE_NGHTTP2
+    if (conn->proto == EVPL_HTTP_PROTO_H2) {
+        evpl_http2_cancel(request);
+        return;
+    }
+#endif /* ifdef HAVE_NGHTTP2 */
+
+    /* HTTP/1.x (or a connection whose protocol is not yet decided): the only
+     * wire action that ends one exchange early is ending the connection.
+     * The teardown that follows frees this request -- its callback is
+     * already cleared -- and completes every other outstanding request with
+     * FAILED, exactly as for a connection the peer closed. */
+    if (conn->bind) {
+        evpl_close(agent->evpl, conn->bind);
+    }
+} /* evpl_http_request_cancel */
 
 SYMBOL_EXPORT void
 evpl_http_server_set_response_length(

--- a/src/http/http2.c
+++ b/src/http/http2.c
@@ -464,6 +464,14 @@ evpl_http2_on_frame_recv(
     if ((frame->hd.type == NGHTTP2_HEADERS || frame->hd.type == NGHTTP2_DATA) &&
         (frame->hd.flags & NGHTTP2_FLAG_END_STREAM)) {
         request->request_state = EVPL_HTTP_REQUEST_STATE_COMPLETE;
+
+        /* For a client this is the terminal notification -- the response has
+         * arrived, nothing more is owed.  A server's request still owes its
+         * response, so its terminal point is RESPONSE_COMPLETE instead. */
+        if (!conn->is_server) {
+            request->h2.complete = 1;
+        }
+
         evpl_http2_notify(request, EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE);
     }
 
@@ -521,7 +529,12 @@ evpl_http2_on_frame_send(
 
     if (request) {
         /* The local message (response on the server, request on the client) has
-         * been fully transmitted. */
+         * been fully transmitted.  For a server that is the terminal
+         * notification -- the exchange it owed is done. */
+        if (((struct evpl_http_conn *) user)->is_server) {
+            request->h2.complete = 1;
+        }
+
         evpl_http2_notify(request, EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE);
     }
 
@@ -547,6 +560,18 @@ evpl_http2_on_stream_close(
     nghttp2_session_set_stream_user_data(session, stream_id, NULL);
 
     DL_DELETE(conn->h2->streams, request);
+
+    /* A stream that closed before the request's terminal notification fired
+     * ends an exchange nobody finished: reset by the peer, refused by a
+     * GOAWAY, or torn down by a protocol error.  The application holding the
+     * request has to hear that it is over before the free below -- a request
+     * freed behind its back leaves it waiting on a completion that can no
+     * longer happen, and still holding whatever it attached.  The connection
+     * itself lives on, which is what STREAM_RESET says. */
+    if (!request->h2.complete && request->notify_callback) {
+        request->status = EVPL_HTTP_ERROR_STREAM_RESET;
+        evpl_http2_notify(request, EVPL_HTTP_NOTIFY_FAILED);
+    }
 
     evpl_http_request_free(conn->agent, request);
 
@@ -601,9 +626,22 @@ evpl_http2_conn_destroy(struct evpl_http_conn *conn)
         return;
     }
 
+    /* The connection is going down with these exchanges unfinished: no
+     * response can arrive for a client's streams now, and a server has
+     * nowhere left to send the ones it was answering.  Tell each caller so
+     * before the free, exactly as the HTTP/1.x teardown does for its lists --
+     * nghttp2_session_del below runs no stream-close callbacks, so this walk
+     * is the only place these applications can hear it. */
     while (h2->streams) {
         request = h2->streams;
         DL_DELETE(h2->streams, request);
+
+        if (!request->h2.complete && request->notify_callback) {
+            request->status = conn->error ? conn->error :
+                EVPL_HTTP_ERROR_CONN_LOST;
+            evpl_http2_notify(request, EVPL_HTTP_NOTIFY_FAILED);
+        }
+
         evpl_http_request_free(conn->agent, request);
     }
 
@@ -910,3 +948,17 @@ evpl_http2_submit(struct evpl_http_request *request)
 
     evpl_defer(conn->agent->evpl, &conn->flush);
 } /* evpl_http2_submit */
+
+void
+evpl_http2_cancel(struct evpl_http_request *request)
+{
+    struct evpl_http_conn *conn = request->conn;
+
+    nghttp2_submit_rst_stream(conn->h2->session, NGHTTP2_FLAG_NONE,
+                              request->h2.stream_id, NGHTTP2_CANCEL);
+
+    /* The request is freed when nghttp2 processes the reset and closes the
+     * stream (evpl_http2_on_stream_close); its notify callback is already
+     * cleared, so nothing is delivered from there. */
+    evpl_defer(conn->agent->evpl, &conn->flush);
+} /* evpl_http2_cancel */

--- a/src/http/http_internal.h
+++ b/src/http/http_internal.h
@@ -116,6 +116,12 @@ struct evpl_http2_stream {
     int     eof;                 /* outgoing body finished (add_datav(NULL,0))    */
     int     trailers_submitted;  /* nghttp2_submit_trailer already done          */
     int     in_trailers;         /* inbound HEADERS now carry trailer fields     */
+    /* The request's terminal success notification has fired: RECEIVE_COMPLETE
+     * on a client (the response arrived), RESPONSE_COMPLETE on a server (the
+     * response was sent).  A stream that closes before this owes its
+     * application EVPL_HTTP_NOTIFY_FAILED instead -- exactly one of the two
+     * reaches every request. */
+    int     complete;
 };
 
 struct evpl_http_request {
@@ -446,6 +452,13 @@ evpl_http2_dispatch(
  * body data via evpl_http_request_add_datav on an h2 connection. */
 void
 evpl_http2_submit(
+    struct evpl_http_request *request);
+
+/* Reset the request's stream (RST_STREAM with CANCEL) for
+ * evpl_http_request_cancel.  The caller has already cleared the notify
+ * callback; the request is freed when the stream close is processed. */
+void
+evpl_http2_cancel(
     struct evpl_http_request *request);
 
 #endif /* HAVE_NGHTTP2 */

--- a/src/http/tests/CMakeLists.txt
+++ b/src/http/tests/CMakeLists.txt
@@ -115,6 +115,11 @@ if (HAVE_NGHTTP2)
     unit_test(http h2_trailers http2_trailers.c)
     target_link_libraries(http_h2_trailers evpl_http)
 
+    # the abort lifecycle: cancel and connection loss deliver FAILED to
+    # whichever side was left holding an unfinished exchange
+    unit_test(http h2_abort http2_abort.c)
+    target_link_libraries(http_h2_abort evpl_http)
+
     # libevpl HTTP/2 server driven by libcurl (reference client)
     unit_test(http h2_basic http2_basic.c)
     target_link_libraries(http_h2_basic evpl_http curl)

--- a/src/http/tests/http2_abort.c
+++ b/src/http/tests/http2_abort.c
@@ -1,0 +1,426 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * The abort lifecycle: every request an application is holding hears exactly
+ * one terminal notification, however its exchange ends.
+ *
+ *   1. an HTTP/2 client cancels mid-stream: the server's request completes
+ *      with FAILED/STREAM_RESET, and the connection survives -- the next
+ *      request on it succeeds;
+ *   2. an HTTP/2 client closes its connection with a stream in flight: both
+ *      ends complete the request with FAILED/CONN_LOST;
+ *   3. an HTTP/1.x client cancels mid-stream: the only abort HTTP/1.x has is
+ *      the connection, so the server sees a disconnect and completes its
+ *      half-answered request with FAILED/CONN_LOST.
+ *
+ * The server answers /stream with a chunked response that sends one chunk and
+ * then stalls without ever finishing, so every abort lands mid-exchange by
+ * construction -- no timing involved.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+
+#define TEST_PORT 8087
+
+static const char           response_body[] = "hello world";
+
+/* terminal outcomes observed by the server thread, read by the main thread.
+ * The doorbell wakes the client loop when a count changes -- without it the
+ * client would sit in its event wait with nothing left to wake it. */
+static volatile int         server_reset_failures = 0; /* FAILED with STREAM_RESET */
+static volatile int         server_lost_failures  = 0; /* FAILED with CONN_LOST    */
+static struct evpl_doorbell count_doorbell;
+
+/* ------------------------------------------------------------------ server */
+
+struct test_server {
+    pthread_t            thread;
+    volatile int         run;
+    struct evpl_doorbell doorbell;
+};
+
+static void
+server_wake(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+} /* server_wake */
+
+static void
+server_notify(
+    struct evpl                *evpl,
+    struct evpl_http_agent     *agent,
+    struct evpl_http_request   *request,
+    enum evpl_http_notify_type  notify_type,
+    enum evpl_http_request_type request_type,
+    const char                 *uri,
+    void                       *notify_data,
+    void                       *private_data)
+{
+    struct evpl_iovec iov;
+    int               status;
+
+    /* Each /stream response sends exactly one chunk and then stalls (the
+     * cases run one /stream exchange at a time).  Without the stall the
+     * server would generate chunks unboundedly fast on HTTP/1.x, where no
+     * flow control paces WANT_DATA. */
+    static int        stream_chunk_sent;
+
+    switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
+            if (strcmp(uri, "/stream") == 0) {
+                stream_chunk_sent = 0;
+                evpl_http_server_set_response_chunked(request);
+                evpl_http_server_dispatch_default(request, 200);
+            } else {
+                evpl_iovec_alloc(evpl, sizeof(response_body) - 1, 0, 1, 0, &iov);
+                memcpy(iov.data, response_body, sizeof(response_body) - 1);
+                iov.length = sizeof(response_body) - 1;
+                evpl_http_server_set_response_length(request,
+                                                     sizeof(response_body) - 1);
+                evpl_http_request_add_datav(request, &iov, 1);
+                evpl_http_server_dispatch_default(request, 200);
+            }
+            break;
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+            /* /stream: the one chunk, then nothing -- the exchange can only
+             * end by being aborted */
+            if (stream_chunk_sent) {
+                break;
+            }
+            stream_chunk_sent = 1;
+
+            evpl_iovec_alloc(evpl, sizeof(response_body) - 1, 0, 1, 0, &iov);
+            memcpy(iov.data, response_body, sizeof(response_body) - 1);
+            iov.length = sizeof(response_body) - 1;
+            evpl_http_request_add_datav(request, &iov, 1);
+            break;
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+        case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
+            break;
+        case EVPL_HTTP_NOTIFY_FAILED:
+            /* the aborted /stream exchanges land here; anything else is a
+             * broken test */
+            if (strcmp(uri, "/stream") != 0) {
+                fprintf(stderr, "server: %s failed unexpectedly (%d)\n",
+                        uri, evpl_http_request_status(request));
+                exit(1);
+            }
+
+            status = evpl_http_request_status(request);
+
+            if (status == EVPL_HTTP_ERROR_STREAM_RESET) {
+                __sync_fetch_and_add(&server_reset_failures, 1);
+            } else if (status == EVPL_HTTP_ERROR_CONN_LOST) {
+                __sync_fetch_and_add(&server_lost_failures, 1);
+            } else {
+                fprintf(stderr, "server: /stream failed with %d\n", status);
+                exit(1);
+            }
+
+            evpl_ring_doorbell(&count_doorbell);
+            break;
+    } /* switch */
+} /* server_notify */
+
+static void
+server_dispatch(
+    struct evpl                 *evpl,
+    struct evpl_http_agent      *agent,
+    struct evpl_http_request    *request,
+    evpl_http_notify_callback_t *notify_callback,
+    void                       **notify_data,
+    void                        *private_data)
+{
+    *notify_callback = server_notify;
+    *notify_data     = NULL;
+} /* server_dispatch */
+
+static void *
+server_function(void *ptr)
+{
+    struct test_server      *server_ctx = ptr;
+    struct evpl_http_server *server;
+    struct evpl             *evpl;
+    struct evpl_endpoint    *endpoint;
+    struct evpl_listener    *listener;
+    struct evpl_http_agent  *agent;
+
+    evpl = evpl_create(NULL);
+
+    evpl_add_doorbell(evpl, &server_ctx->doorbell, server_wake);
+
+    agent = evpl_http_init(evpl);
+
+    endpoint = evpl_endpoint_create("0.0.0.0", TEST_PORT);
+
+    listener = evpl_listener_create();
+
+    server = evpl_http_attach(agent, listener, server_dispatch, NULL);
+
+    if (evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint)) {
+        fprintf(stderr, "failed to listen\n");
+        exit(1);
+    }
+
+    __sync_synchronize();
+
+    server_ctx->run = 1;
+
+    while (server_ctx->run) {
+        evpl_continue(evpl);
+    }
+
+    evpl_http_server_destroy(agent, server);
+    evpl_http_destroy(agent);
+
+    evpl_listener_destroy(listener);
+    evpl_destroy(evpl);
+
+    return NULL;
+} /* server_function */
+
+/* ------------------------------------------------------------------ client */
+
+enum req_mode {
+    MODE_NORMAL,          /* expect a clean 200 + body; FAILED is fatal      */
+    MODE_CANCEL_ON_DATA,  /* cancel on first data; nothing may follow        */
+    MODE_CLOSE_ON_DATA,   /* note first data; main loop closes the conn and
+                           * FAILED/CONN_LOST is the expected completion     */
+};
+
+struct req_ctx {
+    enum req_mode mode;
+    int           done;
+    int           got_data;
+    int           status;
+    int           body_len;
+    char          body[256];
+};
+
+static void
+client_notify(
+    struct evpl                *evpl,
+    struct evpl_http_agent     *agent,
+    struct evpl_http_request   *request,
+    enum evpl_http_notify_type  notify_type,
+    enum evpl_http_request_type request_type,
+    const char                 *uri,
+    void                       *notify_data,
+    void                       *private_data)
+{
+    struct req_ctx   *rc = notify_data;
+    struct evpl_iovec iov[8];
+    uint64_t          avail;
+    int               niov, i;
+
+    switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+            rc->status = evpl_http_request_status(request);
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+            avail = evpl_http_request_get_data_avail(request);
+
+            while (avail > 0) {
+                niov = evpl_http_request_get_datav(evpl, request, iov, (int) avail);
+                for (i = 0; i < niov; i++) {
+                    if (rc->mode == MODE_NORMAL &&
+                        rc->body_len + iov[i].length <= sizeof(rc->body)) {
+                        memcpy(rc->body + rc->body_len, iov[i].data, iov[i].length);
+                        rc->body_len += iov[i].length;
+                    }
+                    evpl_iovec_release(evpl, &iov[i]);
+                }
+                avail = evpl_http_request_get_data_avail(request);
+            }
+
+            if (rc->mode == MODE_CANCEL_ON_DATA && !rc->got_data) {
+                rc->got_data = 1;
+                /* nothing may reference the request after this returns, and
+                 * no notification of any kind may follow */
+                evpl_http_request_cancel(request);
+                rc->done = 1;
+            } else {
+                rc->got_data = 1;
+            }
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
+            if (rc->mode != MODE_NORMAL) {
+                fprintf(stderr, "client: unexpected completion in mode %d\n",
+                        rc->mode);
+                exit(1);
+            }
+            rc->done = 1;
+            break;
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+        case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
+            break;
+        case EVPL_HTTP_NOTIFY_FAILED:
+            if (rc->mode != MODE_CLOSE_ON_DATA) {
+                fprintf(stderr, "client: unexpected FAILED (%d) in mode %d\n",
+                        evpl_http_request_status(request), rc->mode);
+                exit(1);
+            }
+
+            if (evpl_http_request_status(request) != EVPL_HTTP_ERROR_CONN_LOST) {
+                fprintf(stderr, "client: FAILED with %d, wanted CONN_LOST\n",
+                        evpl_http_request_status(request));
+                exit(1);
+            }
+
+            rc->done = 1;
+            break;
+    } /* switch */
+} /* client_notify */
+
+static struct evpl_http_request *
+start_request(
+    struct evpl_http_conn *conn,
+    const char            *url,
+    struct req_ctx        *rc,
+    enum req_mode          mode)
+{
+    struct evpl_http_request *request;
+
+    memset(rc, 0, sizeof(*rc));
+    rc->mode = mode;
+
+    request = evpl_http_request_create(conn, EVPL_HTTP_REQUEST_TYPE_GET, url);
+
+    evpl_http_request_add_header(request, "Host", "localhost");
+    evpl_http_client_set_request_length(request, 0);
+
+    evpl_http_request_dispatch(request, client_notify, rc);
+
+    return request;
+} /* start_request */
+
+static void
+wait_done(
+    struct evpl    *evpl,
+    struct req_ctx *rc)
+{
+    while (!rc->done) {
+        evpl_continue(evpl);
+    }
+} /* wait_done */
+
+/* Wait until the server thread has recorded the expected terminal outcomes.
+ * Event-driven on the server side; the client just keeps its loop turning. */
+static void
+wait_server_counts(
+    struct evpl *evpl,
+    int          resets,
+    int          losses)
+{
+    while (server_reset_failures < resets || server_lost_failures < losses) {
+        evpl_continue(evpl);
+        __sync_synchronize();
+    }
+} /* wait_server_counts */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct test_server         server;
+    struct evpl               *evpl;
+    struct evpl_http_agent    *agent;
+    struct evpl_endpoint      *endpoint;
+    struct evpl_http_conn     *conn;
+    struct evpl_global_config *config;
+    struct req_ctx             rc;
+
+    config = evpl_global_config_init();
+    evpl_init(config);
+
+    server.run = 0;
+
+    pthread_create(&server.thread, NULL, server_function, &server);
+
+    while (!server.run) {
+        __sync_synchronize();
+    }
+
+    evpl = evpl_create(NULL);
+
+    evpl_add_doorbell(evpl, &count_doorbell, server_wake);
+
+    agent = evpl_http_init(evpl);
+
+    endpoint = evpl_endpoint_create("127.0.0.1", TEST_PORT);
+
+    /* 1. h2 cancel mid-stream; the connection survives it */
+    conn = evpl_http_client_connect(agent, EVPL_STREAM_SOCKET_TCP, endpoint,
+                                    EVPL_HTTP_VERSION_HTTP2, NULL);
+
+    start_request(conn, "/stream", &rc, MODE_CANCEL_ON_DATA);
+    wait_done(evpl, &rc);
+    wait_server_counts(evpl, 1, 0);
+    fprintf(stderr, "h2 cancel: ok\n");
+
+    start_request(conn, "/ok", &rc, MODE_NORMAL);
+    wait_done(evpl, &rc);
+
+    if (rc.status != 200 ||
+        rc.body_len != (int) (sizeof(response_body) - 1) ||
+        memcmp(rc.body, response_body, rc.body_len) != 0) {
+        fprintf(stderr, "post-cancel request broken (status %d, %d bytes)\n",
+                rc.status, rc.body_len);
+        exit(1);
+    }
+    fprintf(stderr, "post-cancel request: ok\n");
+
+    evpl_http_client_close(agent, conn);
+
+    /* 2. h2 connection closed with a stream in flight: FAILED/CONN_LOST on
+     * both sides */
+    conn = evpl_http_client_connect(agent, EVPL_STREAM_SOCKET_TCP, endpoint,
+                                    EVPL_HTTP_VERSION_HTTP2, NULL);
+
+    start_request(conn, "/stream", &rc, MODE_CLOSE_ON_DATA);
+
+    while (!rc.got_data) {
+        evpl_continue(evpl);
+    }
+
+    evpl_http_client_close(agent, conn);
+    wait_done(evpl, &rc);
+    wait_server_counts(evpl, 1, 1);
+    fprintf(stderr, "h2 conn loss: ok\n");
+
+    /* 3. h1 cancel: the connection is the only abort HTTP/1.x has */
+    conn = evpl_http_client_connect(agent, EVPL_STREAM_SOCKET_TCP, endpoint,
+                                    EVPL_HTTP_VERSION_HTTP1, NULL);
+
+    start_request(conn, "/stream", &rc, MODE_CANCEL_ON_DATA);
+    wait_done(evpl, &rc);
+    wait_server_counts(evpl, 1, 2);
+    fprintf(stderr, "h1 cancel: ok\n");
+
+    evpl_http_client_close(agent, conn);
+
+    evpl_http_destroy(agent);
+    evpl_destroy(evpl);
+
+    server.run = 0;
+    __sync_synchronize();
+    evpl_ring_doorbell(&server.doorbell);
+    pthread_join(server.thread, NULL);
+
+    fprintf(stderr, "all aborts ok\n");
+
+    return 0;
+} /* main */


### PR DESCRIPTION
Stacked on #138. Second of three HTTP-layer PRs preparing the transport for a gRPC layer; this one is what deadlines and cancellation sit on.

`EVPL_HTTP_NOTIFY_FAILED`'s contract — exactly one of RECEIVE_COMPLETE (client), RESPONSE_COMPLETE (server) or FAILED reaches every request — held only for HTTP/1.x, and there only on the client. Two paths freed requests behind the application's back:

- **HTTP/2 requests were never covered.** They live on the connection's stream list, not the `pending_requests` list the disconnect walk covers, and `evpl_http2_conn_destroy` freed them silently; a stream ending individually (peer reset, GOAWAY refusal) through `on_stream_close` was equally silent. Any handler holding a request across event-loop turns — which is what every streaming handler does — was left waiting forever, or worse, holding a freed pointer.
- **The HTTP/1.x disconnect walk skipped server requests mid-response.** Its `request_state == COMPLETE` skip was written for the client's close-delimited case (answered, not abandoned), but on a server COMPLETE says the request *message* arrived — a request still on the list has its response unfinished, and its application heard nothing.

Both now deliver FAILED before the free. Streams dying with their connection report `CONN_LOST`; a stream ending alone reports the new `EVPL_HTTP_ERROR_STREAM_RESET`, distinct because the connection remains usable. Terminal notification is tracked per stream so a completed exchange is never re-reported.

On top of that lifecycle, `evpl_http_request_cancel()`: the application abandoning an exchange itself. No notification of any kind follows — the caller declared it is done. On HTTP/2 the stream is reset (RST_STREAM/CANCEL) and the connection is untouched; the peer completes its side with STREAM_RESET. HTTP/1.x has no way to end one exchange early except ending the connection, so there the connection closes and other outstanding requests fail as for a peer close. A client request never dispatched is simply released.

The test (`http2_abort`) drives all three shapes against a server whose `/stream` response sends one chunk and then stalls, so every abort lands mid-exchange by construction: an h2 cancel (server sees STREAM_RESET, and the *same connection* then serves a clean request), an h2 connection close with a stream in flight (both ends see CONN_LOST), and an h1 cancel (the server completes its half-answered request with CONN_LOST through the fixed walk).