### PR TITLE
core: keep poll handles stable across evpl_remove_poll

### DIFF
--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -502,7 +502,9 @@ evpl_continue(struct evpl *evpl)
 
         for (i = 0; i < evpl->num_poll; ++i) {
             poll = &evpl->poll[i];
-            poll->callback(evpl, poll->private_data);
+            if (poll->callback) {
+                poll->callback(evpl, poll->private_data);
+            }
         }
 
         evpl->poll_iterations++;

--- a/src/core/poll.c
+++ b/src/core/poll.c
@@ -6,6 +6,20 @@
 #include "core/poll.h"
 #include "macros.h"
 
+/*
+ * A poll slot IS the handle evpl_add_poll() hands back, and every registered
+ * poller on this thread is holding one.  So a slot must never change owner:
+ * removal tombstones it (callback NULL, skipped by the dispatch loops) and
+ * add reuses a tombstone before extending the array.
+ *
+ * Compacting instead -- moving the tail entry into the removed slot -- silently
+ * repoints some other poller's handle at a different poller.  Its own later
+ * evpl_remove_poll() then unregisters the wrong slot and leaves its callback
+ * live, firing against freed private_data.  Any thread with two or more
+ * pollers that are not torn down in exact reverse order can hit it; it showed
+ * up as an intermittent heap-use-after-free tearing down a thread carrying
+ * both a filesystem's completion polls and an RPC thread's.
+ */
 SYMBOL_EXPORT struct evpl_poll *
 evpl_add_poll(
     struct evpl               *evpl,
@@ -14,14 +28,24 @@ evpl_add_poll(
     evpl_poll_callback_t       callback,
     void                      *private_data)
 {
-    struct evpl_poll *poll = &evpl->poll[evpl->num_poll];
+    struct evpl_poll *poll = NULL;
+    int               i;
+
+    for (i = 0; i < evpl->num_poll; ++i) {
+        if (evpl->poll[i].callback == NULL) {
+            poll = &evpl->poll[i];
+            break;
+        }
+    }
+
+    if (!poll) {
+        poll = &evpl->poll[evpl->num_poll++];
+    }
 
     poll->enter_callback = enter_callback;
     poll->exit_callback  = exit_callback;
     poll->callback       = callback;
     poll->private_data   = private_data;
-
-    ++evpl->num_poll;
 
     return poll;
 } /* evpl_add_poll */
@@ -31,14 +55,17 @@ evpl_remove_poll(
     struct evpl      *evpl,
     struct evpl_poll *poll)
 {
-    int index = poll - evpl->poll;
+    poll->enter_callback = NULL;
+    poll->exit_callback  = NULL;
+    poll->callback       = NULL;
+    poll->private_data   = NULL;
 
-    if (index + 1 < evpl->num_poll) {
-        evpl->poll[index] = evpl->poll[evpl->num_poll - 1];
+    /* Reclaim trailing tombstones so num_poll -- which also answers "does this
+     * thread poll at all?" -- returns to zero once the last poller leaves. */
+    while (evpl->num_poll > 0 &&
+           evpl->poll[evpl->num_poll - 1].callback == NULL) {
+        evpl->num_poll--;
     }
-
-    evpl->num_poll--;
-
 } /* evpl_remove_poll */
 
 SYMBOL_EXPORT void

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -31,6 +31,17 @@ foreach(mech ${EVPL_MECHANISMS})
                          PROPERTIES TIMEOUT 10)
 endforeach()
 
+# Retiring one poller must leave the other pollers' handles meaning what they
+# meant before.  Touches no network, so it needs neither a namespace nor the
+# port lock, and it identifies pollers by value, so it fails the same way in a
+# Release build as under AddressSanitizer.
+unit_test_all_mechs(core poll_remove poll_remove.c)
+
+foreach(mech ${EVPL_MECHANISMS})
+    set_tests_properties(libevpl/core/poll_remove_${mech}
+                         PROPERTIES TIMEOUT 10)
+endforeach()
+
 # Growing an iovec ring with a wrapped waist.  Drives the ring directly rather
 # than through a protocol, since the waist is only advanced by the RDMA CM one.
 unit_test(core iovec_ring_resize iovec_ring_resize.c)

--- a/src/core/tests/poll_remove.c
+++ b/src/core/tests/poll_remove.c
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Retiring one poller must not disturb the others.
+ *
+ * evpl_add_poll() returns a handle, and every poller registered on a thread is
+ * holding one at the same time.  A removal therefore has to leave the other
+ * handles meaning exactly what they meant before -- otherwise the next poller
+ * to retire unregisters somebody else's slot, and its own callback stays live
+ * and keeps firing against private_data its owner has already released.
+ *
+ * The order below is the one that exposes it: retire the FIRST poller, then the
+ * LAST.  A dispatch array compacted by moving the tail entry into the freed
+ * slot answers the second removal by unregistering the wrong entry -- the
+ * poller that was moved keeps running and the one that was not stops.  Any
+ * thread with two or more pollers not torn down in exact reverse registration
+ * order can reach it.
+ *
+ * The pollers are identified by value rather than by a pointer into freed
+ * storage, so a stale dispatch is a plain counter mismatch: this fails the same
+ * way in a Release build as under AddressSanitizer.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "evpl/evpl.h"
+
+#define NPOLL     5
+#define PUMP_ITER 64
+
+static int failures;
+static int fired[NPOLL];
+
+#define CHECK(cond, ...) \
+        do { \
+            if (!(cond)) { \
+                printf("FAIL: " __VA_ARGS__); printf("\n"); failures++; \
+            } else { \
+                printf("ok:   " __VA_ARGS__); printf("\n"); \
+            } \
+        } while (0)
+
+static void
+poll_callback(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    fired[(intptr_t) private_data]++;
+} /* poll_callback */
+
+/* Clear the counters and run the loop long enough that every registered poller
+ * has certainly been dispatched.  The loop only visits pollers while it is in
+ * poll mode, which it enters on its own as soon as one is registered and holds
+ * while a caller keeps pumping. */
+static void
+pump(struct evpl *evpl)
+{
+    int i;
+
+    memset(fired, 0, sizeof(fired));
+
+    for (i = 0; i < PUMP_ITER; ++i) {
+        evpl_continue(evpl);
+    }
+} /* pump */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct evpl      *evpl;
+    struct evpl_poll *handle[NPOLL];
+    intptr_t          i;
+
+    evpl_init(NULL);
+
+    evpl = evpl_create(NULL);
+
+    for (i = 0; i < 4; ++i) {
+        handle[i] = evpl_add_poll(evpl, NULL, NULL, poll_callback,
+                                  (void *) i);
+    }
+
+    pump(evpl);
+    CHECK(fired[0] && fired[1] && fired[2] && fired[3],
+          "all four pollers dispatched");
+
+    /* --- retire the first --- */
+    evpl_remove_poll(evpl, handle[0]);
+
+    pump(evpl);
+    CHECK(!fired[0], "the retired poller stopped");
+    CHECK(fired[1] && fired[2] && fired[3], "the other three still dispatch");
+
+    /* --- retire the last, whose handle a compacting removal would have
+     * invalidated above --- */
+    evpl_remove_poll(evpl, handle[3]);
+
+    pump(evpl);
+    CHECK(!fired[3], "the second retired poller stopped");
+    CHECK(!fired[0], "the first retired poller is still gone");
+    CHECK(fired[1] && fired[2], "the survivors still dispatch");
+
+    /* --- a poller added after the removals --- */
+    handle[4] = evpl_add_poll(evpl, NULL, NULL, poll_callback, (void *) 4);
+
+    pump(evpl);
+    CHECK(fired[4], "a poller added after the removals dispatches");
+    CHECK(fired[1] && fired[2], "and the survivors are undisturbed");
+    CHECK(!fired[0] && !fired[3], "and the retired ones stay retired");
+
+    evpl_remove_poll(evpl, handle[1]);
+
+    pump(evpl);
+    CHECK(!fired[1], "the third retired poller stopped");
+    CHECK(fired[2] && fired[4], "the last two still dispatch");
+
+    evpl_remove_poll(evpl, handle[4]);
+    evpl_remove_poll(evpl, handle[2]);
+
+    evpl_destroy(evpl);
+
+    printf("\n%s (%d failures)\n", failures ? "FAILED" : "PASSED", failures);
+
+    return failures != 0;
+} /* main */


### PR DESCRIPTION
`evpl_add_poll()` hands back a pointer into `evpl->poll[]`, and every poller registered on a thread is holding one at the same time. `evpl_remove_poll()` compacted the array by moving the tail entry into the removed slot:

```c
if (index + 1 < evpl->num_poll) {
    evpl->poll[index] = evpl->poll[evpl->num_poll - 1];
}
evpl->num_poll--;
```

That silently repoints some *other* poller's handle at a different poller. The next poller to retire then unregisters the wrong slot, and its own callback stays registered — firing against `private_data` its owner has already freed.

Any thread with two or more pollers that are not torn down in exact reverse registration order can reach it. Four pollers A B C D, remove A, then remove D by its handle:

| step | slots | D's handle |
|---|---|---|
| initial | `[A B C D]` | idx 3 |
| remove A | `[D B C]` | idx 3 — now past the end |
| remove D (idx 3) | `[D B]` | no swap, `num_poll--` |

D is still dispatched and C silently stops.

### How it turned up

An intermittent heap-use-after-free tearing down a thread in a caller whose `evpl` carries both a filesystem's completion polls and an RPC thread's — roughly half of all runs faulted in the filesystem's poll callback, on a thread state its own `evpl_remove_poll()` had already freed. The quieter half of the same bug is the table above: a poller that was supposed to be retired keeps running while a live one stops, with no crash.

### Fix

Tombstone the slot (callback `NULL`, skipped by the dispatch loop) and let `evpl_add_poll()` reuse a tombstone before extending the array, so a slot never changes owner. Trailing tombstones are reclaimed, so `num_poll` still falls back to zero once the last poller leaves and the "does this thread poll at all?" tests behave as before. The enter/exit callback loops already null-check.

### Test

`core/poll_remove`, in the shape of the existing `core/doorbell_remove`: four pollers, retire the first and then the last, and check that the retired ones stop while the survivors keep running — plus a poller added after the removals, which lands on a tombstone. It identifies pollers by value rather than by a pointer into freed storage, so it fails as a plain counter mismatch in a Release build just as it does under AddressSanitizer.

Against the old `evpl_remove_poll()` it reports five failures:

```
ok:   all four pollers dispatched
ok:   the retired poller stopped
ok:   the other three still dispatch
FAIL: the second retired poller stopped
ok:   the first retired poller is still gone
FAIL: the survivors still dispatch
ok:   a poller added after the removals dispatches
FAIL: and the survivors are undisturbed
FAIL: and the retired ones stay retired
ok:   the third retired poller stopped
FAIL: the last two still dispatch
```

Full `ctest` on a Debug build is clean apart from `libevpl/io_uring/basic`, which fails on this host regardless of the change (io_uring is unavailable in the container).