### PR TITLE
core: model the block API, and the two defects that found

### DIFF
--- a/src/core/block.c
+++ b/src/core/block.c
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include <errno.h>
 #include <pthread.h>
 #include <time.h>
 #include <string.h>
@@ -446,9 +447,21 @@ evpl_block_write_zeroes(
 
     /* No native support: write a zero buffer through the ordinary write path,
      * chunked at the device's maximum request size.  The underlying writes
-     * carry their own op-tracking/metrics, so no block_op is taken here. */
+     * carry their own op-tracking/metrics, so no block_op is taken here.
+     *
+     * Also chunked at one buffer.  The zero chunk is a SINGLE iovec, and
+     * evpl_iovec_alloc places at most max_iovecs pieces: asked for more than
+     * one buffer's worth in one, it reports -1 and leaves the iovec
+     * untouched rather than handing back a short one.  Without this clamp a
+     * caller zeroing a range larger than a buffer -- entirely legal, and
+     * ordinary with the small buffer sizes tests configure -- would have
+     * dereferenced that untouched iovec. */
     chunk = (unsigned int) (length < queue->device->max_request_size ?
                             length : queue->device->max_request_size);
+
+    if (chunk > evpl_shared->config->buffer_size) {
+        chunk = evpl_shared->config->buffer_size;
+    }
 
     e               = evpl_zalloc(sizeof(*e));
     e->queue        = queue;
@@ -459,7 +472,14 @@ evpl_block_write_zeroes(
     e->callback     = callback;
     e->private_data = private_data;
 
-    evpl_iovec_alloc(evpl, chunk, 4096, 1, 0, &e->zero);
+    /* Belt and braces on the clamp above: a buffer that cannot be had at all
+     * is a failed request, not a null dereference. */
+    if (evpl_iovec_alloc(evpl, chunk, 4096, 1, 0, &e->zero) != 1) {
+        evpl_free(e);
+        callback(evpl, ENOMEM, private_data);
+        return;
+    }
+
     memset(e->zero.data, 0, chunk);
 
     evpl_block_wz_emul_step(evpl, e);

--- a/src/core/pread/pread_block.c
+++ b/src/core/pread/pread_block.c
@@ -421,8 +421,6 @@ evpl_pread_doorbell(
 
         req = next;
     }
-
-    evpl_activity(evpl);
 } /* evpl_pread_doorbell */
 
 static void

--- a/src/core/pread/tests/basic.c
+++ b/src/core/pread/tests/basic.c
@@ -13,12 +13,14 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 
 #include "core/test_log.h"
 #include "evpl/evpl.h"
 #include "tests/test_common.h"
 
 #define DEVICE_PATH "pread_basic.img"
+#define FIFO_PATH   "pread_basic.fifo"
 #define DEVICE_SIZE (16 * 1024 * 1024)
 #define CHUNK       4096
 #define TEST_OFFSET (1024 * 1024)
@@ -35,6 +37,20 @@ block_callback(
 
     (*pending)--;
 } /* block_callback */
+
+static void
+expect_failure(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    int *pending = private_data;
+
+    evpl_test_abort_if(!status,
+                       "a read running off the end of the device succeeded");
+
+    (*pending)--;
+} /* expect_failure */
 
 static void
 run_until_idle(
@@ -146,6 +162,16 @@ main(
 
     run_until_idle(evpl, &pending);
 
+    /* Past the end of the device.  A transfer that ends short of what was
+     * asked for is an error and not a short success -- the callback has no
+     * way to say "some of it", so a backend that reported success here would
+     * be telling the caller its buffer was filled. */
+    pending++;
+    evpl_block_read(evpl, queue, riov, 1, DEVICE_SIZE - CHUNK / 2,
+                    expect_failure, &pending);
+
+    run_until_idle(evpl, &pending);
+
     for (i = 0; i < 2; i++) {
         evpl_iovec_release(evpl, &wiov[i]);
         evpl_iovec_release(evpl, &riov[i]);
@@ -153,6 +179,24 @@ main(
 
     evpl_block_close_queue(evpl, queue);
     evpl_block_close_device(bdev);
+
+    /* A path that is not there at all, and one that is there but cannot be
+     * addressed by offset.  Both are ordinary operating conditions rather
+     * than programming errors, so both report failure instead of aborting --
+     * and neither may leave the device thread or the descriptor behind. */
+    evpl_test_abort_if(evpl_block_open_device(EVPL_BLOCK_PROTOCOL_PREAD,
+                                              "pread_basic_absent.img"),
+                       "opening a nonexistent path produced a device");
+
+    unlink(FIFO_PATH);
+
+    if (mkfifo(FIFO_PATH, 0644) == 0) {
+        evpl_test_abort_if(evpl_block_open_device(EVPL_BLOCK_PROTOCOL_PREAD,
+                                                  FIFO_PATH),
+                           "opening a fifo produced a device");
+        unlink(FIFO_PATH);
+    }
+
     evpl_destroy(evpl);
 
     unlink(DEVICE_PATH);

--- a/src/core/tests/core_conformance.c
+++ b/src/core/tests/core_conformance.c
@@ -41,6 +41,7 @@
  * anything else fails.
  */
 
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -128,6 +129,39 @@
 #define NUM_EVENT_KIND   CORE_NUM_EVENT_KIND
 
 /*
+ * Block I/O.  The model cuts the device into regions and addresses one whole
+ * region per data op, so these are the two numbers that have to agree with
+ * NUM_REGION and NUM_BLOCK_QUEUE over there.
+ *
+ * The backend is the pread one, unconditionally.  It is the only block
+ * backend present on every platform, and a conformance test of the block API
+ * wants the same programs to run everywhere; the backends with a kernel
+ * dependency keep their own tests.  EVPL_TEST_BLOCK_PROTOCOL overrides it by
+ * name, which is how the same programs can be pointed at io_uring or libaio
+ * on a host that has them.
+ */
+#define NUM_BLOCK_QUEUE  2
+#define NUM_REGION       4
+/* A whole region has to fit in one buffer: the driver allocates each segment
+ * as a single iovec, so that the model's segment count is exactly the
+ * request's iovec count.  CONF_BUFFER_SIZE is deliberately small (see there),
+ * and this is half of it -- which also makes the whole device two buffers,
+ * and so makes the write-zeroes emulation loop rather than finish in one
+ * chunk.  Checked against CONF_BUFFER_SIZE below, where it is defined. */
+#define REGION_BYTES     (16 * 1024)
+#define DEVICE_BYTES     ((uint64_t) NUM_REGION * REGION_BYTES)
+
+/* Segments a request may be scattered across -- BSeg16 is the largest the
+ * model generates, and is deliberately past the point where a backend with a
+ * small inline iovec array has to allocate one instead. */
+#define MAX_BLOCK_SEGS   16
+
+/* What a read buffer is filled with before it is submitted, so that a read
+ * which quietly returns without touching the buffer fails on content rather
+ * than passing on whatever was already there. */
+#define BLOCK_POISON     0xa5
+
+/*
  * Poll mode, as the driver configures it.
  *
  * poll_iterations is deliberately 1 rather than the default 1000.  The loop
@@ -158,6 +192,11 @@
  * test.
  */
 #define CONF_BUFFER_SIZE (32 * 1024)
+
+/* See REGION_BYTES: a block segment is one iovec, so the largest one the
+ * driver allocates must come out of a single buffer. */
+_Static_assert(REGION_BYTES <= CONF_BUFFER_SIZE,
+               "a block region must fit in one buffer");
 
 /* Must match core.qnt's SPIN_MS.  Set rather than assumed: the model's poll
  * transitions are computed against it. */
@@ -249,6 +288,21 @@ struct doorbell_slot {
     int                  remove_in_cb;
 };
 
+/*
+ * One block request in flight.  Allocated per submission and freed by its own
+ * completion, so a request that never completes leaks -- which is exactly
+ * what it is, and the model's obligation check reports it first.
+ */
+struct block_req {
+    struct prog_state *ps;
+    int                queue;
+    int                niov;
+    /* -1 when the model makes no claim about the bytes; otherwise the byte
+     * every one of them must be. */
+    int                pattern;
+    struct evpl_iovec  iov[MAX_BLOCK_SEGS];
+};
+
 /* What a notify callback needs to know about the end it was registered for.
  * A bind carries no slot of its own, so this is how a callback finds its way
  * back into the model's object space. */
@@ -279,6 +333,14 @@ struct prog_state {
     struct timer_slot             timers[MAX_SLOT];
     struct deferral_slot          deferrals[MAX_SLOT];
     struct doorbell_slot          doorbells[MAX_SLOT];
+
+    /* The program's block device and the queues opened on it.  The device is
+     * created fresh at the start of each program, so a region holds nothing
+     * anyone can predict until this program writes it -- which is what the
+     * model assumes. */
+    struct evpl_block_device     *bdev;
+    struct evpl_block_queue      *bqueue[NUM_BLOCK_QUEUE];
+    char                          device_path[128];
 
     struct evpl_listener         *listener;
     struct evpl_listener_binding *binding;
@@ -438,6 +500,15 @@ op_name(uint8_t op)
         case COP_OPSEND: return "Send";
         case COP_OPCLOSE: return "Close";
         case COP_OPFINISH: return "Finish";
+        case COP_OPOPENQUEUE: return "OpenQueue";
+        case COP_OPCLOSEQUEUE: return "CloseQueue";
+        case COP_OPBLOCKREAD: return "BlockRead";
+        case COP_OPBLOCKWRITE: return "BlockWrite";
+        case COP_OPBLOCKWRITESYNC: return "BlockWriteSync";
+        case COP_OPBLOCKFLUSH: return "BlockFlush";
+        case COP_OPBLOCKWRITEZEROES: return "BlockWriteZeroes";
+        case COP_OPBLOCKWRITEZEROESALL: return "BlockWriteZeroesAll";
+        case COP_OPBLOCKDISCARD: return "BlockDiscard";
         case COP_OPQUIESCE: return "Quiesce";
         default: return "?";
     } /* switch */
@@ -459,6 +530,7 @@ event_name(uint8_t kind)
         case CEV_EVRECVMSG: return "recv-messages";
         case CEV_EVSENT: return "sent-bytes";
         case CEV_EVHOOK: return "loop-hook";
+        case CEV_EVBLOCK: return "block-completion";
         default: return "?";
     } /* switch */
 } /* event_name */
@@ -1117,9 +1189,8 @@ do_quiesce(
     int                     stepno)
 {
     uint64_t target = ps->base_ns + (uint64_t) step->at_ms * TICK_NS;
-    int      i;
+    int      i, failures;
 
-    ps->window      = ps->nlog;
     ps->poll_logged = 0;
 
     memset(ps->hook_logged, 0, sizeof(ps->hook_logged));
@@ -1147,7 +1218,18 @@ do_quiesce(
 
     g_results.quiesces++;
 
-    return check_window(ps, step, prog, stepno);
+    failures = check_window(ps, step, prog, stepno);
+
+    /* The next window starts here rather than at the next quiesce.  Almost
+     * every callback arrives from inside the loop, so the two are usually the
+     * same point -- but not always: a block backend with no native discard
+     * answers evpl_block_discard() by calling back inline, before the
+     * submitting call has even returned.  Closing the window at the check
+     * rather than opening it at the next quiesce is what keeps a completion
+     * delivered that way inside the window that is owed it. */
+    ps->window = ps->nlog;
+
+    return failures;
 } /* do_quiesce */
 
 /* ------------------------------------------------------------------ */
@@ -1438,6 +1520,251 @@ do_send(
     cs->tx_off[dest] += len;
 } /* do_send */
 
+
+/*
+ * ---------------------------------------------------------------------------
+ * Block I/O
+ *
+ * The device is the program's, not any op's: it is created at the start and
+ * torn down at the end, so every program starts from a device whose contents
+ * nothing has any business predicting.  What the ops vary is the queues on it
+ * and the requests put through them.
+ * ---------------------------------------------------------------------------
+ */
+
+/* Which backend the programs run against.  Defaults to pread, which exists
+ * everywhere; the override is what lets the same programs be pointed at a
+ * kernel-backed one on a host that has it. */
+static enum evpl_block_protocol_id
+block_protocol(void)
+{
+    const char *name = getenv("EVPL_TEST_BLOCK_PROTOCOL");
+
+    if (!name || !*name || strcmp(name, "pread") == 0) {
+        return EVPL_BLOCK_PROTOCOL_PREAD;
+    }
+
+    if (strcmp(name, "io_uring") == 0) {
+        return EVPL_BLOCK_PROTOCOL_IO_URING;
+    }
+
+    if (strcmp(name, "libaio") == 0) {
+        return EVPL_BLOCK_PROTOCOL_LIBAIO;
+    }
+
+    evpl_test_abort("EVPL_TEST_BLOCK_PROTOCOL names no backend the driver "
+                    "knows: %s", name);
+    return EVPL_BLOCK_PROTOCOL_PREAD;
+} /* block_protocol */
+
+/*
+ * A fresh backing file per program, sized to hold every region.  Named by pid
+ * as well as by program so that concurrent instances -- one per core
+ * mechanism, and one per network namespace under netns testing -- cannot
+ * collide on it.
+ */
+static void
+block_device_open(
+    struct prog_state *ps,
+    int                prog)
+{
+    int fd;
+
+    snprintf(ps->device_path, sizeof(ps->device_path),
+             "core_conf_block-%d-%d.img", (int) getpid(), prog);
+
+    fd = open(ps->device_path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+
+    evpl_test_abort_if(fd < 0, "could not create %s", ps->device_path);
+    evpl_test_abort_if(ftruncate(fd, DEVICE_BYTES) < 0,
+                       "could not size %s", ps->device_path);
+    close(fd);
+
+    ps->bdev = evpl_block_open_device(block_protocol(), ps->device_path);
+
+    evpl_test_abort_if(!ps->bdev, "could not open %s as a block device",
+                       ps->device_path);
+
+    /* Both are pure functions of the device and neither has an ordering to
+     * get wrong, so they are checked here rather than modelled: a device that
+     * misreports its size would have every offset the model chose land
+     * somewhere else. */
+    evpl_test_abort_if(evpl_block_size(ps->bdev) != DEVICE_BYTES,
+                       "block device reports %lu bytes, expected %lu",
+                       (unsigned long) evpl_block_size(ps->bdev),
+                       (unsigned long) DEVICE_BYTES);
+
+    evpl_test_abort_if(evpl_block_max_request_size(ps->bdev) < REGION_BYTES,
+                       "block device takes at most %lu bytes per request, "
+                       "less than one region",
+                       (unsigned long) evpl_block_max_request_size(ps->bdev));
+} /* block_device_open */
+
+static void
+block_device_close(struct prog_state *ps)
+{
+    int q;
+
+    for (q = 0; q < NUM_BLOCK_QUEUE; q++) {
+        if (ps->bqueue[q]) {
+            evpl_block_close_queue(ps->evpl, ps->bqueue[q]);
+            ps->bqueue[q] = NULL;
+        }
+    }
+
+    if (ps->bdev) {
+        evpl_block_close_device(ps->bdev);
+        ps->bdev = NULL;
+    }
+
+    if (ps->device_path[0]) {
+        unlink(ps->device_path);
+        ps->device_path[0] = 0;
+    }
+} /* block_device_close */
+
+/*
+ * One completion.  Logged against the queue it was submitted on, which is
+ * what makes "delivered to the right queue" checkable at all, and -- for a
+ * read the model had a claim about -- checked byte by byte before the request
+ * is retired.
+ */
+static void
+block_complete(
+    struct evpl *evpl,
+    int          status,
+    void        *private_data)
+{
+    struct block_req  *req = private_data;
+    struct prog_state *ps  = req->ps;
+    int                i;
+
+    evpl_test_abort_if(status, "block request on queue %d failed: %d",
+                       req->queue, status);
+
+    if (req->pattern >= 0) {
+        for (i = 0; i < req->niov; i++) {
+            const unsigned char *p = req->iov[i].data;
+            unsigned int         n = req->iov[i].length, j;
+
+            for (j = 0; j < n; j++) {
+                evpl_test_abort_if(p[j] != (unsigned char) req->pattern,
+                                   "block read segment %d byte %u is 0x%02x, "
+                                   "expected 0x%02x", i, j, p[j],
+                                   (unsigned char) req->pattern);
+            }
+        }
+    }
+
+    for (i = 0; i < req->niov; i++) {
+        evpl_iovec_release(evpl, &req->iov[i]);
+    }
+
+    log_event(ps, CEV_EVBLOCK, req->queue, 1);
+
+    free(req);
+} /* block_complete */
+
+/* Everything a request has in common: an allocated record on an open queue,
+ * with its segments carved out and filled. */
+static struct block_req *
+block_req_alloc(
+    struct prog_state      *ps,
+    const struct core_step *step,
+    int                     nsegs,
+    int                     fill)
+{
+    struct block_req *req;
+    unsigned int      seglen = REGION_BYTES / nsegs;
+    int               i;
+
+    evpl_test_abort_if(!ps->bqueue[step->queue],
+                       "block op on queue %d, which is not open", step->queue);
+
+    req = calloc(1, sizeof(*req));
+    evpl_test_abort_if(!req, "out of memory");
+
+    req->ps      = ps;
+    req->queue   = step->queue;
+    req->niov    = nsegs;
+    req->pattern = -1;
+
+    for (i = 0; i < nsegs; i++) {
+        evpl_test_abort_if(evpl_iovec_alloc(ps->evpl, seglen, 0, 1, 0,
+                                            &req->iov[i]) != 1,
+                           "a %u byte iovec came back in more than one piece",
+                           seglen);
+        memset(req->iov[i].data, fill, seglen);
+    }
+
+    return req;
+} /* block_req_alloc */
+
+static int
+block_nsegs(const struct core_step *step)
+{
+    switch (step->segs) {
+        case CSEG_BSEG1: return 1;
+        case CSEG_BSEG4: return 4;
+        case CSEG_BSEG16: return 16;
+        default:
+            evpl_test_abort("segment class %d has no arm in the driver",
+                            step->segs);
+            return 1;
+    } /* switch */
+} /* block_nsegs */
+
+static void
+do_block_io(
+    struct prog_state      *ps,
+    const struct core_step *step)
+{
+    struct block_req *req;
+    uint64_t          offset = (uint64_t) step->region * REGION_BYTES;
+    int               nsegs  = block_nsegs(step);
+
+    if (step->op == COP_OPBLOCKREAD) {
+        /* Poisoned rather than zeroed: a read that returns without writing
+         * anything must fail, and zeros are a value the model can legitimately
+         * expect. */
+        req          = block_req_alloc(ps, step, nsegs, BLOCK_POISON);
+        req->pattern = step->pattern;
+
+        evpl_block_read(ps->evpl, ps->bqueue[step->queue], req->iov, req->niov,
+                        offset, block_complete, req);
+    } else {
+        req = block_req_alloc(ps, step, nsegs, step->pattern);
+
+        evpl_block_write(ps->evpl, ps->bqueue[step->queue], req->iov,
+                         req->niov, offset,
+                         step->op == COP_OPBLOCKWRITESYNC,
+                         block_complete, req);
+    }
+} /* do_block_io */
+
+/* flush, write_zeroes and discard carry no buffers, so their request record
+ * exists only to name the queue the completion belongs to. */
+static struct block_req *
+block_req_bare(
+    struct prog_state      *ps,
+    const struct core_step *step)
+{
+    struct block_req *req;
+
+    evpl_test_abort_if(!ps->bqueue[step->queue],
+                       "block op on queue %d, which is not open", step->queue);
+
+    req = calloc(1, sizeof(*req));
+    evpl_test_abort_if(!req, "out of memory");
+
+    req->ps      = ps;
+    req->queue   = step->queue;
+    req->niov    = 0;
+    req->pattern = -1;
+
+    return req;
+} /* block_req_bare */
+
 static int
 run_step(
     struct prog_state      *ps,
@@ -1449,11 +1776,17 @@ run_step(
     struct deferral_slot *ds;
     struct doorbell_slot *bs;
     struct conn_slot     *cs;
+    struct block_req     *br;
 
     g_results.steps++;
 
     evpl_test_abort_if(step->slot >= MAX_SLOT || step->conn >= MAX_CONN,
                        "program %d step %d: object index outside the driver's "
+                       "tables", prog, stepno);
+
+    evpl_test_abort_if(step->queue >= NUM_BLOCK_QUEUE ||
+                       step->region >= NUM_REGION,
+                       "program %d step %d: block index outside the driver's "
                        "tables", prog, stepno);
 
     switch (step->op) {
@@ -1626,6 +1959,54 @@ run_step(
             evpl_finish(ps->evpl, cs->bind[step->side]);
             break;
 
+        case COP_OPOPENQUEUE:
+            evpl_test_abort_if(ps->bqueue[step->queue],
+                               "queue %d is open already", step->queue);
+            ps->bqueue[step->queue] = evpl_block_open_queue(ps->evpl, ps->bdev);
+            evpl_test_abort_if(!ps->bqueue[step->queue],
+                               "could not open block queue %d", step->queue);
+            break;
+
+        case COP_OPCLOSEQUEUE:
+            evpl_test_abort_if(!ps->bqueue[step->queue],
+                               "close on queue %d, which is not open",
+                               step->queue);
+            evpl_block_close_queue(ps->evpl, ps->bqueue[step->queue]);
+            ps->bqueue[step->queue] = NULL;
+            break;
+
+        case COP_OPBLOCKREAD:
+        case COP_OPBLOCKWRITE:
+        case COP_OPBLOCKWRITESYNC:
+            do_block_io(ps, step);
+            break;
+
+        case COP_OPBLOCKFLUSH:
+            br = block_req_bare(ps, step);
+            evpl_block_flush(ps->evpl, ps->bqueue[step->queue],
+                             block_complete, br);
+            break;
+
+        case COP_OPBLOCKWRITEZEROES:
+            br = block_req_bare(ps, step);
+            evpl_block_write_zeroes(ps->evpl, ps->bqueue[step->queue],
+                                    (uint64_t) step->region * REGION_BYTES,
+                                    REGION_BYTES, block_complete, br);
+            break;
+
+        case COP_OPBLOCKWRITEZEROESALL:
+            br = block_req_bare(ps, step);
+            evpl_block_write_zeroes(ps->evpl, ps->bqueue[step->queue], 0,
+                                    DEVICE_BYTES, block_complete, br);
+            break;
+
+        case COP_OPBLOCKDISCARD:
+            br = block_req_bare(ps, step);
+            evpl_block_discard(ps->evpl, ps->bqueue[step->queue],
+                               (uint64_t) step->region * REGION_BYTES,
+                               REGION_BYTES, block_complete, br);
+            break;
+
         case COP_OPQUIESCE:
             return do_quiesce(ps, step, prog, stepno);
 
@@ -1677,6 +2058,12 @@ teardown_program(struct prog_state *ps)
     if (ps->poll) {
         evpl_remove_poll(ps->evpl, ps->poll);
     }
+
+    /* Queues first, then the device: a queue outlives nothing, and the
+     * device's service thread is only joinable once none is left.  Nothing
+     * can still be in flight here -- every program ends with a quiesce, and
+     * the model never leaves a request outstanding across one. */
+    block_device_close(ps);
 
     /* The owning reference on each global buffer, given back exactly once.
     * Clones the send path took are non-owning and must not be released. */
@@ -1768,6 +2155,8 @@ run_program(
             evpl_test_abort("program %d names a transport the driver has no "
                             "arm for", prog);
     } /* switch */
+
+    block_device_open(ps, prog);
 
     /* Where this program's model clock starts.  The clock is process-wide and
      * monotonic, so each program takes a base rather than resetting it. */

--- a/src/core/tests/quint/core.qnt
+++ b/src/core/tests/quint/core.qnt
@@ -80,6 +80,20 @@ module evpl_core {
 
     pure val END_SLOTS = CONN_SLOTS.map(c => SIDES.map(s => sideSlot(c, s))).flatten()
 
+    /// Block queues, all on one device.  Two rather than one: a queue owns
+    /// its own completion path and a backend threads each completion back to
+    /// the queue that submitted it, so a second queue is what makes
+    /// "delivered to the right one" a claim at all.
+    pure val NUM_BLOCK_QUEUE = 2
+    pure val BLOCK_QUEUE_SLOTS = 0.to(NUM_BLOCK_QUEUE - 1)
+
+    /// The device is cut into fixed regions and every data op addresses
+    /// exactly one whole region.  Content is then a property of a region
+    /// rather than of an arbitrary extent, which is what makes "what does
+    /// this read return" answerable without modelling a byte map.
+    pure val NUM_REGION = 4
+    pure val REGION_SLOTS = 0.to(NUM_REGION - 1)
+
     /// Ops per program, not counting the OpReset that opens it.  Short on
     /// purpose: a failure at step 380 of a 400-step program is not
     /// debuggable, so this buys coverage with many short programs rather than
@@ -128,6 +142,19 @@ module evpl_core {
             | QShort => 10
             | QLong => 100
         }
+
+    /// Every block request submitted on a queue owes exactly one completion,
+    /// and owes it in the window it was submitted in.  Exactly, not at least:
+    /// a request whose callback fires twice has run the caller's completion
+    /// handling twice, which is the same class of bug as one that never fires
+    /// and just as quiet.
+    ///
+    /// There is no ordering claim.  The API queues requests and says nothing
+    /// about the order they finish in, so what is owed is a COUNT.
+    pure def blockExpect(q: int, owes: int): Set[Expect] =
+        if (owes > 0)
+            Set({ kind: EvBlock, slot: q, mult: MExactly, count: owes })
+        else Set()
 
     /// Order is only claimed between deadlines at least this far apart.  Two
     /// timers due within a millisecond of each other are ordered by the heap's
@@ -236,6 +263,39 @@ module evpl_core {
          * flag. */
         | OpPollPin
         | OpPollUnpin
+
+        /* --- block I/O (evpl_block.h) ---------------------------------- */
+        /* Open a per-thread queue on the program's device, and close it.
+         * The device itself is not an op: it is opened once per program by
+         * the driver, because a program with no device has no block
+         * behaviour to state and nothing else varies with it. */
+        | OpOpenQueue
+        /* Closing is only legal with nothing outstanding -- a request in
+         * flight still names the queue it was submitted on -- so the model
+         * never generates it otherwise.  That is the contract, not a
+         * limitation of the model. */
+        | OpCloseQueue
+        | OpBlockRead
+        | OpBlockWrite
+        /* The same write with sync set.  A separate op rather than a flag on
+         * OpBlockWrite so that op coverage says whether the durable path was
+         * reached; nothing else observable distinguishes them, since whether
+         * a write survives a crash is not a question this suite can put. */
+        | OpBlockWriteSync
+        | OpBlockFlush
+        /* Documented as a data guarantee: the range reads back as zeros. */
+        | OpBlockWriteZeroes
+        /* The same, over the whole device rather than one region.  A separate
+         * op because the range is what makes it interesting: a backend
+         * without native zeroing emulates it by writing a zero buffer, and a
+         * range larger than one buffer is what makes that emulation loop. */
+        | OpBlockWriteZeroesAll
+        /* Documented as advisory: the backend may drop the range or ignore
+         * the hint, and what reads back afterwards is unspecified.  So the
+         * model asserts the completion and then stops claiming to know what
+         * is there -- asserting either outcome would be inventing a promise
+         * the header explicitly declines to make. */
+        | OpBlockDiscard
 
         /* --- the loop -------------------------------------------------- */
         | OpQuiesce
@@ -359,6 +419,25 @@ module evpl_core {
     /// removing it at teardown and stepping over a stale predecessor.
     pure def isLocal(k: TransportKind): bool = k == TStreamUnix
 
+    /// How many iovecs a block request is scattered across.  One is the
+    /// contiguous case; the others make the backend walk a list, and 16 is
+    /// past the point where a backend that keeps a small inline array has to
+    /// allocate one instead.
+    type SegCls = | BSeg1 | BSeg4 | BSeg16
+
+    pure def segCount(s: SegCls): int =
+        match s {
+            | BSeg1 => 1
+            | BSeg4 => 4
+            | BSeg16 => 16
+        }
+
+    /// What a region holds, as a byte value: CONTENT_UNKNOWN when nothing is
+    /// claimed (never written, or discarded), CONTENT_ZERO after
+    /// write_zeroes, and otherwise the byte a write filled it with.
+    pure val CONTENT_UNKNOWN = -1
+    pure val CONTENT_ZERO = 0
+
     type Step = {
         op: OpKind,
         slot: int,
@@ -371,6 +450,14 @@ module evpl_core {
         size: SizeCls,
         send: SendMode,
         drain: DrainMode,
+        /* Block I/O: which queue, which region, how many segments, and the
+         * byte the region is filled with (a write) or must read back as (a
+         * read).  CONTENT_UNKNOWN on a read means the model has no claim to
+         * make about the bytes, only about the completion. */
+        queue: int,
+        region: int,
+        segs: SegCls,
+        pattern: int,
         /* Model time at the END of this step.  Only a quiesce advances it;
          * the driver uses it as the absolute deadline to run that quiesce
          * to. */
@@ -381,7 +468,9 @@ module evpl_core {
         op: OpReset, slot: 0, timerKind: TOneshot, delay: DFast,
         budget: QShort, conn: 0, side: SIDE_CLIENT, transport: TStreamInproc,
         size: SzTiny,
-        send: SendBuf, drain: DrainRecv, atMs: 0
+        send: SendBuf, drain: DrainRecv,
+        queue: 0, region: 0, segs: BSeg1, pattern: CONTENT_UNKNOWN,
+        atMs: 0
     }
 
     // ------------------------------------------------------------------
@@ -419,6 +508,10 @@ module evpl_core {
         /* One of the three loop hooks ran; the slot says which.  Logged once
          * per window, like EvPoll, since they fire on every pass. */
         | EvHook
+        /* One block request completed, on the queue it was submitted on.
+         * Counted exactly: an asynchronous I/O that completes twice is as
+         * wrong as one that never completes, and both are silent. */
+        | EvBlock
 
     /// MExactly is a closed claim, MAtLeast an open one.  The distinction is
     /// not laziness: a periodic timer's firing count over a wall-clock window
@@ -497,6 +590,13 @@ module evpl_core {
          * applies to it. */
         | ShapeUdp
         | ShapeTimers
+        /* Opens a queue and writes a region, then reads it back in a later
+         * window.  A shape for the same reason ShapeTransport is one: the
+         * read-back property needs a write, a quiesce and a read in that
+         * order on the same region, and a uniform walk over thirty-odd
+         * enabled actions inside a twelve-op program draws that sequence
+         * about as often as it draws a live connection. */
+        | ShapeBlock
 
     var shape: Shape
 
@@ -533,6 +633,25 @@ module evpl_core {
     var transport: TransportKind
     var pendingMsgs: int -> int
 
+    /// A block queue is open on the program's device or it is not.
+    type BlockQSt = | BQAbsent | BQOpen
+
+    var blockQSt: int -> BlockQSt
+    /// Completions this queue is owed and has not yet been given.
+    var blockOwes: int -> int
+
+    /// Settled region content: what a read issued in a later window must
+    /// return.  CONTENT_UNKNOWN where the model has no claim.
+    var regionContent: int -> int
+    /// What this window's op leaves the region holding, applied at the
+    /// quiesce that closes the window.
+    var regionPending: int -> int
+    /// A region already addressed in this window.  At most one data op per
+    /// region per window: two would be concurrently outstanding against each
+    /// other, and the API orders concurrent requests in no particular way, so
+    /// whatever the second one saw would be unspecified rather than wrong.
+    var regionBusy: int -> bool
+
     var listening: bool
     var connSt: int -> ConnSt
     /// Bytes sent to an end and not yet required to have arrived.  Indexed by
@@ -547,6 +666,10 @@ module evpl_core {
     pure val ALL_DOORBELLS_ABSENT = DOORBELL_SLOTS.mapBy(_ => BAbsent)
     pure val ALL_DOORBELLS_UNRUNG = DOORBELL_SLOTS.mapBy(_ => false)
     pure val ALL_DOORBELLS_ZERO = DOORBELL_SLOTS.mapBy(_ => 0)
+    pure val ALL_QUEUES_ABSENT = BLOCK_QUEUE_SLOTS.mapBy(_ => BQAbsent)
+    pure val ALL_QUEUES_ZERO = BLOCK_QUEUE_SLOTS.mapBy(_ => 0)
+    pure val ALL_REGIONS_UNKNOWN = REGION_SLOTS.mapBy(_ => CONTENT_UNKNOWN)
+    pure val ALL_REGIONS_IDLE = REGION_SLOTS.mapBy(_ => false)
     pure val ALL_CONNS_FREE = CONN_SLOTS.mapBy(_ => CFree)
     pure val ALL_ENDS_DRAINED = END_SLOTS.mapBy(_ => 0)
     pure val ALL_ENDS_UNNOTIFIED = END_SLOTS.mapBy(_ => false)
@@ -699,6 +822,14 @@ module evpl_core {
         doorbellSt' = ALL_DOORBELLS_ABSENT,
         doorbellOwes' = ALL_DOORBELLS_ZERO,
         doorbellRung' = ALL_DOORBELLS_UNRUNG,
+        blockQSt' = ALL_QUEUES_ABSENT,
+        blockOwes' = ALL_QUEUES_ZERO,
+        /* A fresh device every program: the driver re-creates the backing
+         * file at each reset, so nothing is known about any region until this
+         * program writes it. */
+        regionContent' = ALL_REGIONS_UNKNOWN,
+        regionPending' = ALL_REGIONS_UNKNOWN,
+        regionBusy' = ALL_REGIONS_IDLE,
         listening' = false,
         connSt' = ALL_CONNS_FREE,
         pendingBytes' = ALL_ENDS_DRAINED,
@@ -745,9 +876,19 @@ module evpl_core {
         doorbellRung' = doorbellRung,
     }
 
+    action keepBlock = all {
+        blockQSt' = blockQSt, blockOwes' = blockOwes,
+        regionContent' = regionContent, regionPending' = regionPending,
+        regionBusy' = regionBusy,
+    }
+
     /// Ops other than a quiesce do not run the loop, so no callback can fire
     /// during one and the clock does not move.
-    action emit(s: Step): bool = all {
+    ///
+    /// Split from `emit` so the block ops, which are the only ones that touch
+    /// the block state themselves, can reuse it without assigning those vars
+    /// twice.  Every other op wants `emit`.
+    action emitCore(s: Step): bool = all {
         current' = s.with("atMs", elapsedMs).with("transport", transport),
         expects' = Set(),
         orders' = Set(),
@@ -755,6 +896,11 @@ module evpl_core {
         elapsedMs' = elapsedMs,
         shape' = shape,
         transport' = transport,
+    }
+
+    action emit(s: Step): bool = all {
+        emitCore(s),
+        keepBlock,
     }
 
     action addTimer(s: int, k: TimerKind, d: DelayCls): bool = all {
@@ -1228,6 +1374,142 @@ module evpl_core {
         keepPolls,
     }
 
+    // ------------------------------------------------------------------
+    // Block I/O (evpl_block.h)
+    //
+    // The device belongs to the program rather than to any op: the driver
+    // creates a fresh one at each reset and tears it down at the end, so what
+    // varies here is the queues opened on it and the requests put through
+    // them.
+    //
+    // Two things are claimed.  One is the completion: every request owes
+    // exactly one callback, in the window it was submitted in -- an
+    // asynchronous API's only universal promise, and the one whose breach
+    // presents as a hang rather than as a wrong answer.  The other is the
+    // data: a region written in one window must read back as what was written
+    // when a later window reads it.  Both are properties of the API and not
+    // of any backend, which is why they live here rather than in a backend's
+    // own test.
+    // ------------------------------------------------------------------
+
+    action keepRegions = all {
+        regionContent' = regionContent, regionPending' = regionPending,
+        regionBusy' = regionBusy,
+    }
+
+    action keepOthers = all {
+        keepTimers, keepDeferrals, keepDoorbells, keepTransport, keepPolls,
+        keepHooks,
+    }
+
+    action openQueue(q: int): bool = all {
+        blockQSt.get(q) == BQAbsent,
+        emitCore(NOP_STEP.with("op", OpOpenQueue).with("queue", q)),
+        blockQSt' = blockQSt.set(q, BQOpen),
+        blockOwes' = blockOwes.set(q, 0),
+        keepRegions,
+        keepOthers,
+    }
+
+    /// Only ever with nothing outstanding.  A request in flight still names
+    /// the queue it was submitted on, so closing under one is a use-after-free
+    /// waiting to happen rather than a case to test -- the contract is that
+    /// the caller waits for its callbacks, and the model keeps to it.
+    action closeQueue(q: int): bool = all {
+        blockQSt.get(q) == BQOpen,
+        blockOwes.get(q) == 0,
+        emitCore(NOP_STEP.with("op", OpCloseQueue).with("queue", q)),
+        blockQSt' = blockQSt.set(q, BQAbsent),
+        blockOwes' = blockOwes,
+        keepRegions,
+        keepOthers,
+    }
+
+    /// What every request has in common: an open queue, and one more
+    /// completion owed on it.
+    action submit(q: int, s: Step): bool = all {
+        blockQSt.get(q) == BQOpen,
+        emitCore(s.with("queue", q)),
+        blockQSt' = blockQSt,
+        blockOwes' = blockOwes.set(q, blockOwes.get(q) + 1),
+    }
+
+    /// The byte a write fills its region with, keyed to where in the program
+    /// it happens so that two writes in one program are distinguishable and a
+    /// read that came back with the wrong one is caught as such rather than
+    /// merely as "not zeros".
+    pure def writePattern(st: int): int = 1 + st
+
+    action blockWrite(q: int, r: int, sc: SegCls, kind: OpKind): bool = all {
+        not(regionBusy.get(r)),
+        submit(q, NOP_STEP.with("op", kind).with("region", r).with("segs", sc)
+                   .with("pattern", writePattern(programStep))),
+        regionContent' = regionContent,
+        regionPending' = regionPending.set(r, writePattern(programStep)),
+        regionBusy' = regionBusy.set(r, true),
+        keepOthers,
+    }
+
+    /// Carries what the region is known to hold, or CONTENT_UNKNOWN where
+    /// nothing is known -- a region never written, or one a discard has since
+    /// been allowed to drop.  The driver checks the bytes only in the first
+    /// case; in the second the completion is still owed and still checked.
+    action blockRead(q: int, r: int, sc: SegCls): bool = all {
+        not(regionBusy.get(r)),
+        submit(q, NOP_STEP.with("op", OpBlockRead).with("region", r)
+                   .with("segs", sc).with("pattern", regionContent.get(r))),
+        regionContent' = regionContent,
+        regionPending' = regionPending.set(r, regionContent.get(r)),
+        regionBusy' = regionBusy.set(r, true),
+        keepOthers,
+    }
+
+    /// A data guarantee, unlike discard: the header promises the range reads
+    /// back as zeros, so the model claims it and a later read checks it.
+    action blockWriteZeroes(q: int, r: int): bool = all {
+        not(regionBusy.get(r)),
+        submit(q, NOP_STEP.with("op", OpBlockWriteZeroes).with("region", r)
+                   .with("pattern", CONTENT_ZERO)),
+        regionContent' = regionContent,
+        regionPending' = regionPending.set(r, CONTENT_ZERO),
+        regionBusy' = regionBusy.set(r, true),
+        keepOthers,
+    }
+
+    /// Zero the whole device.  Every region must be idle for the same reason
+    /// one has to be for a single-region op, and every region is left holding
+    /// zeros.
+    action blockWriteZeroesAll(q: int): bool = all {
+        REGION_SLOTS.forall(r => not(regionBusy.get(r))),
+        submit(q, NOP_STEP.with("op", OpBlockWriteZeroesAll)
+                   .with("pattern", CONTENT_ZERO)),
+        regionContent' = regionContent,
+        regionPending' = REGION_SLOTS.mapBy(_ => CONTENT_ZERO),
+        regionBusy' = REGION_SLOTS.mapBy(_ => true),
+        keepOthers,
+    }
+
+    /// Advisory.  The completion is owed like any other, but afterwards the
+    /// model stops claiming to know what the region holds: the header says
+    /// the data read back is unspecified, and asserting either outcome would
+    /// be inventing a promise it explicitly declines to make.
+    action blockDiscard(q: int, r: int): bool = all {
+        not(regionBusy.get(r)),
+        submit(q, NOP_STEP.with("op", OpBlockDiscard).with("region", r)),
+        regionContent' = regionContent,
+        regionPending' = regionPending.set(r, CONTENT_UNKNOWN),
+        regionBusy' = regionBusy.set(r, true),
+        keepOthers,
+    }
+
+    /// Addresses no region, so it makes no claim about content -- only that
+    /// it completes.
+    action blockFlush(q: int): bool = all {
+        submit(q, NOP_STEP.with("op", OpBlockFlush)),
+        keepRegions,
+        keepOthers,
+    }
+
     /// Run the loop to the end of this window and collect what fell out.  The
     /// obligations are computed here, at the point where they are checked,
     /// and travel in the trace: the C driver consumes the trace, not the
@@ -1272,6 +1554,8 @@ module evpl_core {
                     recvMsgExpect(transport, e, pendingMsgs.get(e))).flatten())
                 .union(END_SLOTS.map(e =>
                     sentExpect(e, sentNotify.get(e), pendingSent.get(e))).flatten())
+                .union(BLOCK_QUEUE_SLOTS.map(q =>
+                    blockExpect(q, blockOwes.get(q))).flatten())
                 .union(pollExpects)
                 .union(if (hooksInstalled)
                            HOOK_SLOTS.map(h => { kind: EvHook, slot: h,
@@ -1304,6 +1588,19 @@ module evpl_core {
 
             deferralSt' = ALL_DEFERRALS_IDLE,
             deferralOwes' = ALL_DEFERRALS_ZERO,
+
+            /* Every request submitted in this window has completed by the end
+             * of it, so the queues owe nothing going into the next.  A region
+             * this window wrote now holds what was written -- that is the
+             * point at which the claim becomes checkable, since only a
+             * completed write has a defined result. */
+            blockQSt' = blockQSt,
+            blockOwes' = ALL_QUEUES_ZERO,
+            regionContent' = REGION_SLOTS.mapBy(r =>
+                if (regionBusy.get(r)) regionPending.get(r)
+                else regionContent.get(r)),
+            regionPending' = ALL_REGIONS_UNKNOWN,
+            regionBusy' = ALL_REGIONS_IDLE,
 
             doorbellSt' = dbSt,
             doorbellOwes' = ALL_DOORBELLS_ZERO,
@@ -1367,6 +1664,9 @@ module evpl_core {
          * API offers, and excluded because exercising them leaks. */
         nondet sm = Set(SendBuf, SendV, SendVTakeRef, SendReserveCommit,
                         SendGlobal).oneOf()
+        nondet bq = BLOCK_QUEUE_SLOTS.oneOf()
+        nondet br = REGION_SLOTS.oneOf()
+        nondet bg = Set(BSeg1, BSeg4, BSeg16).oneOf()
         any {
             addTimer(ts, tk, td),
             removeTimer(ts),
@@ -1397,6 +1697,15 @@ module evpl_core {
             send(cs, sd, sz, sm),
             close(cs, sd),
             finish(cs, sd),
+            openQueue(bq),
+            closeQueue(bq),
+            blockRead(bq, br, bg),
+            blockWrite(bq, br, bg, OpBlockWrite),
+            blockWrite(bq, br, bg, OpBlockWriteSync),
+            blockWriteZeroes(bq, br),
+            blockWriteZeroesAll(bq),
+            blockDiscard(bq, br),
+            blockFlush(bq),
             quiesce(b),
         }
     }
@@ -1428,11 +1737,28 @@ module evpl_core {
         connect(0, d)
     }
 
+    /// Fill region 0 on the prologue's queue, scattered any way the model
+    /// allows -- including across more segments than a backend is likely to
+    /// keep inline.
+    action blockWriteAny = {
+        nondet g = Set(BSeg1, BSeg4, BSeg16).oneOf()
+        nondet k = Set(OpBlockWrite, OpBlockWriteSync).oneOf()
+        blockWrite(0, 0, g, k)
+    }
+
+    /// And read it back.  The gather on the way out and the scatter on the
+    /// way in are chosen independently, since a backend has no business
+    /// requiring them to match.
+    action blockReadAny = {
+        nondet g = Set(BSeg1, BSeg4, BSeg16).oneOf()
+        blockRead(0, 0, g)
+    }
+
     action resetUdp = doReset(ShapeUdp, TDatagramUdp)
 
     action resetAny = {
         nondet sh = Set(ShapeMixed, ShapeTransport, ShapeTransportNotify,
-                        ShapeTimers).oneOf()
+                        ShapeTimers, ShapeBlock).oneOf()
         nondet k = Set(TStreamInproc, TDatagramInproc, TStreamTcp,
                        TStreamUnix).oneOf()
         doReset(if (sh == ShapeUdp) ShapeMixed else sh, k)
@@ -1509,6 +1835,11 @@ module evpl_core {
         else if (shape == ShapeUdp and programStep == 1) sendAnyEp
         else if (shape == ShapeUdp and programStep == 2) quiesce(QShort)
         else if (shape == ShapeTimers and programStep < 3) addTimerAny(programStep)
+        else if (shape == ShapeBlock and programStep == 0) openQueue(0)
+        else if (shape == ShapeBlock and programStep == 1) blockWriteAny
+        else if (shape == ShapeBlock and programStep == 2) quiesce(QShort)
+        else if (shape == ShapeBlock and programStep == 3) blockReadAny
+        else if (shape == ShapeBlock and programStep == 4) quiesce(QShort)
         else pickOp
 
     // ------------------------------------------------------------------
@@ -1547,6 +1878,15 @@ module evpl_core {
         | OpSend => true
         | OpClose => true
         | OpFinish => true
+        | OpOpenQueue => true
+        | OpCloseQueue => true
+        | OpBlockRead => true
+        | OpBlockWrite => true
+        | OpBlockWriteSync => true
+        | OpBlockFlush => true
+        | OpBlockWriteZeroes => true
+        | OpBlockWriteZeroesAll => true
+        | OpBlockDiscard => true
         | OpQuiesce => true
     }
 
@@ -1960,4 +2300,72 @@ module evpl_core {
                 { kind: EvRecvMsg, slot: sideSlot(0, SIDE_SERVER), mult: MExactly, count: 1 },
                 { kind: EvRecv, slot: sideSlot(0, SIDE_CLIENT), mult: MExactly, count: 1 },
                 { kind: EvRecvMsg, slot: sideSlot(0, SIDE_CLIENT), mult: MExactly, count: 1 }))
+
+    /// Every request owes exactly one completion, and owes it in the window
+    /// it was submitted in.  Three requests in one window owe three; the
+    /// window after owes none, which is what makes a completion that fires
+    /// twice a failure rather than a shrug.
+    run blockRequestOwesOneCompletionTest =
+        init
+            .then(openQueue(0))
+            .then(blockWrite(0, 0, BSeg1, OpBlockWrite))
+            .then(blockWrite(0, 1, BSeg4, OpBlockWriteSync))
+            .then(blockFlush(0))
+            .then(quiesce(QShort))
+            .expect(expects == Set({ kind: EvBlock, slot: 0, mult: MExactly, count: 3 }))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
+
+    /// A region reads back what was written to it, whatever the two calls
+    /// scattered their buffers across.  The claim only exists once the write
+    /// has completed -- before the quiesce there is nothing to read back.
+    run blockReadReturnsWhatWasWrittenTest =
+        init
+            .then(openQueue(0))
+            .then(blockWrite(0, 0, BSeg16, OpBlockWrite))
+            .then(quiesce(QShort))
+            .then(blockRead(0, 0, BSeg1))
+            .expect(current.pattern == writePattern(1))
+            .then(quiesce(QShort))
+            .expect(expects == Set({ kind: EvBlock, slot: 0, mult: MExactly, count: 1 }))
+
+    /// write_zeroes is a data guarantee: the range reads back as zeros.
+    /// discard is not one -- it is advisory, and what is there afterwards is
+    /// unspecified -- so the model goes back to claiming nothing about the
+    /// region while still requiring the completion.
+    run blockZeroesAndDiscardDifferTest =
+        init
+            .then(openQueue(0))
+            .then(blockWriteZeroes(0, 2))
+            .then(quiesce(QShort))
+            .then(blockRead(0, 2, BSeg4))
+            .expect(current.pattern == CONTENT_ZERO)
+            .then(quiesce(QShort))
+            .then(blockWriteZeroesAll(0))
+            .then(quiesce(QShort))
+            .then(blockRead(0, 3, BSeg1))
+            .expect(current.pattern == CONTENT_ZERO)
+            .then(quiesce(QShort))
+            .then(blockDiscard(0, 2))
+            .then(quiesce(QShort))
+            .then(blockRead(0, 2, BSeg4))
+            .expect(current.pattern == CONTENT_UNKNOWN)
+
+    /// Two queues on one device are independent: each is owed exactly what
+    /// was submitted on it, which is the claim a backend breaks by handing a
+    /// completion to whichever queue it finds first.
+    run blockQueuesAreIndependentTest =
+        init
+            .then(openQueue(0))
+            .then(openQueue(1))
+            .then(blockWrite(0, 0, BSeg1, OpBlockWrite))
+            .then(blockWrite(1, 1, BSeg1, OpBlockWrite))
+            .then(blockFlush(1))
+            .then(quiesce(QShort))
+            .expect(expects == Set(
+                { kind: EvBlock, slot: 0, mult: MExactly, count: 1 },
+                { kind: EvBlock, slot: 1, mult: MExactly, count: 2 }))
+            .then(closeQueue(0))
+            .then(quiesce(QShort))
+            .expect(expects == Set())
 }

--- a/src/core/tests/quint/itf_to_core_cases.py
+++ b/src/core/tests/quint/itf_to_core_cases.py
@@ -53,6 +53,15 @@ OPS = [
     "OpSend",
     "OpClose",
     "OpFinish",
+    "OpOpenQueue",
+    "OpCloseQueue",
+    "OpBlockRead",
+    "OpBlockWrite",
+    "OpBlockWriteSync",
+    "OpBlockFlush",
+    "OpBlockWriteZeroes",
+    "OpBlockWriteZeroesAll",
+    "OpBlockDiscard",
     "OpQuiesce",
 ]
 
@@ -65,10 +74,11 @@ TRANSPORTS = ["TStreamInproc", "TDatagramInproc", "TStreamTcp", "TStreamUnix",
               "TDatagramUdp"]
 SENDS = ["SendBuf", "SendV", "SendVTakeRef", "SendToEp", "SendToEpV",
          "SendReserveCommit", "SendGlobal"]
+SEGS = ["BSeg1", "BSeg4", "BSeg16"]
 EVENTS = ["EvTimer", "EvDeferral", "EvDoorbell",
           "EvConnected", "EvDisconnected", "EvRecv",
           "EvPollEnter", "EvPollExit", "EvPoll", "EvRecvMsg", "EvSent",
-          "EvHook"]
+          "EvHook", "EvBlock"]
 MULTS = ["MExactly", "MAtLeast"]
 
 # OpReset is the program delimiter, not something the driver runs, so it is
@@ -154,6 +164,10 @@ def read_step(state):
             index_of(SIZES, tag_of(cur["size"]), "size class"),
             index_of(SENDS, tag_of(cur["send"]), "send mode"),
             index_of(DRAINS, tag_of(cur["drain"]), "drain mode"),
+            itf_int(cur["queue"]),
+            itf_int(cur["region"]),
+            index_of(SEGS, tag_of(cur["segs"]), "segment class"),
+            itf_int(cur["pattern"]),
             itf_int(cur["atMs"]),
             tuple(read_expects(state)),
             tuple(read_orders(state)))
@@ -237,12 +251,14 @@ def main():
     for prog in programs:
         first_step = len(steps)
         for (op_tag, op, slot, tk, delay, budget, conn, side, transport, size,
-             send, drain, at_ms, exps, ords) in prog:
+             send, drain, queue, region, segs, pattern, at_ms,
+             exps, ords) in prog:
             reached.add(op_tag)
             ef, ec = intern(expect_rows, expect_index, exps)
             of, oc = intern(order_rows, order_index, ords)
             steps.append((op, slot, tk, delay, budget, conn, side, transport,
-                          size, send, drain, at_ms, ef, ec, of, oc))
+                          size, send, drain, queue, region, segs, pattern,
+                          at_ms, ef, ec, of, oc))
         prog_rows.append((first_step, len(steps) - first_step))
 
     missing = sorted(set(OPS) - COVERAGE_EXEMPT - reached)
@@ -283,6 +299,7 @@ def main():
     emit_enum(o, "core_size", "CSZ", SIZES)
     emit_enum(o, "core_send", "CSND", SENDS)
     emit_enum(o, "core_drain", "CDRN", DRAINS)
+    emit_enum(o, "core_segs", "CSEG", SEGS)
     emit_enum(o, "core_event", "CEV", EVENTS)
 
     # The driver indexes per-event-kind arrays by this, so it is emitted
@@ -328,6 +345,13 @@ def main():
     o.append("    uint8_t  size;        /* OpSend only    */")
     o.append("    uint8_t  send;        /* OpSend only    */")
     o.append("    uint8_t  drain;       /* OpConnect only */")
+    o.append("    uint8_t  queue;       /* block ops only */")
+    o.append("    uint8_t  region;      /* block data ops only */")
+    o.append("    uint8_t  segs;        /* block read/write only */")
+    o.append("    /* The byte a block write fills its region with, or the one")
+    o.append("     * a read must find there.  Negative means the model makes")
+    o.append("     * no claim about the bytes -- only about the completion. */")
+    o.append("    int16_t  pattern;")
     o.append("    /* Model time in milliseconds at the end of this step,")
     o.append("     * measured from the start of the program.  A quiesce runs")
     o.append("     * to this as an ABSOLUTE deadline, so real and model time")
@@ -364,10 +388,12 @@ def main():
 
     o.append("static const struct core_step core_steps[] = {")
     for (op, slot, tk, delay, budget, conn, side, transport, size, send, drain,
-         at_ms, ef, ec, of, oc) in steps:
-        o.append("    { %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d },"
+         queue, region, segs, pattern, at_ms, ef, ec, of, oc) in steps:
+        o.append("    { %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, "
+                 "%d, %d, %d, %d, %d, %d, %d, %d, %d },"
                  % (op, slot, tk, delay, budget, conn, side, transport, size,
-                    send, drain, at_ms, ef, ec, of, oc))
+                    send, drain, queue, region, segs, pattern, at_ms,
+                    ef, ec, of, oc))
     o.append("};")
     o.append("")
 


### PR DESCRIPTION
Stacked on #143, which is not a branch in this repo, so this PR carries that commit too — review only the second one, `core: model the block API, ...`. It rebases onto whatever #143 lands as.

The core conformance model covered timers, deferrals, doorbells, polls, loop hooks and the transports. It said nothing about block I/O, so the only thing holding the block API to its contract was each backend's own hand-written test — and on a platform with one backend, that is one test.

## What the model says

A program opens queues on the device it is given and puts requests through them; what travels with the program is what each quiesce window is owed.

- **Every request owes exactly one completion, in the window it was submitted in.** Exactly, not at least: a completion that fires twice has run the caller's completion handling twice, which is as wrong as one that never fires and just as quiet.
- **A region written in one window reads back as what was written** when a later window reads it. `write_zeroes` carries the same claim with zeros, because the header promises it. `discard` does not, because the header explicitly declines to say what is there afterwards — so the model stops claiming to know, while still requiring the completion.

The device is cut into fixed regions and one whole region is addressed per data op, at most one op per region per window. That is what makes the read question answerable at all: the API orders concurrent requests in no particular way, so a read racing a write to the same range is unspecified rather than wrong, and the model declines to generate it.

Requests are scattered across 1, 4 or 16 segments — 16 being past the point where a backend with a small inline iovec array has to allocate one instead.

## Two defects

**`evpl_block_write_zeroes` dereferenced a null iovec.** The emulation ignored `evpl_iovec_alloc`'s return value. The zero chunk is a single iovec and `evpl_iovec_alloc` places at most `max_iovecs` pieces, so a range larger than one buffer came back as `-1` with the iovec untouched — and the `memset` that followed dereferenced it. Nothing had ever called it on a backend without native support (only VFIO has one), so the path had no coverage at all; the model's first whole-device zero found it immediately. Now chunked at one buffer as well as at the device's maximum request, with an allocation that still fails treated as a failed request rather than a crash.

**The pread backend reported `evpl_activity()` from its completion drain**, copied from libaio — where it belongs, because libaio is reaped from a poll callback and saying "the ring produced something" keeps the loop spinning on it. The pread backend is doorbell-driven and has no ring to poll, so all that did was force the loop back into poll mode after every completion: a device imposing a loop-wide policy the block API says nothing about. The model's poll-mode claims are what surfaced it.

## Also

The driver now closes a window at its check rather than opening it at the next quiesce. Almost every callback arrives from inside the loop, so the two are the same point — except that a backend with no native discard answers `evpl_block_discard()` by calling back inline, before the submitting call has returned, and a completion delivered that way was landing outside every window. (Worth noting on its own: the same call is asynchronous on a backend with native discard and synchronous on one without.)

## Coverage

`libevpl/pread/basic` picks up the paths a program cannot reach: a path that is not there, one that is there but cannot be addressed by offset, and a read running off the end of the device.

Coverage of `src/core/pread/pread_block.c` on macOS, clang source-based:

| | lines | regions | branches |
|---|---|---|---|
| before (hand-written tests only) | 83.8% | 61.9% | 60.0% |
| model alone | 85.4% | 63.5% | 64.4% |
| model + unit tests | **91.6%** | **76.2%** | **71.1%** |

The residual 26 lines are four things, all needing fault injection or hardware: an `EINTR` mid-transfer, an `F_FULLFSYNC` that fails, a raw disk's `DKIOCGETBLOCKCOUNT`, and a `pthread_create` that will not start.

The driver takes `EVPL_TEST_BLOCK_PROTOCOL` so the same programs can be pointed at io_uring or libaio on a host that has them; the registered test uses pread, which is the one backend present on every platform.