### PR TITLE
http: consumption-driven HTTP/2 flow control

### DIFF
--- a/include/evpl/evpl_config.h
+++ b/include/evpl/evpl_config.h
@@ -115,6 +115,21 @@ void evpl_global_config_set_http_max_header_size(
     struct evpl_global_config *config,
     unsigned int               size);
 
+/*
+ * Initial HTTP/2 flow-control window in bytes, applied to both the
+ * per-stream window (via SETTINGS_INITIAL_WINDOW_SIZE) and the connection
+ * window of every HTTP/2 session.  0 (the default) keeps the protocol
+ * default of 65535 bytes.  The window is how much inbound content the peer
+ * may have in flight beyond what the application has drained with
+ * evpl_http_request_get_datav, so it bounds per-stream buffering and, for
+ * high-bandwidth streams, bounds throughput to window / round-trip-time --
+ * raise it when a single stream must carry bulk data at rate.  Values above
+ * RFC 9113's 2^31-1 maximum are clamped.
+ */
+void evpl_global_config_set_http2_window_size(
+    struct evpl_global_config *config,
+    unsigned int               size);
+
 struct evpl_thread_config *
 evpl_thread_config_init(
     void);

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -51,6 +51,7 @@ evpl_global_config_init(void)
     }
 
     config->http_max_header_size = 8192;
+    config->http2_window_size    = 0;
 
     config->io_uring_enabled = 1;
     config->io_uring_entries = 8192;
@@ -308,6 +309,25 @@ evpl_global_config_get_http_max_header_size(void)
 {
     return evpl_shared->config->http_max_header_size;
 } /* evpl_global_config_get_http_max_header_size */
+
+SYMBOL_EXPORT void
+evpl_global_config_set_http2_window_size(
+    struct evpl_global_config *config,
+    unsigned int               size)
+{
+    /* RFC 9113 section 6.9.1 caps a flow-control window at 2^31-1 */
+    if (size > 0x7fffffffU) {
+        size = 0x7fffffffU;
+    }
+
+    config->http2_window_size = size;
+} /* evpl_global_config_set_http2_window_size */
+
+SYMBOL_EXPORT unsigned int
+evpl_global_config_get_http2_window_size(void)
+{
+    return evpl_shared->config->http2_window_size;
+} /* evpl_global_config_get_http2_window_size */
 
 SYMBOL_EXPORT struct evpl_thread_config *
 evpl_thread_config_init(void)

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -113,6 +113,7 @@ struct evpl_global_config {
     int                       tls_ktls_enabled;
 
     unsigned int              http_max_header_size;
+    unsigned int              http2_window_size;
 };
 
 /* Read the configured HTTP header block limit from the live global config.
@@ -120,6 +121,11 @@ struct evpl_global_config {
  * hidden evpl_shared symbol) can fetch it at agent init. */
 unsigned int
 evpl_global_config_get_http_max_header_size(
+    void);
+
+/* Read the configured HTTP/2 flow-control window, same arrangement. */
+unsigned int
+evpl_global_config_get_http2_window_size(
     void);
 
 typedef void (*evpl_accept_callback_t)(

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -171,6 +171,8 @@ evpl_http_init(struct evpl *evpl)
         agent->max_header_size = 512;
     }
 
+    agent->http2_window_size = evpl_global_config_get_http2_window_size();
+
     return agent;
 } /* evpl_http_init */
 
@@ -3566,5 +3568,27 @@ evpl_http_request_get_datav(
     struct evpl_iovec        *iov,
     int                       length)
 {
-    return evpl_iovec_ring_copyv(evpl, iov, &request->recv_ring, length);
+    int      niov;
+
+#ifdef HAVE_NGHTTP2
+    uint64_t before = evpl_iovec_ring_bytes(&request->recv_ring);
+#endif /* ifdef HAVE_NGHTTP2 */
+
+    niov = evpl_iovec_ring_copyv(evpl, iov, &request->recv_ring, length);
+
+#ifdef HAVE_NGHTTP2
+    /* Draining is what earns the peer more flow-control window: on h2 the
+     * bytes taken here are reported to the session, which answers with
+     * WINDOW_UPDATE.  This is the backpressure path -- an application that
+     * stops draining stops the peer within a window. */
+    if (request->conn->proto == EVPL_HTTP_PROTO_H2) {
+        uint64_t drained = before - evpl_iovec_ring_bytes(&request->recv_ring);
+
+        if (drained > 0) {
+            evpl_http2_consume(request, drained);
+        }
+    }
+#endif /* ifdef HAVE_NGHTTP2 */
+
+    return niov;
 } /* evpl_http_request_get_datav */

--- a/src/http/http2.c
+++ b/src/http/http2.c
@@ -494,6 +494,13 @@ evpl_http2_on_data_chunk(
     request = nghttp2_session_get_stream_user_data(session, stream_id);
 
     if (!request || len == 0) {
+        /* Data for a stream nobody holds (reset locally, or already closed)
+         * still occupied the connection window; with auto window updates off
+         * it has to be consumed here or that share of the window is lost for
+         * the connection's remaining life. */
+        if (len > 0) {
+            nghttp2_session_consume_connection(session, len);
+        }
         return 0;
     }
 
@@ -561,6 +568,14 @@ evpl_http2_on_stream_close(
 
     DL_DELETE(conn->h2->streams, request);
 
+    /* Whatever the application never drained still occupied the connection
+     * window; give that share back before the request (and its ring) is
+     * freed.  The stream's own window dies with the stream. */
+    if (evpl_iovec_ring_bytes(&request->recv_ring) > 0) {
+        nghttp2_session_consume_connection(session,
+                                           evpl_iovec_ring_bytes(&request->recv_ring));
+    }
+
     /* A stream that closed before the request's terminal notification fired
      * ends an exchange nobody finished: reset by the peer, refused by a
      * GOAWAY, or torn down by a protocol error.  The application holding the
@@ -585,7 +600,10 @@ evpl_http2_conn_init(struct evpl_http_conn *conn)
 {
     struct evpl_http2_conn    *h2;
     nghttp2_session_callbacks *callbacks;
-    nghttp2_settings_entry     iv[1];
+    nghttp2_option            *option;
+    nghttp2_settings_entry     iv[2];
+    size_t                     niv;
+    unsigned int               window = conn->agent->http2_window_size;
 
     h2       = evpl_zalloc(sizeof(*h2));
     h2->conn = conn;
@@ -602,18 +620,42 @@ evpl_http2_conn_init(struct evpl_http_conn *conn)
     nghttp2_session_callbacks_set_on_frame_send_callback(callbacks, evpl_http2_on_frame_send);
     nghttp2_session_callbacks_set_on_stream_close_callback(callbacks, evpl_http2_on_stream_close);
 
+    /* Inbound flow control follows the application's consumption rather than
+     * the library's arrival processing: WINDOW_UPDATE goes out as data is
+     * drained through evpl_http_request_get_datav (nghttp2_session_consume),
+     * so a peer can have at most a window of content in flight beyond what
+     * the application has taken.  With the default auto-update the library
+     * acknowledges data the moment it buffers it, and a stream fed faster
+     * than its application drains buffers without bound. */
+    nghttp2_option_new(&option);
+    nghttp2_option_set_no_auto_window_update(option, 1);
+
     if (conn->is_server) {
-        nghttp2_session_server_new3(&h2->session, callbacks, conn, NULL, &evpl_http2_mem);
+        nghttp2_session_server_new3(&h2->session, callbacks, conn, option, &evpl_http2_mem);
     } else {
-        nghttp2_session_client_new3(&h2->session, callbacks, conn, NULL, &evpl_http2_mem);
+        nghttp2_session_client_new3(&h2->session, callbacks, conn, option, &evpl_http2_mem);
     }
 
     nghttp2_session_callbacks_del(callbacks);
+    nghttp2_option_del(option);
 
     iv[0].settings_id = NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS;
     iv[0].value       = 100;
+    niv               = 1;
 
-    nghttp2_submit_settings(h2->session, NGHTTP2_FLAG_NONE, iv, 1);
+    if (window) {
+        iv[niv].settings_id = NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
+        iv[niv].value       = window;
+        niv++;
+
+        /* The setting covers stream windows; the connection window (stream
+         * 0) is adjusted directly, or it would stay at the 65535-byte
+         * protocol default and cap all streams together. */
+        nghttp2_session_set_local_window_size(h2->session, NGHTTP2_FLAG_NONE,
+                                              0, (int32_t) window);
+    }
+
+    nghttp2_submit_settings(h2->session, NGHTTP2_FLAG_NONE, iv, niv);
 } /* evpl_http2_conn_init */
 
 void
@@ -948,6 +990,19 @@ evpl_http2_submit(struct evpl_http_request *request)
 
     evpl_defer(conn->agent->evpl, &conn->flush);
 } /* evpl_http2_submit */
+
+void
+evpl_http2_consume(
+    struct evpl_http_request *request,
+    uint64_t                  bytes)
+{
+    struct evpl_http_conn *conn = request->conn;
+
+    nghttp2_session_consume(conn->h2->session, request->h2.stream_id, bytes);
+
+    /* the WINDOW_UPDATEs this earns go out with the next send pass */
+    evpl_defer(conn->agent->evpl, &conn->flush);
+} /* evpl_http2_consume */
 
 void
 evpl_http2_cancel(struct evpl_http_request *request)

--- a/src/http/http_internal.h
+++ b/src/http/http_internal.h
@@ -228,6 +228,9 @@ struct evpl_http_agent {
     struct evpl_http_conn           *conns; /* live connections; see conn */
     struct evpl                     *evpl;
     unsigned int                     max_header_size;
+    /* Configured HTTP/2 flow-control window; 0 keeps the protocol default.
+     * See evpl_global_config_set_http2_window_size. */
+    unsigned int                     http2_window_size;
     /* The Date header field's value, and the second it was formatted for.
      * Cached because it changes once a second and is needed on every
      * response, and formatting it costs a gmtime_r that would otherwise run
@@ -460,5 +463,13 @@ evpl_http2_submit(
 void
 evpl_http2_cancel(
     struct evpl_http_request *request);
+
+/* Report bytes the application drained from the request's recv_ring, so the
+ * session can widen the peer's flow-control windows accordingly
+ * (nghttp2_session_consume).  Called from evpl_http_request_get_datav. */
+void
+evpl_http2_consume(
+    struct evpl_http_request *request,
+    uint64_t                  bytes);
 
 #endif /* HAVE_NGHTTP2 */

--- a/src/http/tests/CMakeLists.txt
+++ b/src/http/tests/CMakeLists.txt
@@ -120,6 +120,15 @@ if (HAVE_NGHTTP2)
     unit_test(http h2_abort http2_abort.c)
     target_link_libraries(http_h2_abort evpl_http)
 
+    # consumption-driven flow control: transfers complete because draining
+    # earns window, and buffering stays within one window -- at the default
+    # 65535 and at a configured 256KB
+    unit_test(http h2_flow http2_flow.c)
+    target_link_libraries(http_h2_flow evpl_http)
+
+    unit_test(http h2_flow_window http2_flow_window.c)
+    target_link_libraries(http_h2_flow_window evpl_http)
+
     # libevpl HTTP/2 server driven by libcurl (reference client)
     unit_test(http h2_basic http2_basic.c)
     target_link_libraries(http_h2_basic evpl_http curl)

--- a/src/http/tests/http2_flow.c
+++ b/src/http/tests/http2_flow.c
@@ -1,0 +1,458 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * HTTP/2 inbound flow control follows the application's consumption: window
+ * credit is granted as data is drained through evpl_http_request_get_datav,
+ * so a peer can never have more than one flow-control window in flight
+ * beyond what the application has taken.
+ *
+ * A 1MB chunked download and a 1MB chunked upload each get drained half at a
+ * time, so the receiver is always behind the sender and the windows are what
+ * paces the transfer.  Two things are asserted on each direction: the full
+ * content arrives (the WINDOW_UPDATEs earned by draining keep the transfer
+ * alive at all -- with consumption unreported it would stall inside the
+ * first window), and the receive buffer never holds more than one window of
+ * undrained content (the peer respected the credit).
+ *
+ * http2_flow_window runs the same file with a 256KB window configured via
+ * evpl_global_config_set_http2_window_size, proving the knob reaches both
+ * the stream and connection windows.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+
+#ifndef TEST_PORT
+#define TEST_PORT     8088
+#endif /* ifndef TEST_PORT */
+
+/* 0: keep the RFC 9113 default window of 65535 bytes */
+#ifndef TEST_WINDOW
+#define TEST_WINDOW   0
+#endif /* ifndef TEST_WINDOW */
+
+#define WINDOW_BOUND  (TEST_WINDOW ? TEST_WINDOW : 65535)
+
+#define TRANSFER_SIZE (1024 * 1024)
+#define CHUNK_SIZE    (32 * 1024)
+
+/* ------------------------------------------------------------------ shared */
+
+/* Drain about half of what is buffered, in bounded steps, and account it.
+ * Returns the bytes taken. */
+static uint64_t
+drain_half(
+    struct evpl              *evpl,
+    struct evpl_http_request *request,
+    uint64_t                 *total,
+    uint64_t                 *max_avail)
+{
+    struct evpl_iovec iov[64];
+    uint64_t          avail = evpl_http_request_get_data_avail(request);
+    uint64_t          target;
+    uint64_t          taken = 0;
+    int               niov, i;
+
+    if (avail > *max_avail) {
+        *max_avail = avail;
+    }
+
+    target = (avail + 1) / 2;
+
+    while (taken < target) {
+        uint64_t step = target - taken;
+
+        if (step > CHUNK_SIZE) {
+            step = CHUNK_SIZE;
+        }
+
+        niov = evpl_http_request_get_datav(evpl, request, iov, (int) step);
+
+        if (niov <= 0) {
+            break;
+        }
+
+        for (i = 0; i < niov; i++) {
+            taken += iov[i].length;
+            evpl_iovec_release(evpl, &iov[i]);
+        }
+    }
+
+    *total += taken;
+
+    return taken;
+} /* drain_half */
+
+static void
+drain_all(
+    struct evpl              *evpl,
+    struct evpl_http_request *request,
+    uint64_t                 *total,
+    uint64_t                 *max_avail)
+{
+    while (evpl_http_request_get_data_avail(request) > 0) {
+        drain_half(evpl, request, total, max_avail);
+    }
+} /* drain_all */
+
+static void
+add_chunk(
+    struct evpl              *evpl,
+    struct evpl_http_request *request)
+{
+    struct evpl_iovec iov;
+
+    evpl_iovec_alloc(evpl, CHUNK_SIZE, 0, 1, 0, &iov);
+    memset(iov.data, 'x', CHUNK_SIZE);
+    iov.length = CHUNK_SIZE;
+
+    evpl_http_request_add_datav(request, &iov, 1);
+} /* add_chunk */
+
+/* ------------------------------------------------------------------ server */
+
+struct test_server {
+    pthread_t            thread;
+    volatile int         run;
+    struct evpl_doorbell doorbell;
+};
+
+static void
+server_wake(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+} /* server_wake */
+
+/* one exchange at a time, so per-exchange state can live here */
+static uint64_t download_sent;
+static uint64_t upload_received;
+static uint64_t upload_max_avail;
+
+static void
+server_notify(
+    struct evpl                *evpl,
+    struct evpl_http_agent     *agent,
+    struct evpl_http_request   *request,
+    enum evpl_http_notify_type  notify_type,
+    enum evpl_http_request_type request_type,
+    const char                 *uri,
+    void                       *notify_data,
+    void                       *private_data)
+{
+    struct evpl_iovec iov;
+    int               n;
+
+    switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+            /* the /upload body: drain half, so the client runs ahead of us
+             * and the window is what stops it */
+            drain_half(evpl, request, &upload_received, &upload_max_avail);
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
+            if (strcmp(uri, "/download") == 0) {
+                download_sent = 0;
+                evpl_http_server_set_response_chunked(request);
+                evpl_http_server_dispatch_default(request, 200);
+            } else {
+                /* /upload: take the tail, then answer with the byte count */
+                drain_all(evpl, request, &upload_received, &upload_max_avail);
+
+                if (upload_max_avail > WINDOW_BOUND) {
+                    fprintf(stderr,
+                            "server: %llu bytes buffered, window is %d\n",
+                            (unsigned long long) upload_max_avail,
+                            WINDOW_BOUND);
+                    exit(1);
+                }
+
+                evpl_iovec_alloc(evpl, 32, 0, 1, 0, &iov);
+                n = snprintf(iov.data, 32, "%llu",
+                             (unsigned long long) upload_received);
+                iov.length = n;
+
+                evpl_http_server_set_response_length(request, n);
+                evpl_http_request_add_datav(request, &iov, 1);
+                evpl_http_server_dispatch_default(request, 200);
+            }
+            break;
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+            /* the /download body: the next chunk, until 1MB is out */
+            if (download_sent >= TRANSFER_SIZE) {
+                break;
+            }
+
+            add_chunk(evpl, request);
+            download_sent += CHUNK_SIZE;
+
+            if (download_sent >= TRANSFER_SIZE) {
+                evpl_http_request_add_datav(request, NULL, 0);
+            }
+            break;
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+        case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
+            break;
+        case EVPL_HTTP_NOTIFY_FAILED:
+            fprintf(stderr, "server: %s failed unexpectedly (%d)\n",
+                    uri, evpl_http_request_status(request));
+            exit(1);
+    } /* switch */
+} /* server_notify */
+
+static void
+server_dispatch(
+    struct evpl                 *evpl,
+    struct evpl_http_agent      *agent,
+    struct evpl_http_request    *request,
+    evpl_http_notify_callback_t *notify_callback,
+    void                       **notify_data,
+    void                        *private_data)
+{
+    *notify_callback = server_notify;
+    *notify_data     = NULL;
+} /* server_dispatch */
+
+static void *
+server_function(void *ptr)
+{
+    struct test_server      *server_ctx = ptr;
+    struct evpl_http_server *server;
+    struct evpl             *evpl;
+    struct evpl_endpoint    *endpoint;
+    struct evpl_listener    *listener;
+    struct evpl_http_agent  *agent;
+
+    evpl = evpl_create(NULL);
+
+    evpl_add_doorbell(evpl, &server_ctx->doorbell, server_wake);
+
+    agent = evpl_http_init(evpl);
+
+    endpoint = evpl_endpoint_create("0.0.0.0", TEST_PORT);
+
+    listener = evpl_listener_create();
+
+    server = evpl_http_attach(agent, listener, server_dispatch, NULL);
+
+    if (evpl_listen(listener, EVPL_STREAM_SOCKET_TCP, endpoint)) {
+        fprintf(stderr, "failed to listen\n");
+        exit(1);
+    }
+
+    __sync_synchronize();
+
+    server_ctx->run = 1;
+
+    while (server_ctx->run) {
+        evpl_continue(evpl);
+    }
+
+    evpl_http_server_destroy(agent, server);
+    evpl_http_destroy(agent);
+
+    evpl_listener_destroy(listener);
+    evpl_destroy(evpl);
+
+    return NULL;
+} /* server_function */
+
+/* ------------------------------------------------------------------ client */
+
+struct req_ctx {
+    int      done;
+    int      status;
+    int      upload;      /* this request streams the 1MB request body */
+    uint64_t sent;
+    uint64_t received;
+    uint64_t max_avail;
+    char     small_body[64];
+    int      small_len;
+};
+
+static void
+client_notify(
+    struct evpl                *evpl,
+    struct evpl_http_agent     *agent,
+    struct evpl_http_request   *request,
+    enum evpl_http_notify_type  notify_type,
+    enum evpl_http_request_type request_type,
+    const char                 *uri,
+    void                       *notify_data,
+    void                       *private_data)
+{
+    struct req_ctx   *rc = notify_data;
+    struct evpl_iovec iov[8];
+    uint64_t          avail;
+    int               niov, i;
+
+    switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+            rc->status = evpl_http_request_status(request);
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+            if (rc->upload) {
+                /* the count reply is tiny; take it whole */
+                avail = evpl_http_request_get_data_avail(request);
+
+                while (avail > 0) {
+                    niov = evpl_http_request_get_datav(evpl, request, iov,
+                                                       (int) avail);
+                    for (i = 0; i < niov; i++) {
+                        if (rc->small_len + iov[i].length <=
+                            sizeof(rc->small_body)) {
+                            memcpy(rc->small_body + rc->small_len,
+                                   iov[i].data, iov[i].length);
+                            rc->small_len += iov[i].length;
+                        }
+                        evpl_iovec_release(evpl, &iov[i]);
+                    }
+                    avail = evpl_http_request_get_data_avail(request);
+                }
+            } else {
+                drain_half(evpl, request, &rc->received, &rc->max_avail);
+            }
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
+            if (!rc->upload) {
+                drain_all(evpl, request, &rc->received, &rc->max_avail);
+            }
+            rc->done = 1;
+            break;
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+            if (!rc->upload || rc->sent >= TRANSFER_SIZE) {
+                break;
+            }
+
+            add_chunk(evpl, request);
+            rc->sent += CHUNK_SIZE;
+
+            if (rc->sent >= TRANSFER_SIZE) {
+                evpl_http_request_add_datav(request, NULL, 0);
+            }
+            break;
+        case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
+            break;
+        case EVPL_HTTP_NOTIFY_FAILED:
+            fprintf(stderr, "client: %s failed unexpectedly (%d)\n",
+                    uri, evpl_http_request_status(request));
+            exit(1);
+    } /* switch */
+} /* client_notify */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct test_server         server;
+    struct evpl               *evpl;
+    struct evpl_http_agent    *agent;
+    struct evpl_endpoint      *endpoint;
+    struct evpl_http_conn     *conn;
+    struct evpl_http_request  *request;
+    struct evpl_global_config *config;
+    struct req_ctx             rc;
+
+    config = evpl_global_config_init();
+
+    if (TEST_WINDOW) {
+        evpl_global_config_set_http2_window_size(config, TEST_WINDOW);
+    }
+
+    evpl_init(config);
+
+    server.run = 0;
+
+    pthread_create(&server.thread, NULL, server_function, &server);
+
+    while (!server.run) {
+        __sync_synchronize();
+    }
+
+    evpl = evpl_create(NULL);
+
+    agent = evpl_http_init(evpl);
+
+    endpoint = evpl_endpoint_create("127.0.0.1", TEST_PORT);
+
+    conn = evpl_http_client_connect(agent, EVPL_STREAM_SOCKET_TCP, endpoint,
+                                    EVPL_HTTP_VERSION_HTTP2, NULL);
+
+    /* 1MB download, drained half at a time */
+    memset(&rc, 0, sizeof(rc));
+
+    request = evpl_http_request_create(conn, EVPL_HTTP_REQUEST_TYPE_GET,
+                                       "/download");
+    evpl_http_request_add_header(request, "Host", "localhost");
+    evpl_http_client_set_request_length(request, 0);
+    evpl_http_request_dispatch(request, client_notify, &rc);
+
+    while (!rc.done) {
+        evpl_continue(evpl);
+    }
+
+    if (rc.status != 200 || rc.received != TRANSFER_SIZE) {
+        fprintf(stderr, "download: status %d, %llu of %d bytes\n",
+                rc.status, (unsigned long long) rc.received, TRANSFER_SIZE);
+        exit(1);
+    }
+
+    if (rc.max_avail > WINDOW_BOUND) {
+        fprintf(stderr, "download: %llu bytes buffered, window is %d\n",
+                (unsigned long long) rc.max_avail, WINDOW_BOUND);
+        exit(1);
+    }
+
+    fprintf(stderr, "download: ok (%llu bytes, high-water %llu)\n",
+            (unsigned long long) rc.received,
+            (unsigned long long) rc.max_avail);
+
+    /* 1MB upload; the server drains half at a time and replies with the
+     * byte count it received */
+    memset(&rc, 0, sizeof(rc));
+    rc.upload = 1;
+
+    request = evpl_http_request_create(conn, EVPL_HTTP_REQUEST_TYPE_POST,
+                                       "/upload");
+    evpl_http_request_add_header(request, "Host", "localhost");
+    evpl_http_client_set_request_chunked(request);
+    evpl_http_request_dispatch(request, client_notify, &rc);
+
+    while (!rc.done) {
+        evpl_continue(evpl);
+    }
+
+    rc.small_body[rc.small_len < (int) sizeof(rc.small_body) ?
+                  rc.small_len : (int) sizeof(rc.small_body) - 1] = '\0';
+
+    if (rc.status != 200 ||
+        strtoull(rc.small_body, NULL, 10) != TRANSFER_SIZE) {
+        fprintf(stderr, "upload: status %d, server counted '%s'\n",
+                rc.status, rc.small_body);
+        exit(1);
+    }
+
+    fprintf(stderr, "upload: ok (server received %s bytes)\n", rc.small_body);
+
+    evpl_http_client_close(agent, conn);
+
+    evpl_http_destroy(agent);
+    evpl_destroy(evpl);
+
+    server.run = 0;
+    __sync_synchronize();
+    evpl_ring_doorbell(&server.doorbell);
+    pthread_join(server.thread, NULL);
+
+    fprintf(stderr, "flow control ok\n");
+
+    return 0;
+} /* main */

--- a/src/http/tests/http2_flow_window.c
+++ b/src/http/tests/http2_flow_window.c
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * The http2_flow transfers with a 256KB flow-control window configured
+ * through evpl_global_config_set_http2_window_size: the same completion and
+ * high-water assertions hold against the larger bound, proving the setting
+ * reaches both the per-stream and connection windows.
+ */
+
+#define TEST_WINDOW (256 * 1024)
+#define TEST_PORT   8089
+
+#include "http2_flow.c"


### PR DESCRIPTION
Stacked on #139. Third of three HTTP-layer PRs preparing the transport for a gRPC layer; this one makes long-lived streams safe against slow consumers.

nghttp2's automatic window updates acknowledge inbound DATA the moment the library buffers it, so the peer's view of the flow-control window tracked arrival rather than consumption: a stream fed faster than its application drains buffered without bound — flow control in name only.

Automatic updates are turned off, and consumption is reported where it actually happens: `evpl_http_request_get_datav` tells the session how much the application drained (`nghttp2_session_consume`), which is what earns the peer WINDOW_UPDATE. A peer can now have at most one window of content in flight beyond what the application has taken; draining is the backpressure signal.

Bytes that never reach an application still occupied the connection window and are consumed where they fall out — data for a stream nobody holds in the data-chunk callback, and whatever was left undrained when a stream closed in `on_stream_close`. Missing either leaks that share of the connection window for the connection's remaining life.

The window becomes configurable: `evpl_global_config_set_http2_window_size` applies to stream windows via SETTINGS_INITIAL_WINDOW_SIZE and to the connection window directly (0, the default, keeps the protocol's 65535 bytes). A single stream's throughput is bounded by window / RTT, so bulk streams over real networks want it raised.

The test (`http2_flow`) streams 1MB each way with the receiver deliberately draining half of what is buffered at a time, and asserts both that the transfer completes — with consumption unreported it stalls inside the first window, verified by neutering the consume call — and that undrained buffering never exceeds one window. `http2_flow_window` repeats both transfers with a 256KB configured window, proving the knob reaches both the stream and connection windows.