### PR TITLE
core: a block backend that needs nothing but pread/pwrite

### DIFF
--- a/docs/api/block.md
+++ b/docs/api/block.md
@@ -17,7 +17,7 @@ libevpl's Block I/O subsystem offers:
 
 - **Asynchronous operations** - Read, write, and flush integrate with the event loop
 - **Zero-copy I/O** - Uses iovec-based scatter-gather
-- **Multiple backends** - io_uring and VFIO-NVMe for maximum performance
+- **Multiple backends** - io_uring and VFIO-NVMe for maximum performance, pread everywhere else
 - **High IOPS** - Optimized for NVMe SSDs (millions of IOPS)
 - **Per-thread queues** - Lock-free operation within event loops
 
@@ -52,6 +52,35 @@ libevpl's Block I/O subsystem offers:
 
 **Use cases:** Ultra-low latency storage, maximum IOPS, dedicated storage devices
 
+### libaio
+
+**Description:** Linux native asynchronous I/O (io_submit/io_getevents)
+
+**Availability:** Linux with libaio
+
+**Characteristics:**
+- Kernel-mediated I/O, completions delivered through an eventfd
+- Requires O_DIRECT; unaligned buffers are bounced through an aligned copy
+
+**Use cases:** Kernels or distributions without io_uring
+
+### pread
+
+**Description:** Blocking pread()/pwrite() on a service thread per device
+
+**Availability:** Everywhere -- it depends on nothing beyond POSIX
+
+**Characteristics:**
+- One dedicated thread per device services a single submission queue
+- Completions are posted back to the issuing thread's queue and delivered
+  through a doorbell, so callers never block
+- Requests are serviced one at a time: portability and correctness rather
+  than depth
+- Buffered I/O, so there are no alignment rules and nothing is ever bounced
+
+**Use cases:** macOS and any other platform with no asynchronous I/O facility;
+development and test on machines without io_uring, libaio or VFIO
+
 ## Types
 
 ### `struct evpl_block_device`
@@ -70,6 +99,8 @@ Identifies block device backend:
 |----------|-------------|
 | `EVPL_BLOCK_PROTOCOL_IO_URING` | Linux io_uring |
 | `EVPL_BLOCK_PROTOCOL_VFIO` | VFIO-NVMe direct access |
+| `EVPL_BLOCK_PROTOCOL_LIBAIO` | Linux native AIO |
+| `EVPL_BLOCK_PROTOCOL_PREAD` | Blocking pread/pwrite on a per-device thread |
 
 ### `evpl_block_callback_t`
 
@@ -287,15 +318,15 @@ For io_uring, performs a sync(), for VFIO-NVME performs an NVMe flush operation.
 
 ## Backend Comparison
 
-| Feature | io_uring | VFIO-NVMe |
-|---------|----------|-----------|
-| **Latency** | Low  | Ultra-low |
-| **IOPS** | Very High | Maximum |
-| **CPU Usage** | Low | Very Low |
-| **Setup** | Simple | Complex (device unbind) |
-| **Permissions** | Standard | Root or VFIO setup |
-| **Device Support** | All block devices | NVMe only |
-| **Kernel Dependency** | Yes | No (userspace) |
+| Feature | io_uring | VFIO-NVMe | pread |
+|---------|----------|-----------|-------|
+| **Latency** | Low  | Ultra-low | Moderate |
+| **IOPS** | Very High | Maximum | Low (one request in flight per device) |
+| **CPU Usage** | Low | Very Low | One thread per device |
+| **Setup** | Simple | Complex (device unbind) | Simple |
+| **Permissions** | Standard | Root or VFIO setup | Standard |
+| **Device Support** | All block devices | NVMe only | All block devices and files |
+| **Kernel Dependency** | Yes | No (userspace) | No (POSIX only) |
 
 ## Choosing a Backend
 
@@ -304,6 +335,11 @@ For io_uring, performs a sync(), for VFIO-NVME performs an NVMe flush operation.
 - You want simple setup and configuration
 - You're using standard filesystems or partitions
 - You need kernel features (filesystem, encryption, etc.)
+
+### Use pread when:
+- The platform has no asynchronous I/O facility at all (macOS)
+- io_uring, libaio and VFIO are all unavailable or undesirable
+- You want a backend with no alignment requirements
 
 ### Use VFIO-NVMe when:
 - You need absolute minimum latency
@@ -320,6 +356,9 @@ io_uring genereally requires page and block aligned I/O to allow DMA.
 
 VFIO-NVMe alignment dependency varies device to device. All NVMe devices require
 sector-aligned I/O, but many do not have any memory alignment requirement.
+
+pread imposes no alignment requirement of its own: it is buffered I/O, so any
+address and length work and no bounce buffer is ever taken.
 
 All else being equal, use page aligned memory when possible.
 

--- a/include/evpl/evpl_config.h
+++ b/include/evpl/evpl_config.h
@@ -237,6 +237,13 @@ void evpl_global_config_set_libaio_max_pending(
     struct evpl_global_config *config,
     unsigned int               max_pending);
 
+/* The pread block backend, which services a device from its own thread with
+ * blocking pread()/pwrite().  Enabled by default: it depends on nothing but
+ * POSIX, so unlike the other block backends it is always compiled in. */
+void evpl_global_config_set_pread_enabled(
+    struct evpl_global_config *config,
+    unsigned int               enabled);
+
 void evpl_global_config_set_hf_time_mode(
     struct evpl_global_config *config,
     unsigned int               mode);

--- a/include/evpl/evpl_core.h
+++ b/include/evpl/evpl_core.h
@@ -44,7 +44,8 @@ enum evpl_block_protocol_id {
     EVPL_BLOCK_PROTOCOL_VFIO          = 1,
     EVPL_BLOCK_PROTOCOL_LIBAIO        = 2,
     EVPL_BLOCK_PROTOCOL_IO_URING_NVME = 3,
-    EVPL_NUM_BLOCK_PROTOCOL           = 4
+    EVPL_BLOCK_PROTOCOL_PREAD         = 4,
+    EVPL_NUM_BLOCK_PROTOCOL           = 5
 };
 
 struct evpl;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -53,6 +53,12 @@ add_subdirectory(socket)
 set(CORE_SRC ${CORE_SRC} inproc/inproc.c inproc/inproc.h)
 add_subdirectory(inproc)
 
+# Block I/O over plain pread()/pwrite() on a per-device service thread.  Needs
+# no kernel async facility either, so it is the block backend that exists
+# everywhere -- notably macOS, which has nothing io_uring/libaio-shaped.
+set(CORE_SRC ${CORE_SRC} pread/pread_block.c pread/pread.h)
+add_subdirectory(pread)
+
 # TLS is available wherever OpenSSL is (HAVE_TLS is set at the top level).  Its
 # kTLS zero-copy path is Linux-only; on other platforms BIO_get_ktls_*() simply
 # reports unavailable and the normal SSL_read/SSL_write path is used.

--- a/src/core/block.c
+++ b/src/core/block.c
@@ -119,10 +119,17 @@ evpl_block_open_device(
         return NULL;
     }
 
-    evpl_attach_framework_shared(protocol->framework->id);
+    /* A block protocol needs a framework only if it has process-wide or
+     * per-thread state to stand up; the pread backend keeps everything on the
+     * device and queue it owns, so its framework pointer is NULL. */
+    if (protocol->framework) {
+        evpl_attach_framework_shared(protocol->framework->id);
 
-    protocol_private_data = evpl_shared->framework_private[protocol->framework->
-                                                           id];
+        protocol_private_data = evpl_shared->framework_private[protocol->
+                                                               framework->id];
+    } else {
+        protocol_private_data = NULL;
+    }
 
     blockdev = protocol->open_device(uri, protocol_private_data);
 
@@ -191,7 +198,9 @@ evpl_block_open_queue(
 {
     struct evpl_block_queue *queue;
 
-    evpl_attach_framework(evpl, blockdev->protocol->framework->id);
+    if (blockdev->protocol->framework) {
+        evpl_attach_framework(evpl, blockdev->protocol->framework->id);
+    }
 
     queue = blockdev->open_queue(evpl, blockdev);
 

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -76,6 +76,8 @@ evpl_global_config_init(void)
     config->libaio_enabled     = 1;
     config->libaio_max_pending = 256;
 
+    config->pread_enabled = 1;
+
     config->preallocate_slabs   = 0;
     config->preallocate_threads = 0;
 
@@ -548,6 +550,14 @@ evpl_global_config_set_libaio_max_pending(
 {
     config->libaio_max_pending = max_pending;
 } /* evpl_global_config_set_libaio_max_pending */
+
+SYMBOL_EXPORT void
+evpl_global_config_set_pread_enabled(
+    struct evpl_global_config *config,
+    unsigned int               enabled)
+{
+    config->pread_enabled = enabled;
+} /* evpl_global_config_set_pread_enabled */
 
 SYMBOL_EXPORT void
 evpl_global_config_set_hf_time_mode(

--- a/src/core/evpl.c
+++ b/src/core/evpl.c
@@ -59,6 +59,8 @@
 #include "libaio/libaio.h"
 #endif /* ifdef HAVE_LIBAIO */
 
+#include "pread/pread.h"
+
 #include "socket/udp.h"
 #include "socket/tcp.h"
 #include "socket/tcp_rdma.h"
@@ -217,6 +219,15 @@ evpl_shared_init(struct evpl_global_config *config)
 
     evpl_protocol_init(evpl_shared, EVPL_DATAGRAM_INPROC,
                        &evpl_inproc_datagram);
+
+    /* Block I/O over blocking pread()/pwrite() on a per-device thread.  Needs
+     * no kernel async facility, so like the socket protocols it is always
+     * present rather than gated on a build option -- it is the only block
+     * backend on platforms without io_uring or libaio. */
+    if (config->pread_enabled) {
+        evpl_block_protocol_init(evpl_shared, EVPL_BLOCK_PROTOCOL_PREAD,
+                                 &evpl_block_protocol_pread);
+    }
 
 #ifdef HAVE_IO_URING
     if (config->io_uring_enabled) {

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -100,6 +100,8 @@ struct evpl_global_config {
     unsigned int              libaio_enabled;
     unsigned int              libaio_max_pending;
 
+    unsigned int              pread_enabled;
+
     unsigned int              preallocate_slabs;
     unsigned int              preallocate_threads;
 

--- a/src/core/pread/CMakeLists.txt
+++ b/src/core/pread/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Ben Jarvis
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/core/pread/pread.h
+++ b/src/core/pread/pread.h
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+extern struct evpl_block_protocol evpl_block_protocol_pread;

--- a/src/core/pread/pread_block.c
+++ b/src/core/pread/pread_block.c
@@ -1,0 +1,696 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Block backend built on plain pread()/pwrite().
+ *
+ * The other block backends hand the kernel an asynchronous submission
+ * interface -- io_uring, libaio, a VFIO-mapped NVMe queue pair -- and are
+ * therefore Linux-only.  macOS has no equivalent: POSIX AIO exists but caps
+ * in-flight requests per process and cannot deliver completions to kqueue,
+ * and libdispatch's dispatch_io is itself a thread pool.  So rather than
+ * chase a kernel facility that is not there, this backend builds the
+ * asynchrony itself.
+ *
+ * Each device gets one dedicated thread.  Callers on any number of evpl
+ * threads push requests onto the device's single submission queue; the device
+ * thread pops them in order and services each one with ordinary blocking
+ * pread()/pwrite()/fsync() calls, then posts the finished request back to the
+ * completion queue of the evpl thread that issued it and rings that thread's
+ * doorbell.  The issuing thread never blocks, so from the caller's side this
+ * looks exactly like the async backends: submit, return to the event loop,
+ * get a callback.
+ *
+ * Serving requests one at a time is deliberate.  The point of this backend is
+ * portability and correctness on platforms with no async I/O, not peak IOPS;
+ * a device that wants depth should use io_uring.  What it does buy, besides
+ * running anywhere POSIX does, is that buffered I/O has no alignment rules,
+ * so unlike the O_DIRECT backends nothing is ever bounced through a
+ * temporary aligned buffer.
+ *
+ * Threading contract:
+ *   - a queue belongs to the evpl thread that opened it, and only that
+ *     thread may submit on it or close it
+ *   - every request on a queue must have completed before the queue is
+ *     closed, and every queue must be closed before the device is
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#ifdef __linux__
+#include <linux/fs.h>
+#endif /* ifdef __linux__ */
+
+#ifdef __APPLE__
+#include <sys/disk.h>
+#endif /* ifdef __APPLE__ */
+
+#include "core/evpl.h"
+#include "core/logging.h"
+#include "core/macros.h"
+#include "core/protocol.h"
+#include "core/pthread_util.h"
+#include "core/pread/pread.h"
+
+#define evpl_pread_debug(...) evpl_debug("pread", __FILE__, __LINE__, __VA_ARGS__)
+#define evpl_pread_info(...)  evpl_info("pread", __FILE__, __LINE__, __VA_ARGS__)
+#define evpl_pread_error(...) evpl_error("pread", __FILE__, __LINE__, __VA_ARGS__)
+
+#define evpl_pread_abort_if(cond, ...) \
+        evpl_abort_if(cond, "pread", __FILE__, __LINE__, __VA_ARGS__)
+
+/* Requests below this many segments carry their iovec array inline, which
+ * covers everything the callers issue in practice; larger ones allocate. */
+#define EVPL_PREAD_INLINE_IOV  8
+
+#define EVPL_PREAD_MAX_REQUEST (4 * 1024 * 1024)
+
+enum evpl_pread_opcode {
+    EVPL_PREAD_READ = 0,
+    EVPL_PREAD_WRITE,
+    EVPL_PREAD_FLUSH,
+};
+
+struct evpl_pread_queue;
+
+struct evpl_pread_request {
+    struct evpl_pread_queue   *queue;
+    evpl_block_callback_t      callback;
+    void                      *private_data;
+    uint64_t                   offset;
+    unsigned int               opcode;
+    unsigned int               sync;
+    int                        status;
+    int                        niov;
+    struct iovec              *iov;
+    struct iovec               iov_inline[EVPL_PREAD_INLINE_IOV];
+    struct evpl_pread_request *next;
+};
+
+struct evpl_pread_device {
+    int                        fd;
+
+    pthread_t                  thread;
+    int                        thread_started;
+
+    /* Submission queue, in FIFO order.  Written by any submitting thread,
+     * drained by the device thread; both under lock. */
+    pthread_mutex_t            lock;
+    pthread_cond_t             cond;
+    struct evpl_pread_request *submitted;
+    struct evpl_pread_request *submitted_tail;
+    int                        shutdown;
+};
+
+struct evpl_pread_queue {
+    /* First member: the core hands back a struct evpl_block_queue *, and the
+     * queue callbacks recover this from it. */
+    struct evpl_block_queue    base;
+
+    struct evpl_pread_device  *device;
+    struct evpl_doorbell       doorbell;
+
+    /* Completion queue.  Appended by the device thread, drained by the
+     * owning evpl thread out of the doorbell callback. */
+    pthread_mutex_t            lock;
+    struct evpl_pread_request *completed;
+    struct evpl_pread_request *completed_tail;
+
+    /* Set while a doorbell ring is outstanding, so a run of completions
+     * costs one wakeup rather than one per request.  Guarded by lock.
+     */
+    int                        notified;
+
+    /* Owning-thread-only state: a freelist of retired requests, and the
+     * number of requests that have been submitted but whose callbacks have
+     * not yet run. */
+    struct evpl_pread_request *free_requests;
+    uint64_t                   outstanding;
+};
+
+static inline struct evpl_pread_queue *
+evpl_pread_queue(struct evpl_block_queue *queue)
+{
+    return (struct evpl_pread_queue *) queue;
+} /* evpl_pread_queue */
+
+static struct evpl_pread_request *
+evpl_pread_request_alloc(
+    struct evpl_pread_queue *pq,
+    int                      niov)
+{
+    struct evpl_pread_request *req = pq->free_requests;
+
+    if (req) {
+        pq->free_requests = req->next;
+    } else {
+        req = evpl_zalloc(sizeof(*req));
+    }
+
+    req->queue = pq;
+    req->niov  = niov;
+    req->next  = NULL;
+
+    if (niov > EVPL_PREAD_INLINE_IOV) {
+        req->iov = evpl_malloc(niov * sizeof(struct iovec));
+    } else {
+        req->iov = req->iov_inline;
+    }
+
+    return req;
+} /* evpl_pread_request_alloc */
+
+static void
+evpl_pread_request_free(
+    struct evpl_pread_queue   *pq,
+    struct evpl_pread_request *req)
+{
+    if (req->iov != req->iov_inline) {
+        evpl_free(req->iov);
+        req->iov = req->iov_inline;
+    }
+
+    req->next         = pq->free_requests;
+    pq->free_requests = req;
+} /* evpl_pread_request_free */
+
+/*
+ * Transfer one request's iovec array with ordinary pread()/pwrite() calls.
+ *
+ * Returns 0, or a positive errno.  A transfer that ends short of what was
+ * asked for -- a read that runs off the end of the device, a write the
+ * filesystem could not take in full -- reports EIO, matching what the libaio
+ * and io_uring backends report when their result is shorter than the request.
+ */
+static int
+evpl_pread_transfer(
+    int                        fd,
+    struct evpl_pread_request *req,
+    int                        is_write)
+{
+    uint64_t offset = req->offset;
+    ssize_t  len;
+    char    *base;
+    size_t   left;
+    int      i;
+
+    for (i = 0; i < req->niov; i++) {
+        base = req->iov[i].iov_base;
+        left = req->iov[i].iov_len;
+
+        while (left) {
+            if (is_write) {
+                len = pwrite(fd, base, left, offset);
+            } else {
+                len = pread(fd, base, left, offset);
+            }
+
+            if (len < 0) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                return errno;
+            }
+
+            if (len == 0) {
+                /* End of device with bytes still owed. */
+                return EIO;
+            }
+
+            base   += len;
+            left   -= len;
+            offset += len;
+        }
+    }
+
+    return 0;
+} /* evpl_pread_transfer */
+
+static int
+evpl_pread_sync(int fd)
+{
+    int rc;
+
+    do {
+#ifdef __linux__
+        rc = fdatasync(fd);
+#else  /* ifdef __linux__ */
+        /* macOS has fdatasync but it is a plain fsync underneath, and fsync
+         * there does not push the drive's write cache.  Durability on a real
+         * disk needs F_FULLFSYNC; fall back to fsync where the fcntl is not
+         * supported (it fails with ENOTTY on some filesystems). */
+        rc = fcntl(fd, F_FULLFSYNC);
+
+        if (rc < 0 && (errno == ENOTTY || errno == EINVAL ||
+                       errno == ENOTSUP)) {
+            rc = fsync(fd);
+        }
+#endif /* ifdef __linux__ */
+    } while (rc < 0 && errno == EINTR);
+
+    return rc < 0 ? errno : 0;
+} /* evpl_pread_sync */
+
+/*
+ * Post a finished request back to the thread that issued it.
+ *
+ * Runs on the device thread.  The doorbell is only rung when no ring is
+ * already outstanding: notified is cleared under the same lock the drain
+ * takes, so a completion appended after the drain always finds it clear and
+ * rings, and one appended before is picked up by the drain in progress.
+ */
+static void
+evpl_pread_post(struct evpl_pread_request *req)
+{
+    struct evpl_pread_queue *pq = req->queue;
+    int                      ring;
+
+    pthread_mutex_lock(&pq->lock);
+
+    req->next = NULL;
+
+    if (pq->completed_tail) {
+        pq->completed_tail->next = req;
+    } else {
+        pq->completed = req;
+    }
+
+    pq->completed_tail = req;
+
+    ring = !pq->notified;
+
+    pq->notified = 1;
+
+    pthread_mutex_unlock(&pq->lock);
+
+    if (ring) {
+        evpl_ring_doorbell(&pq->doorbell);
+    }
+} /* evpl_pread_post */
+
+static void *
+evpl_pread_device_thread(void *arg)
+{
+    struct evpl_pread_device  *dev = arg;
+    struct evpl_pread_request *req;
+
+    pthread_mutex_lock(&dev->lock);
+
+    for ( ; ;) {
+
+        while (!dev->submitted && !dev->shutdown) {
+            pthread_cond_wait(&dev->cond, &dev->lock);
+        }
+
+        /* Shut down only once the queue is drained, so nothing submitted is
+         * ever dropped without a completion. */
+        if (!dev->submitted) {
+            break;
+        }
+
+        req            = dev->submitted;
+        dev->submitted = req->next;
+
+        if (!dev->submitted) {
+            dev->submitted_tail = NULL;
+        }
+
+        pthread_mutex_unlock(&dev->lock);
+
+        switch (req->opcode) {
+            case EVPL_PREAD_READ:
+                req->status = evpl_pread_transfer(dev->fd, req, 0);
+                break;
+            case EVPL_PREAD_WRITE:
+                req->status = evpl_pread_transfer(dev->fd, req, 1);
+
+                if (!req->status && req->sync) {
+                    req->status = evpl_pread_sync(dev->fd);
+                }
+                break;
+            case EVPL_PREAD_FLUSH:
+                req->status = evpl_pread_sync(dev->fd);
+                break;
+        } /* switch */
+
+        evpl_pread_post(req);
+
+        pthread_mutex_lock(&dev->lock);
+    }
+
+    pthread_mutex_unlock(&dev->lock);
+
+    return NULL;
+} /* evpl_pread_device_thread */
+
+static void
+evpl_pread_submit(
+    struct evpl_pread_queue   *pq,
+    struct evpl_pread_request *req)
+{
+    struct evpl_pread_device *dev = pq->device;
+
+    pq->outstanding++;
+
+    pthread_mutex_lock(&dev->lock);
+
+    if (dev->submitted_tail) {
+        dev->submitted_tail->next = req;
+    } else {
+        dev->submitted = req;
+    }
+
+    dev->submitted_tail = req;
+
+    pthread_cond_signal(&dev->cond);
+
+    pthread_mutex_unlock(&dev->lock);
+} /* evpl_pread_submit */
+
+/*
+ * Drain this thread's completion queue.  The whole list is taken in one
+ * lock/unlock so callbacks -- which routinely issue the next request -- run
+ * outside the lock the device thread needs to post into it.
+ */
+static void
+evpl_pread_doorbell(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct evpl_pread_queue   *pq = container_of(doorbell, struct evpl_pread_queue, doorbell);
+    struct evpl_pread_request *req, *next;
+    evpl_block_callback_t      callback;
+    void                      *private_data;
+    int                        status;
+
+    pthread_mutex_lock(&pq->lock);
+
+    req = pq->completed;
+
+    pq->completed      = NULL;
+    pq->completed_tail = NULL;
+    pq->notified       = 0;
+
+    pthread_mutex_unlock(&pq->lock);
+
+    while (req) {
+        next = req->next;
+
+        /* Retire the request before calling back rather than after.  The last
+         * callback of a drain is entitled to close the queue -- nothing is
+         * outstanding by then -- so read everything out of the request and the
+         * queue first; both may be gone once the callback returns. */
+        callback     = req->callback;
+        private_data = req->private_data;
+        status       = req->status;
+
+        pq->outstanding--;
+
+        evpl_pread_request_free(pq, req);
+
+        callback(evpl, status, private_data);
+
+        req = next;
+    }
+
+    evpl_activity(evpl);
+} /* evpl_pread_doorbell */
+
+static void
+evpl_pread_read(
+    struct evpl *evpl,
+    struct evpl_block_queue *queue,
+    struct evpl_iovec *iov,
+    int niov,
+    uint64_t offset,
+    void ( *callback )(struct evpl *evpl, int status, void *private_data),
+    void *private_data)
+{
+    struct evpl_pread_queue   *pq = evpl_pread_queue(queue);
+    struct evpl_pread_request *req;
+    int                        i;
+
+    req = evpl_pread_request_alloc(pq, niov);
+
+    req->callback     = callback;
+    req->private_data = private_data;
+    req->offset       = offset;
+    req->opcode       = EVPL_PREAD_READ;
+    req->sync         = 0;
+
+    for (i = 0; i < niov; i++) {
+        req->iov[i].iov_base = iov[i].data;
+        req->iov[i].iov_len  = iov[i].length;
+    }
+
+    evpl_pread_submit(pq, req);
+} /* evpl_pread_read */
+
+static void
+evpl_pread_write(
+    struct evpl *evpl,
+    struct evpl_block_queue *queue,
+    const struct evpl_iovec *iov,
+    int niov,
+    uint64_t offset,
+    int sync,
+    void ( *callback )(struct evpl *evpl, int status, void *private_data),
+    void *private_data)
+{
+    struct evpl_pread_queue   *pq = evpl_pread_queue(queue);
+    struct evpl_pread_request *req;
+    int                        i;
+
+    req = evpl_pread_request_alloc(pq, niov);
+
+    req->callback     = callback;
+    req->private_data = private_data;
+    req->offset       = offset;
+    req->opcode       = EVPL_PREAD_WRITE;
+    req->sync         = sync ? 1 : 0;
+
+    for (i = 0; i < niov; i++) {
+        req->iov[i].iov_base = iov[i].data;
+        req->iov[i].iov_len  = iov[i].length;
+    }
+
+    evpl_pread_submit(pq, req);
+} /* evpl_pread_write */
+
+static void
+evpl_pread_flush(
+    struct evpl *evpl,
+    struct evpl_block_queue *queue,
+    void ( *callback )(struct evpl *evpl, int status, void *private_data),
+    void *private_data)
+{
+    struct evpl_pread_queue   *pq = evpl_pread_queue(queue);
+    struct evpl_pread_request *req;
+
+    req = evpl_pread_request_alloc(pq, 0);
+
+    req->callback     = callback;
+    req->private_data = private_data;
+    req->offset       = 0;
+    req->opcode       = EVPL_PREAD_FLUSH;
+    req->sync         = 0;
+
+    evpl_pread_submit(pq, req);
+} /* evpl_pread_flush */
+
+static void
+evpl_pread_close_queue(
+    struct evpl             *evpl,
+    struct evpl_block_queue *queue)
+{
+    struct evpl_pread_queue   *pq = evpl_pread_queue(queue);
+    struct evpl_pread_request *req;
+
+    /* A request still in flight holds a pointer to this queue, and the device
+     * thread would post its completion into memory about to be freed.  That
+     * is a caller error rather than something to paper over: wait for the
+     * callbacks before closing. */
+    evpl_pread_abort_if(pq->outstanding,
+                        "block queue closed with %lu request(s) still outstanding",
+                        (unsigned long) pq->outstanding);
+
+    evpl_remove_doorbell(evpl, &pq->doorbell);
+
+    while ((req = pq->free_requests)) {
+        pq->free_requests = req->next;
+        evpl_free(req);
+    }
+
+    pthread_mutex_destroy(&pq->lock);
+
+    evpl_free(pq);
+} /* evpl_pread_close_queue */
+
+static struct evpl_block_queue *
+evpl_pread_open_queue(
+    struct evpl              *evpl,
+    struct evpl_block_device *bdev)
+{
+    struct evpl_pread_queue *pq;
+
+    pq = evpl_zalloc(sizeof(*pq));
+
+    pq->device = bdev->private_data;
+
+    pthread_mutex_init(&pq->lock, NULL);
+
+    evpl_add_doorbell(evpl, &pq->doorbell, evpl_pread_doorbell);
+
+    pq->base.private_data = pq;
+    pq->base.close_queue  = evpl_pread_close_queue;
+    pq->base.read         = evpl_pread_read;
+    pq->base.write        = evpl_pread_write;
+    pq->base.flush        = evpl_pread_flush;
+
+    return &pq->base;
+} /* evpl_pread_open_queue */
+
+static void
+evpl_pread_close_device(struct evpl_block_device *bdev)
+{
+    struct evpl_pread_device *dev = bdev->private_data;
+
+    if (dev->thread_started) {
+        pthread_mutex_lock(&dev->lock);
+        dev->shutdown = 1;
+        pthread_cond_signal(&dev->cond);
+        pthread_mutex_unlock(&dev->lock);
+
+        pthread_join(dev->thread, NULL);
+    }
+
+    pthread_cond_destroy(&dev->cond);
+    pthread_mutex_destroy(&dev->lock);
+
+    close(dev->fd);
+
+    evpl_free(dev);
+    evpl_free(bdev);
+} /* evpl_pread_close_device */
+
+/*
+ * Size of the thing behind the fd.  A regular file is its own length; a raw
+ * disk has to be asked, and the two platforms ask differently.
+ */
+static int
+evpl_pread_device_size(
+    int          fd,
+    struct stat *st,
+    uint64_t    *sizep)
+{
+    if (S_ISREG(st->st_mode)) {
+        *sizep = st->st_size;
+        return 0;
+    }
+
+#ifdef __linux__
+    if (S_ISBLK(st->st_mode)) {
+        uint64_t bytes;
+
+        if (ioctl(fd, BLKGETSIZE64, &bytes) < 0) {
+            return -1;
+        }
+
+        *sizep = bytes;
+        return 0;
+    }
+#endif /* ifdef __linux__ */
+
+#ifdef __APPLE__
+    if (S_ISBLK(st->st_mode) || S_ISCHR(st->st_mode)) {
+        uint64_t blocks;
+        uint32_t block_size;
+
+        if (ioctl(fd, DKIOCGETBLOCKCOUNT, &blocks) < 0 ||
+            ioctl(fd, DKIOCGETBLOCKSIZE, &block_size) < 0) {
+            return -1;
+        }
+
+        *sizep = blocks * block_size;
+        return 0;
+    }
+#endif /* ifdef __APPLE__ */
+
+    /* A fifo, a socket, a directory: nothing that can be addressed by offset. */
+    errno = ENOTSUP;
+
+    return -1;
+} /* evpl_pread_device_size */
+
+static struct evpl_block_device *
+evpl_pread_open_device(
+    const char *uri,
+    void       *private_data)
+{
+    struct evpl_block_device *bdev;
+    struct evpl_pread_device *dev;
+    struct stat               st;
+    int                       rc;
+
+    bdev = evpl_zalloc(sizeof(*bdev));
+    dev  = evpl_zalloc(sizeof(*dev));
+
+    dev->fd = open(uri, O_RDWR);
+
+    if (dev->fd < 0) {
+        evpl_pread_error("failed to open %s: %s", uri, strerror(errno));
+        evpl_free(dev);
+        evpl_free(bdev);
+        return NULL;
+    }
+
+    if (fstat(dev->fd, &st) < 0 ||
+        evpl_pread_device_size(dev->fd, &st, &bdev->size) < 0) {
+        evpl_pread_error("failed to size %s: %s", uri, strerror(errno));
+        close(dev->fd);
+        evpl_free(dev);
+        evpl_free(bdev);
+        return NULL;
+    }
+
+    pthread_mutex_init(&dev->lock, NULL);
+    pthread_cond_init(&dev->cond, NULL);
+
+    rc = evpl_pthread_create(&dev->thread, NULL, evpl_pread_device_thread, dev);
+
+    if (rc) {
+        evpl_pread_error("failed to start device thread for %s: %s",
+                         uri, strerror(rc));
+        pthread_cond_destroy(&dev->cond);
+        pthread_mutex_destroy(&dev->lock);
+        close(dev->fd);
+        evpl_free(dev);
+        evpl_free(bdev);
+        return NULL;
+    }
+
+    dev->thread_started = 1;
+
+    bdev->private_data     = dev;
+    bdev->open_queue       = evpl_pread_open_queue;
+    bdev->close_device     = evpl_pread_close_device;
+    bdev->max_request_size = EVPL_PREAD_MAX_REQUEST;
+
+    return bdev;
+} /* evpl_pread_open_device */
+
+struct evpl_block_protocol evpl_block_protocol_pread = {
+    .id          = EVPL_BLOCK_PROTOCOL_PREAD,
+    .name        = "pread",
+    .framework   = NULL,
+    .open_device = evpl_pread_open_device,
+};

--- a/src/core/pread/tests/CMakeLists.txt
+++ b/src/core/pread/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Ben Jarvis
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+unit_test(pread basic basic.c)
+unit_test(pread threads threads.c)

--- a/src/core/pread/tests/basic.c
+++ b/src/core/pread/tests/basic.c
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Round-trip the pread block backend on a single thread: sized correctly,
+ * writes land where they were addressed, reads bring back what was written,
+ * and the core's write_zeroes emulation reaches the device.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "core/test_log.h"
+#include "evpl/evpl.h"
+#include "tests/test_common.h"
+
+#define DEVICE_PATH "pread_basic.img"
+#define DEVICE_SIZE (16 * 1024 * 1024)
+#define CHUNK       4096
+#define TEST_OFFSET (1024 * 1024)
+
+static void
+block_callback(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    int *pending = private_data;
+
+    evpl_test_abort_if(status, "block operation failed: %d", status);
+
+    (*pending)--;
+} /* block_callback */
+
+static void
+run_until_idle(
+    struct evpl *evpl,
+    int         *pending)
+{
+    while (*pending) {
+        evpl_continue(evpl);
+    }
+} /* run_until_idle */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct evpl              *evpl;
+    struct evpl_block_device *bdev;
+    struct evpl_block_queue  *queue;
+    struct evpl_iovec         wiov[2], riov[2];
+    int                       fd, rc, i, pending = 0;
+
+    test_evpl_config();
+
+    fd = open(DEVICE_PATH, O_RDWR | O_CREAT | O_TRUNC, 0644);
+
+    evpl_test_abort_if(fd < 0, "failed to create " DEVICE_PATH);
+
+    rc = ftruncate(fd, DEVICE_SIZE);
+
+    evpl_test_abort_if(rc < 0, "failed to size " DEVICE_PATH);
+
+    close(fd);
+
+    evpl = evpl_create(NULL);
+
+    bdev = evpl_block_open_device(EVPL_BLOCK_PROTOCOL_PREAD, DEVICE_PATH);
+
+    evpl_test_abort_if(!bdev, "failed to open pread device");
+
+    evpl_test_abort_if(evpl_block_size(bdev) != DEVICE_SIZE,
+                       "device size %lu, expected %u",
+                       evpl_block_size(bdev), DEVICE_SIZE);
+
+    evpl_test_abort_if(evpl_block_max_request_size(bdev) == 0,
+                       "device reports a zero maximum request size");
+
+    queue = evpl_block_open_queue(evpl, bdev);
+
+    /* Two segments, each with its own byte pattern, so a backend that lost
+     * track of where one iovec ended and the next began would be caught.
+     */
+    for (i = 0; i < 2; i++) {
+        evpl_iovec_alloc(evpl, CHUNK, 4096, 1, 0, &wiov[i]);
+        memset(wiov[i].data, 'a' + i, CHUNK);
+
+        evpl_iovec_alloc(evpl, CHUNK, 4096, 1, 0, &riov[i]);
+        memset(riov[i].data, 0, CHUNK);
+    }
+
+    pending++;
+    evpl_block_write(evpl, queue, wiov, 2, TEST_OFFSET, 1,
+                     block_callback, &pending);
+
+    run_until_idle(evpl, &pending);
+
+    pending++;
+    evpl_block_flush(evpl, queue, block_callback, &pending);
+
+    run_until_idle(evpl, &pending);
+
+    pending++;
+    evpl_block_read(evpl, queue, riov, 2, TEST_OFFSET,
+                    block_callback, &pending);
+
+    run_until_idle(evpl, &pending);
+
+    for (i = 0; i < 2; i++) {
+        evpl_test_abort_if(memcmp(riov[i].data, wiov[i].data, CHUNK),
+                           "segment %d did not read back what was written", i);
+    }
+
+    /* Emulated in the core as ordinary writes, so this also proves the
+     * backend handles a chain of requests issued from its own callbacks. */
+    pending++;
+    evpl_block_write_zeroes(evpl, queue, TEST_OFFSET, 2 * CHUNK,
+                            block_callback, &pending);
+
+    run_until_idle(evpl, &pending);
+
+    pending++;
+    evpl_block_read(evpl, queue, riov, 2, TEST_OFFSET,
+                    block_callback, &pending);
+
+    run_until_idle(evpl, &pending);
+
+    for (i = 0; i < 2; i++) {
+        const char *bytes = riov[i].data;
+
+        evpl_test_abort_if(bytes[0] != 0 ||
+                           memcmp(bytes, bytes + 1, CHUNK - 1),
+                           "segment %d was not zeroed", i);
+    }
+
+    /* No native discard here, so the core answers it as a successful no-op. */
+    pending++;
+    evpl_block_discard(evpl, queue, TEST_OFFSET, 2 * CHUNK,
+                       block_callback, &pending);
+
+    run_until_idle(evpl, &pending);
+
+    for (i = 0; i < 2; i++) {
+        evpl_iovec_release(evpl, &wiov[i]);
+        evpl_iovec_release(evpl, &riov[i]);
+    }
+
+    evpl_block_close_queue(evpl, queue);
+    evpl_block_close_device(bdev);
+    evpl_destroy(evpl);
+
+    unlink(DEVICE_PATH);
+
+    return 0;
+} /* main */

--- a/src/core/pread/tests/threads.c
+++ b/src/core/pread/tests/threads.c
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * One device, several evpl threads.
+ *
+ * The pread backend funnels every queue into a single per-device service
+ * thread and hands each completion back to the thread that issued it, so what
+ * matters here is that the routing is right: each worker owns a disjoint
+ * region and a pattern derived from its own index, and verifies its reads
+ * against it.  A completion delivered to the wrong thread, or a request
+ * serviced against the wrong queue, shows up as a pattern mismatch rather
+ * than as a hang.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "core/test_log.h"
+#include "evpl/evpl.h"
+#include "tests/test_common.h"
+
+#define DEVICE_PATH "pread_threads.img"
+#define DEVICE_SIZE (16 * 1024 * 1024)
+#define NUM_WORKERS 4
+#define CHUNK       (64 * 1024)
+#define NUM_ROUNDS  16
+#define REGION      (NUM_ROUNDS * CHUNK)
+
+struct shared_state {
+    struct evpl_block_device *bdev;
+    int                       next_index;
+    int                       finished;
+};
+
+struct worker {
+    struct shared_state     *shared;
+    struct evpl_block_queue *queue;
+    struct evpl_iovec        wiov;
+    struct evpl_iovec        riov;
+    uint64_t                 base;
+    int                      index;
+    int                      round;
+    int                      reading;
+};
+
+static char
+worker_pattern(
+    int index,
+    int round)
+{
+    return (char) (index * 37 + round * 11 + 1);
+} /* worker_pattern */
+
+static void
+worker_issue(
+    struct evpl   *evpl,
+    struct worker *w);
+
+static void
+worker_callback(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct worker       *w     = private_data;
+    const unsigned char *bytes = w->riov.data;
+    unsigned char        expect;
+
+    evpl_test_abort_if(status, "worker %d round %d failed: %d",
+                       w->index, w->round, status);
+
+    if (!w->reading) {
+        w->reading = 1;
+
+        memset(w->riov.data, 0, CHUNK);
+
+        evpl_block_read(evpl, w->queue, &w->riov, 1,
+                        w->base + (uint64_t) w->round * CHUNK,
+                        worker_callback, w);
+        return;
+    }
+
+    expect = (unsigned char) worker_pattern(w->index, w->round);
+
+    evpl_test_abort_if(memcmp(w->riov.data, w->wiov.data, CHUNK),
+                       "worker %d round %d read back 0x%02x, expected 0x%02x",
+                       w->index, w->round, bytes[0], expect);
+
+    w->round++;
+    w->reading = 0;
+
+    if (w->round == NUM_ROUNDS) {
+        __atomic_add_fetch(&w->shared->finished, 1, __ATOMIC_RELEASE);
+        return;
+    }
+
+    worker_issue(evpl, w);
+} /* worker_callback */
+
+static void
+worker_issue(
+    struct evpl   *evpl,
+    struct worker *w)
+{
+    memset(w->wiov.data, worker_pattern(w->index, w->round), CHUNK);
+
+    evpl_block_write(evpl, w->queue, &w->wiov, 1,
+                     w->base + (uint64_t) w->round * CHUNK, 0,
+                     worker_callback, w);
+} /* worker_issue */
+
+static void *
+worker_init(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct shared_state *shared = private_data;
+    struct worker       *w;
+
+    w = calloc(1, sizeof(*w));
+
+    w->shared = shared;
+    w->index  = __atomic_fetch_add(&shared->next_index, 1, __ATOMIC_RELAXED);
+    w->base   = (uint64_t) w->index * REGION;
+    w->queue  = evpl_block_open_queue(evpl, shared->bdev);
+
+    evpl_iovec_alloc(evpl, CHUNK, 4096, 1, 0, &w->wiov);
+    evpl_iovec_alloc(evpl, CHUNK, 4096, 1, 0, &w->riov);
+
+    worker_issue(evpl, w);
+
+    return w;
+} /* worker_init */
+
+static void
+worker_shutdown(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct worker *w = private_data;
+
+    evpl_test_abort_if(w->round != NUM_ROUNDS,
+                       "worker %d shut down after %d of %d rounds",
+                       w->index, w->round, NUM_ROUNDS);
+
+    evpl_iovec_release(evpl, &w->wiov);
+    evpl_iovec_release(evpl, &w->riov);
+
+    evpl_block_close_queue(evpl, w->queue);
+
+    free(w);
+} /* worker_shutdown */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct shared_state     shared;
+    struct evpl_threadpool *pool;
+    int                     fd, rc;
+
+    test_evpl_config();
+
+    fd = open(DEVICE_PATH, O_RDWR | O_CREAT | O_TRUNC, 0644);
+
+    evpl_test_abort_if(fd < 0, "failed to create " DEVICE_PATH);
+
+    rc = ftruncate(fd, DEVICE_SIZE);
+
+    evpl_test_abort_if(rc < 0, "failed to size " DEVICE_PATH);
+
+    close(fd);
+
+    memset(&shared, 0, sizeof(shared));
+
+    shared.bdev = evpl_block_open_device(EVPL_BLOCK_PROTOCOL_PREAD,
+                                         DEVICE_PATH);
+
+    evpl_test_abort_if(!shared.bdev, "failed to open pread device");
+
+    pool = evpl_threadpool_create(NULL, NUM_WORKERS, worker_init,
+                                  worker_shutdown, &shared);
+
+    /* The workers drive themselves from their own completions; wait for the
+     * last one rather than for any particular amount of time.  A worker that
+     * never completes hangs here and is caught by the ctest timeout. */
+    while (__atomic_load_n(&shared.finished, __ATOMIC_ACQUIRE) < NUM_WORKERS) {
+        usleep(1000);
+    }
+
+    evpl_threadpool_destroy(pool);
+
+    evpl_block_close_device(shared.bdev);
+
+    unlink(DEVICE_PATH);
+
+    return 0;
+} /* main */


### PR DESCRIPTION
Every block backend so far hands the kernel an asynchronous submission interface -- io_uring, libaio, a VFIO-mapped NVMe queue pair -- and all three are Linux-only. macOS has nothing equivalent to reach for: POSIX AIO exists but caps in-flight requests per process and its `sigevent` cannot notify kqueue, and libdispatch's `dispatch_io` is itself a thread pool. A block device therefore could not be opened there at all, which is what keeps diskfs -- and everything layered on it -- off the platform.

This builds the asynchrony instead of chasing a kernel facility that is not there.

## Shape

Each device gets one dedicated thread and a single submission queue. Callers on any number of evpl threads push requests onto it; the device thread services each with ordinary blocking `pread()`/`pwrite()`/`fsync()`, then posts the finished request onto the completion queue of the thread that issued it and rings that thread's doorbell. Submitters never block, so from the caller's side this is the same submit-and-get-a-callback shape the async backends present.

Requests are serviced one at a time deliberately: the point is portability, not depth -- a device that wants queue depth should use io_uring. What it buys beyond running anywhere POSIX does is that buffered I/O has no alignment rules, so unlike the O_DIRECT backends nothing is ever bounced through a temporary aligned buffer.

The doorbell is rung only when no ring is already outstanding, so a run of completions costs one wakeup rather than one per request. The flag saying so is cleared under the same lock the drain takes, which is what stops a completion from being appended and then missed.

## Status convention

Matches the existing backends: `0` on success, a positive errno otherwise, `EIO` when a transfer ends short of what was asked for. A `sync` write is `pwrite` followed by `fdatasync` on Linux and `F_FULLFSYNC` on Darwin (falling back to `fsync` where the fcntl is unsupported), since a plain `fsync` there does not push the drive's write cache.

## Core change

This is the first block protocol with no framework behind it -- it has no process-wide or per-thread state to stand up, only the device and the queue it owns -- so `evpl_block_open_device`/`evpl_block_open_queue` stop assuming every block protocol has one.

## Contract

A queue belongs to the evpl thread that opened it, and only that thread may submit on it or close it. Every request on a queue must have completed before the queue is closed, and every queue must be closed before the device is; closing a queue with requests still outstanding aborts loudly rather than letting the device thread post into freed memory.

## Tests

`libevpl/pread/basic` round-trips multi-segment writes, reads, flush, the core's write_zeroes emulation and discard on one thread. `libevpl/pread/threads` runs four evpl threads against one device, each owning a disjoint region and a pattern derived from its own index, so a completion routed to the wrong thread shows up as a mismatch rather than a hang. Both pass under ASan.