### PR TITLE
quint: generate a batch of traces per process, not one

### DIFF
--- a/src/core/tests/quint/generate_core_cases.sh
+++ b/src/core/tests/quint/generate_core_cases.sh
@@ -40,21 +40,31 @@ mkdir -p "${WORK_DIR}"
 # advances of libevpl's virtual clock rather than sleeps, so a 100ms window is
 # a few hundred non-blocking passes of the event loop and the whole suite runs
 # in well under a second.  On a real clock this many programs would be minutes.
-SEEDS=(0xe1 0xe2 0xe3 0xe4 0xe5 0xe6 0xe7 0xe8 0xe9 0xea)
+#
+# Split across a few seeds, several traces each, rather than one trace per
+# seed.  Two costs are in play: quint parses and typechecks the model once per
+# PROCESS, and simulates once per TRACE.  This model is big enough that the
+# simulation is not lost in the noise, so neither extreme is right -- one
+# process per trace pays the parse ten times, and one process for all ten
+# serialises the simulation.  A handful of processes, each producing a
+# handful of traces, pays the parse once per core and still runs them at once.
+SEEDS=(0xe1 0xe2 0xe3 0xe4 0xe5)
+TRACES_PER_SEED=2
 STEPS=260
 
-# The seeds are independent, so they run concurrently -- serially this is the
-# slowest step of the build by an order of magnitude, and it is pure waiting on
-# a simulator that uses about one and a half cores.
 TRACES=()
 PIDS=()
 
 for s in "${SEEDS[@]}"; do
-    f="${WORK_DIR}/core-${s}.itf.json"
     "${QUINT}" run "${SRC_DIR}/core.qnt" \
-        --seed="$s" --max-steps="${STEPS}" --out-itf="$f" > /dev/null &
+        --seed="$s" --max-steps="${STEPS}" \
+        --max-samples="${TRACES_PER_SEED}" --n-traces="${TRACES_PER_SEED}" \
+        --out-itf="${WORK_DIR}/core-${s}-{seq}.itf.json" > /dev/null &
     PIDS+=($!)
-    TRACES+=("$f")
+
+    for i in $(seq 0 $((TRACES_PER_SEED - 1))); do
+        TRACES+=("${WORK_DIR}/core-${s}-${i}.itf.json")
+    done
 done
 
 for pid in "${PIDS[@]}"; do

--- a/src/http/tests/quint/generate_cases.sh
+++ b/src/http/tests/quint/generate_cases.sh
@@ -37,33 +37,39 @@ mkdir -p "${WORK_DIR}"
 # small and enumerable, so its traces only need to be long enough to reach
 # every (defect, version, delivery) triple -- the case count printed at the end
 # is the check on that, and must equal the size of that cross product.
-REQUEST_SEEDS=(0x21 0x22 0x23 0x24 0x25 0x26)
-DEFECT_SEEDS=(0x41 0x42 0x43 0x44 0x45 0x46 0x47 0x48 0x0009 0x1234 0xdead 0x0777)
-CLIENT_SEEDS=(0x61 0x62 0x63 0x64 0x65 0x66 0x67 0x68 0x0009 0x1234 0xdead 0x0777)
+#
+# One quint invocation per group rather than one per trace.  Nearly all of a
+# quint run is parsing and typechecking the model -- for this one, 2.1s of a
+# 2.2s invocation -- so the cost is per PROCESS, not per trace, and --n-traces
+# pays it once for the whole group instead of once each.  The three groups then
+# run concurrently because they are independent.
+REQUEST_TRACES=6
+DEFECT_TRACES=12
+CLIENT_TRACES=12
 
-REQUEST_TRACES=()
-for s in "${REQUEST_SEEDS[@]}"; do
-    f="${WORK_DIR}/requests-${s}.itf.json"
-    "${QUINT}" run "${SRC_DIR}/http1x.qnt" --main=http1x_requests \
-        --seed="$s" --max-steps=200 --out-itf="$f" > /dev/null
-    REQUEST_TRACES+=("$f")
-done
+REQUEST_SEED=0x21
+DEFECT_SEED=0x41
+CLIENT_SEED=0x61
 
-DEFECT_TRACES=()
-for s in "${DEFECT_SEEDS[@]}"; do
-    f="${WORK_DIR}/defects-${s}.itf.json"
-    "${QUINT}" run "${SRC_DIR}/http1x.qnt" --main=http1x_defects \
-        --seed="$s" --max-steps=300 --out-itf="$f" > /dev/null
-    DEFECT_TRACES+=("$f")
-done
+# gen MAIN STEPS NTRACES SEED PREFIX
+gen() {
+    "${QUINT}" run "${SRC_DIR}/http1x.qnt" --main="$1" \
+        --max-steps="$2" --max-samples="$3" --n-traces="$3" --seed="$4" \
+        --out-itf="${WORK_DIR}/$5-{seq}.itf.json" > /dev/null
+}
 
-CLIENT_TRACES=()
-for s in "${CLIENT_SEEDS[@]}"; do
-    f="${WORK_DIR}/client-${s}.itf.json"
-    "${QUINT}" run "${SRC_DIR}/http1x.qnt" --main=http1x_client \
-        --seed="$s" --max-steps=300 --out-itf="$f" > /dev/null
-    CLIENT_TRACES+=("$f")
+gen http1x_requests 200 "${REQUEST_TRACES}" "${REQUEST_SEED}" requests &
+pids="$!"
+gen http1x_defects  300 "${DEFECT_TRACES}"  "${DEFECT_SEED}"  defects  &
+pids="${pids} $!"
+gen http1x_client   300 "${CLIENT_TRACES}"  "${CLIENT_SEED}"  client   &
+pids="${pids} $!"
+
+for pid in ${pids}; do
+    wait "${pid}" || { echo "quint run failed" >&2; exit 1; }
 done
 
 "${PYTHON}" "${SRC_DIR}/itf_to_cases.py" "${OUT_HEADER}" \
-    "${REQUEST_TRACES[@]}" -- "${DEFECT_TRACES[@]}" -- "${CLIENT_TRACES[@]}"
+    "${WORK_DIR}"/requests-*.itf.json -- \
+    "${WORK_DIR}"/defects-*.itf.json -- \
+    "${WORK_DIR}"/client-*.itf.json

--- a/src/rpc2/tests/quint/generate_cases.sh
+++ b/src/rpc2/tests/quint/generate_cases.sh
@@ -31,30 +31,37 @@ OUT_HEADER="${5:?}"
 
 mkdir -p "${WORK_DIR}"
 
-# The value matrix is a wide cross-product, so it is sampled: several seeds,
-# long traces, de-duplicated by the converter.  The defect taxonomy is small
-# and enumerable, so its traces only need to be long enough to reach every
+# The value matrix is a wide cross-product, so it is sampled: several traces,
+# long ones, de-duplicated by the converter.  The defect taxonomy is small and
+# enumerable, so its traces only need to be long enough to reach every
 # (defect, target) pair -- the case count printed at the end is the check on
 # that.
-VALUE_SEEDS=(0xa1 0xa2 0xa3 0xa4 0xa5 0xa6 0xa7 0xa8)
-DEFECT_SEEDS=(0xb1 0xb2 0xb3 0xb4)
+#
+# One quint invocation per model rather than one per trace: nearly all of a
+# quint run is parsing and typechecking, so the cost is per PROCESS and
+# --n-traces pays it once for the group.  The two models are independent and
+# run concurrently.
+VALUE_TRACES=10
+DEFECT_TRACES=4
 
-VALUE_TRACES=()
-for s in "${VALUE_SEEDS[@]}"; do
-    f="${WORK_DIR}/values-${s}.itf.json"
-    "${QUINT}" run "${SRC_DIR}/values.qnt" \
-        --seed="$s" --max-steps=200 --out-itf="$f" > /dev/null
-    VALUE_TRACES+=("$f")
-done
+VALUE_SEED=0xa1
+DEFECT_SEED=0xb1
 
-DEFECT_TRACES=()
-for s in "${DEFECT_SEEDS[@]}"; do
-    f="${WORK_DIR}/defects-${s}.itf.json"
-    "${QUINT}" run "${SRC_DIR}/defects.qnt" \
-        --seed="$s" --max-steps=400 --out-itf="$f" > /dev/null
-    DEFECT_TRACES+=("$f")
-done
+"${QUINT}" run "${SRC_DIR}/values.qnt" --max-steps=200 \
+    --max-samples="${VALUE_TRACES}" --n-traces="${VALUE_TRACES}" \
+    --seed="${VALUE_SEED}" \
+    --out-itf="${WORK_DIR}/values-{seq}.itf.json" > /dev/null &
+values_pid=$!
+
+"${QUINT}" run "${SRC_DIR}/defects.qnt" --max-steps=400 \
+    --max-samples="${DEFECT_TRACES}" --n-traces="${DEFECT_TRACES}" \
+    --seed="${DEFECT_SEED}" \
+    --out-itf="${WORK_DIR}/defects-{seq}.itf.json" > /dev/null &
+defects_pid=$!
+
+wait "${values_pid}" || { echo "quint run failed (values)" >&2; exit 1; }
+wait "${defects_pid}" || { echo "quint run failed (defects)" >&2; exit 1; }
 
 "${PYTHON}" "${SRC_DIR}/itf_to_cases.py" "${OUT_HEADER}" \
-    --values "${VALUE_TRACES[@]}" \
-    --defects "${DEFECT_TRACES[@]}"
+    --values "${WORK_DIR}"/values-*.itf.json \
+    --defects "${WORK_DIR}"/defects-*.itf.json

--- a/src/rpc2/tests/quint/generate_client_cases.sh
+++ b/src/rpc2/tests/quint/generate_client_cases.sh
@@ -35,14 +35,17 @@ mkdir -p "${WORK_DIR}"
 # enough to reach every (defect, delivery) pair.  The case count printed at the
 # end is the check on that: it must equal the size of the cross product the
 # model declares, minus the pairs the converter collapses.
-SEEDS=(0xc1 0xc2 0xc3 0xc4 0xc5 0xc6)
+#
+# One quint invocation for the whole group: nearly all of a quint run is
+# parsing and typechecking the model, so the cost is per PROCESS rather than
+# per trace, and --n-traces pays it once.
+CLIENT_TRACES=6
+CLIENT_SEED=0xc1
 
-TRACES=()
-for s in "${SEEDS[@]}"; do
-    f="${WORK_DIR}/client-${s}.itf.json"
-    "${QUINT}" run "${SRC_DIR}/client.qnt" \
-        --seed="$s" --max-steps=400 --out-itf="$f" > /dev/null
-    TRACES+=("$f")
-done
+"${QUINT}" run "${SRC_DIR}/client.qnt" --max-steps=400 \
+    --max-samples="${CLIENT_TRACES}" --n-traces="${CLIENT_TRACES}" \
+    --seed="${CLIENT_SEED}" \
+    --out-itf="${WORK_DIR}/client-{seq}.itf.json" > /dev/null
 
-"${PYTHON}" "${SRC_DIR}/itf_to_client_cases.py" "${OUT_HEADER}" "${TRACES[@]}"
+"${PYTHON}" "${SRC_DIR}/itf_to_client_cases.py" "${OUT_HEADER}" \
+    "${WORK_DIR}"/client-*.itf.json


### PR DESCRIPTION
Every quint invocation parses and typechecks the whole model before it simulates anything, and that front end is most of the cost. Measured on this tree:

| | |
|---|---|
| `quint --version` (bare node startup) | 0.27s |
| `quint typecheck http1x.qnt` | 2.11s |
| full 300-step run producing a trace | 2.20s |

The simulation is the last 0.1s of it.

So the cost of generating a corpus is **per process, not per trace** — and these four generators spawned one process per trace: thirty for http, twelve for rpc2's values and defects, six for its client, ten for core. Nearly all of that time was parsing the same file again.

## The change

`--n-traces` emits a whole batch from one invocation, paying the parse once. Each generator now runs one invocation per independent group, and the groups run concurrently.

| generator | before | after | |
|---|---|---|---|
| http | 82.9s | **3.3s** | 25× |
| rpc2 values+defects | 33.3s | **0.8s** | 40× |
| rpc2 client | 6.9s | **3.3s** | 2.1× |
| core | 14.4s | **9.0s** | 1.6× |

(Each pair measured back to back, so the comparison survives a busy machine.)

`core` is the one that does *not* want a single invocation. It is big enough that simulation is not lost in the noise — about 2s per trace against a 7s parse — so neither extreme wins: a process per trace pays the parse ten times, and one process for all ten serialises the simulation. A handful of processes, each producing a handful of traces, pays the parse once per core and still runs them at once.

## Not a coverage change

Trace counts were chosen so the corpora come out the same size or slightly larger, and the enumerable taxonomies — the ones whose case count *is* the check that every case was reached — come out identical or better:

| | before | after |
|---|---|---|
| http requests / defects / client | 1118 / 201 / 186 | 1136 / **201** / **186** |
| rpc2 values / defects | 1037 / 286 | 1197 / 307 |
| rpc2 client | 97 | **97** |
| core programs / steps | 200 / 2400 | **200 / 2400** |

Every quint-generated conformance suite passes against the regenerated tables. Two rpc2 TCP cases fail on my machine (`N accepts announced for 156 connections opened`) — I A/B'd them against the unmodified generators and they fail identically, with the same 156 connections and the same 1661/155 cases run, so this change adds no test load. They pass on the hosted runners.

## For whoever looks at this next

The evaluator is not the bottleneck and there is nothing to be gained by chasing it. quint 0.32 already defaults to `--backend=rust`, and forcing `--backend=typescript` changes a 300-step http run by 30ms, because simulation is a twentieth of the work.

`ext/specs` already generates this way, and its numbers say the same thing from the other side: one nfs4 invocation producing sixteen traces takes 60.2s where sixteen separate ones would take 279s.