### PR TITLE
rpc2 tests: drive the RPCSEC_GSS cases with real Kerberos too

### DIFF
--- a/src/rpc2/tests/CMakeLists.txt
+++ b/src/rpc2/tests/CMakeLists.txt
@@ -84,6 +84,51 @@ macro(unit_test_rpc2_instance_named test_name protocol)
     endforeach()
 endmacro()
 
+# Real-Kerberos RPCSEC_GSS: the conformance cases signed by an actual
+# mechanism rather than by the deterministic stub.  Needs MIT krb5 -- both the
+# GSSAPI library and the ticket-minting entry points krb5_local.c uses -- and
+# is simply not registered without it, so a host with no krb5 builds and runs
+# everything else as before.
+#
+# On macOS krb5 is keg-only, so its pkgconfig has to be pointed at explicitly;
+# the system gssapi there is Heimdal, which is not what this wants.
+if(APPLE)
+    set(ENV{PKG_CONFIG_PATH}
+        "${HOMEBREW_PREFIX}/opt/krb5/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+endif()
+
+find_package(PkgConfig QUIET)
+
+if(PkgConfig_FOUND)
+    pkg_check_modules(KRB5_GSSAPI QUIET krb5-gssapi krb5)
+endif()
+
+if(KRB5_GSSAPI_FOUND)
+    message(STATUS "RPC2 krb5 conformance enabled (krb5 ${KRB5_GSSAPI_VERSION})")
+else()
+    message(STATUS "RPC2 krb5 conformance disabled (no MIT krb5)")
+endif()
+
+# As unit_test_rpc2_instance, but names the instance after the auth flavor it
+# drives and passes the flag that selects it.  The flavors are separate ctest
+# instances rather than one run that loops, so a failure names the mechanism
+# and one flavor going missing on a host does not hide the others.
+macro(unit_test_rpc2_instance_flavor test_name protocol port flavor flag)
+    foreach(mech ${EVPL_MECHANISMS})
+        set(_test libevpl/rpc2/${test_name}_${flavor}_${protocol}_${mech})
+
+        add_test(NAME ${_test}
+                 COMMAND ${RPC2_TEST_EXE_${test_name}} -r ${protocol}
+                         -p ${port} ${flag})
+
+        set_tests_properties(${_test} PROPERTIES
+            RESOURCE_LOCK evpl_net
+            ENVIRONMENT "TEST_FILE=${RPC2_TEST_SRC_${test_name}};EVPL_TEST_CORE_MECH=${mech}"
+            SKIP_RETURN_CODE 77
+            TIMEOUT 30)
+    endforeach()
+endmacro()
+
 # Build RPC2 test executables
 unit_test_rpc2(hello_world hello_world.x hello_world.c)
 unit_test_rpc2(builtin_bool builtin_bool.x builtin_bool.c)
@@ -162,8 +207,23 @@ if(QUINT_EXECUTABLE AND PYTHON3_EXECUTABLE)
 
     add_custom_target(conformance_cases DEPENDS ${CONFORMANCE_CASES})
 
-    unit_test_rpc2(conformance conformance.x conformance.c gss_stub.c)
+    if(KRB5_GSSAPI_FOUND)
+        unit_test_rpc2(conformance conformance.x conformance.c gss_stub.c
+                       krb5_local.c)
+    else()
+        unit_test_rpc2(conformance conformance.x conformance.c gss_stub.c
+                       krb5_local_none.c)
+    endif()
+
     target_link_libraries(evpl_rpc2_conformance m)
+
+    if(KRB5_GSSAPI_FOUND)
+        target_include_directories(evpl_rpc2_conformance PRIVATE
+                                   ${KRB5_GSSAPI_INCLUDE_DIRS})
+        target_link_directories(evpl_rpc2_conformance PRIVATE
+                                ${KRB5_GSSAPI_LIBRARY_DIRS})
+        target_link_libraries(evpl_rpc2_conformance ${KRB5_GSSAPI_LIBRARIES})
+    endif()
     target_sources(evpl_rpc2_conformance PRIVATE ${CONFORMANCE_CASES})
 
     # The ERR_VERS check builds an RPC-over-RDMA transport header by hand, so
@@ -185,6 +245,21 @@ if(QUINT_EXECUTABLE AND PYTHON3_EXECUTABLE)
     target_include_directories(evpl_rpc2_conformance PRIVATE ${QUINT_WORK_DIR})
 
     unit_test_rpc2_instance(conformance STREAM_SOCKET_TCP 8104)
+
+    # The same cases again, signed by real Kerberos instead of the stub.  Only
+    # over TCP: what changes is who computes the MICs, not the transport, so
+    # running it against every transport would buy nothing.  Skips (77) where
+    # krb5 is absent or refuses to mint a realm.
+    if(KRB5_GSSAPI_FOUND)
+        unit_test_rpc2_instance_flavor(conformance STREAM_SOCKET_TCP 8106
+                                       krb5 -k)
+
+        # And again with the scattered MIC entry point withheld, so rpc2's
+        # gathering fallback is exercised rather than left to whether the
+        # host's krb5 happens to have the IOV extension.
+        unit_test_rpc2_instance_flavor(conformance STREAM_SOCKET_TCP 8107
+                                       krb5_gather -K)
+    endif()
 
     # Also over RDMA-on-TCP: that transport needs no RDMA hardware or verbs but
     # does carry the RPC-over-RDMA framing, so it reaches the chunk-negotiation

--- a/src/rpc2/tests/conformance.c
+++ b/src/rpc2/tests/conformance.c
@@ -67,6 +67,7 @@
 #include "test_common.h"
 
 #include "gss_stub.h"
+#include "krb5_local.h"
 #include "evpl/evpl_rpc2_gss.h"
 
 #include "conformance_xdr.h"
@@ -367,6 +368,8 @@ defect_name(int d)
         case DEF_GSSPRIVDATAVALID:        return "GssPrivDataValid";
         case DEF_GSSPRIVSEALCORRUPT:      return "GssPrivSealCorrupt";
         case DEF_GSSPRIVSEQMISMATCH:      return "GssPrivSeqMismatch";
+        case DEF_GSSPRIVSPLITACROSSFRAGMENTS: return "GssPrivSplitAcrossFragments";
+        case DEF_GSSPRIVEMPTYARGS:        return "GssPrivEmptyArgs";
         case DEF_GSSDESTROYCONTEXT:       return "GssDestroyContext";
         case DEF_GSSDESTROYUNAUTHENTICATED: return "GssDestroyUnauthenticated";
         case DEF_GSSSEQABOVEMAX:          return "GssSeqAboveMax";
@@ -2577,6 +2580,169 @@ gss_exchange_split(
 } /* gss_exchange_split */
 
 /* How the GSS token in an rpc_gss_init_arg should be encoded. */
+/*
+ * Which mechanism this run drives.
+ *
+ * The stub is the default and owns the defect taxonomy: a real mechanism
+ * cannot be told to reject on command, and most of what this model asserts is
+ * a rejection.  Selecting krb5 (-k) leaves every message builder and every
+ * expectation exactly as it is and only changes who signs -- which is the
+ * point.  A stub whose MIC the driver also computes can never establish that
+ * libevpl and a real mechanism agree on WHICH BYTES are covered; two
+ * independent implementations of that agreement can.
+ *
+ * The handful of cases that need behaviour injection cannot run against a real
+ * mechanism and are skipped there; see gss_case_needs_stub().
+ */
+static struct krb5_local *g_krb5;   /* NULL => the stub */
+
+/* Whether the krb5 provider is presenting its scattered MIC entry point. */
+static int                g_krb5_noiov;
+
+
+/* Room for any mechanism's MIC.  The stub's is 8 bytes and krb5 aes256's is
+ * 28; this is checked at runtime rather than assumed. */
+#define MIC_MAX 64
+
+/* Sign as the initiator would, and report how long the MIC is.  Length is a
+ * return value rather than a constant because a real mechanism's is neither
+ * fixed nor the same as the stub's -- and a receiver that assumed otherwise is
+ * exactly the kind of thing this mode is here to catch. */
+static size_t
+mech_mic(
+    const void *msg,
+    size_t      len,
+    uint8_t    *out)
+{
+    void  *m;
+    size_t ml;
+
+    if (!g_krb5) {
+        gss_stub_mic(msg, len, out);
+        return GSS_STUB_MIC_LEN;
+    }
+
+    evpl_test_abort_if(krb5_local_get_mic(g_krb5, msg, len, &m, &ml),
+                       "krb5 get_mic failed");
+    evpl_test_abort_if(ml > MIC_MAX, "krb5 MIC is %zu bytes, over MIC_MAX", ml);
+
+    memcpy(out, m, ml);
+    free(m);
+    return ml;
+} /* mech_mic */
+
+/*
+ * Seal as the initiator would, and report the token length.
+ *
+ * The privacy counterpart of mech_mic, and it carries the same point: under
+ * the stub, the driver seals with the very routine the provider unseals with,
+ * so the two can only ever agree.  Under krb5 the token is a real RFC 4121
+ * wrap token -- header, confounder, ciphertext, checksum, and whatever
+ * rotation the mechanism chose -- and nothing in this file knows how any of
+ * that is laid out.  That is what makes the privacy cases worth running here:
+ * they stop testing that rpc2 agrees with the test, and start testing that
+ * rpc2 agrees with Kerberos.
+ */
+static size_t
+mech_seal(
+    const void *plain,
+    size_t      plain_len,
+    void       *out,
+    size_t      out_cap)
+{
+    void  *tok;
+    size_t tl;
+
+    if (!g_krb5) {
+        return gss_stub_seal(plain, plain_len, out, out_cap);
+    }
+
+    evpl_test_abort_if(krb5_local_wrap(g_krb5, plain, plain_len, &tok, &tl),
+                       "krb5 wrap failed");
+    evpl_test_abort_if(tl > out_cap,
+                       "krb5 token is %zu bytes, over the %zu-byte buffer",
+                       tl, out_cap);
+    memcpy(out, tok, tl);
+    free(tok);
+    return tl;
+} /* mech_seal */
+
+/* Unseal a reply.  Returns the plaintext length, or 0 if the token will not
+ * open -- which for a reply the server built is a failure of rpc2's sealing,
+ * not of the case. */
+static size_t
+mech_unseal(
+    const void *token,
+    size_t      token_len,
+    void       *out,
+    size_t      out_cap)
+{
+    void  *plain;
+    size_t pl;
+
+    if (!g_krb5) {
+        /* The stub's seal is symmetric: [len][xor][mic]. */
+        if (token_len < GSS_STUB_SEAL_OVERHEAD) {
+            return 0;
+        }
+        pl = ((size_t) ((const uint8_t *) token)[0] << 24) |
+            ((size_t) ((const uint8_t *) token)[1] << 16) |
+            ((size_t) ((const uint8_t *) token)[2] << 8) |
+            ((const uint8_t *) token)[3];
+        if (pl + GSS_STUB_SEAL_OVERHEAD != token_len || pl > out_cap) {
+            return 0;
+        }
+        return gss_stub_unseal(token, token_len, out) ? 0 : pl;
+    }
+
+    if (krb5_local_unwrap(g_krb5, token, token_len, &plain, &pl)) {
+        return 0;
+    }
+    if (pl > out_cap) {
+        free(plain);
+        return 0;
+    }
+    memcpy(out, plain, pl);
+    free(plain);
+    return pl;
+} /* mech_unseal */
+
+/* Check a MIC the ACCEPTOR produced -- a reply verifier, or the checksum over
+ * a krb5i reply body. */
+static int
+mech_verify(
+    const void *msg,
+    size_t      len,
+    const void *mic,
+    size_t      mic_len)
+{
+    uint8_t expect[GSS_STUB_MIC_LEN];
+
+    if (g_krb5) {
+        return krb5_local_verify_mic(g_krb5, msg, len, mic, mic_len);
+    }
+
+    if (mic_len != GSS_STUB_MIC_LEN) {
+        return -1;
+    }
+
+    gss_stub_mic(msg, len, expect);
+    return memcmp(expect, mic, GSS_STUB_MIC_LEN) == 0 ? 0 : -1;
+} /* mech_verify */
+
+/* Cases that steer the mechanism itself rather than the wire.  A real
+ * mechanism has no such switch, so these stay stub-only. */
+static int
+gss_case_needs_stub(int defect)
+{
+    return defect == DEF_GSSINITMECHFAILS ||
+           defect == DEF_GSSINITMECHFAILSWITHTOKEN ||
+           defect == DEF_GSSINITCONTINUES ||
+           defect == DEF_GSSCONTINUEINITTOKENMALFORMED ||
+           defect == DEF_GSSINTEGREPLYMICFAILS ||
+           defect == DEF_GSSINTEGREPLYMICOVERSIZE;
+} /* gss_case_needs_stub */
+
 #define INIT_TOKEN_GOOD    0   /* a well-formed opaque<>                    */
 #define INIT_TOKEN_ABSENT  1   /* no arguments at all: not even a length    */
 #define INIT_TOKEN_OVERRUN 2   /* a length that runs past the message       */
@@ -2613,8 +2779,23 @@ build_gss_init_call(
             put_bytes(msg, "INIT", 4);
             break;
         default:
-            put32(msg, 4);              /* token<> */
-            put_bytes(msg, "INIT", 4);
+            /* The stub accepts any token; a real mechanism wants the AP-REQ
+             * its own initiator produced, so the good token is whatever the
+             * mechanism in force calls good. */
+            if (g_krb5) {
+                void  *tok;
+                size_t tok_len;
+
+                evpl_test_abort_if(krb5_local_init_token(g_krb5, &tok,
+                                                         &tok_len),
+                                   "krb5 could not produce an AP-REQ");
+                put32(msg, tok_len);
+                put_bytes(msg, tok, tok_len);
+                free(tok);
+            } else {
+                put32(msg, 4);          /* token<> */
+                put_bytes(msg, "INIT", 4);
+            }
             break;
     } /* switch */
 } /* build_gss_init_call */
@@ -2674,7 +2855,8 @@ build_gss_data_call(
     int             good_mic,
     int             gss_verf)
 {
-    uint8_t  mic[GSS_STUB_MIC_LEN];
+    uint8_t  mic[MIC_MAX];
+    size_t   mic_len;
     uint32_t cred_len;
 
     msg->len = 0;
@@ -2688,13 +2870,13 @@ build_gss_data_call(
                             seq, service, &handle);
 
     if (gss_verf) {
-        gss_stub_mic(msg->data, gss_signed_len(cred_len), mic);
+        mic_len = mech_mic(msg->data, gss_signed_len(cred_len), mic);
         if (!good_mic) {
             mic[0] ^= 0xff;
         }
         put32(msg, RPCSEC_GSS_FLAVOR);
-        put32(msg, GSS_STUB_MIC_LEN);
-        put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+        put32(msg, mic_len);
+        put_bytes(msg, mic, mic_len);
     } else {
         put32(msg, 0);                      /* verf AUTH_NONE */
         put32(msg, 0);
@@ -2730,7 +2912,8 @@ build_gss_integ_call(
     int             with_args)
 {
     struct wirebuf databody;
-    uint8_t        mic[GSS_STUB_MIC_LEN];
+    uint8_t        mic[MIC_MAX];
+    size_t         mic_len;
     uint32_t       cred_len;
 
     msg->len = 0;
@@ -2745,10 +2928,10 @@ build_gss_integ_call(
 
     /* The header MIC covers the message up to and including the credential,
      * so it has to be taken before the verifier or the arguments land. */
-    gss_stub_mic(msg->data, gss_signed_len(cred_len), mic);
+    mic_len = mech_mic(msg->data, gss_signed_len(cred_len), mic);
     put32(msg, RPCSEC_GSS_FLAVOR);
-    put32(msg, GSS_STUB_MIC_LEN);
-    put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+    put32(msg, mic_len);
+    put_bytes(msg, mic, mic_len);
 
     databody.len = 0;
     put32(&databody, body_seq);
@@ -2761,12 +2944,12 @@ build_gss_integ_call(
 
     /* The checksum covers the unpadded databody, which is what the server
      * gathers back out of the message. */
-    gss_stub_mic(databody.data, databody.len, mic);
+    mic_len = mech_mic(databody.data, databody.len, mic);
     if (!good_checksum) {
         mic[0] ^= 0xff;
     }
-    put32(msg, GSS_STUB_MIC_LEN);
-    put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+    put32(msg, mic_len);
+    put_bytes(msg, mic, mic_len);
 } /* build_gss_integ_call */
 
 /*
@@ -2795,9 +2978,9 @@ build_gss_priv_call(
     int             with_args)
 {
     struct wirebuf plain;
-    uint8_t        mic[GSS_STUB_MIC_LEN];
+    uint8_t        mic[MIC_MAX];
     uint8_t        token[4096];
-    size_t         token_len;
+    size_t         token_len, mic_len;
     uint32_t       cred_len;
 
     msg->len = 0;
@@ -2813,10 +2996,10 @@ build_gss_priv_call(
     /* The header MIC covers the message through the credential and is sent in
      * the clear: under privacy the *arguments* are sealed, the RPC header is
      * not, which is exactly why the seq has to be sealed as well. */
-    gss_stub_mic(msg->data, gss_signed_len(cred_len), mic);
+    mic_len = mech_mic(msg->data, gss_signed_len(cred_len), mic);
     put32(msg, RPCSEC_GSS_FLAVOR);
-    put32(msg, GSS_STUB_MIC_LEN);
-    put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+    put32(msg, (uint32_t) mic_len);
+    put_bytes(msg, mic, mic_len);
 
     plain.len = 0;
     put32(&plain, body_seq);
@@ -2824,13 +3007,16 @@ build_gss_priv_call(
         build_args_into(&plain, TGT_TSCALARS);
     }
 
-    token_len = gss_stub_seal(plain.data, plain.len, token, sizeof(token));
+    token_len = mech_seal(plain.data, plain.len, token, sizeof(token));
 
     if (!good_seal) {
-        /* Flip a bit inside the sealed body.  The stub's unseal recomputes the
-         * MIC over the recovered plaintext, so this is caught as a failed
-         * unseal -- the token no longer decrypts to what was sealed. */
-        token[4] ^= 0xff;
+        /* Corrupt the token's last byte rather than a fixed early offset.
+         * Under the stub that lands in the trailing MIC; under krb5 it lands
+         * in the wrap token's checksum or final ciphertext block.  Either way
+         * it is inside the sealed region for both mechanisms, which a fixed
+         * offset into the stub's framing would not be -- a real token's header
+         * is a different size and shape entirely. */
+        token[token_len - 1] ^= 0xff;
     }
 
     put32(msg, (uint32_t) token_len);
@@ -2857,7 +3043,8 @@ build_gss_integ_bad_call(
     int             mode)
 {
     struct wirebuf databody;
-    uint8_t        mic[GSS_STUB_MIC_LEN];
+    uint8_t        mic[MIC_MAX];
+    size_t         mic_len;
     uint32_t       cred_len;
 
     msg->len = 0;
@@ -2870,10 +3057,10 @@ build_gss_integ_bad_call(
     cred_len = put_gss_cred(msg, RPCSEC_GSS_VERS_1, RPCSEC_GSS_DATA,
                             seq, GSS_SVC_INTEGRITY, &handle);
 
-    gss_stub_mic(msg->data, gss_signed_len(cred_len), mic);
+    mic_len = mech_mic(msg->data, gss_signed_len(cred_len), mic);
     put32(msg, RPCSEC_GSS_FLAVOR);
-    put32(msg, GSS_STUB_MIC_LEN);
-    put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+    put32(msg, mic_len);
+    put_bytes(msg, mic, mic_len);
 
     if (mode == INTEG_BAD_NO_LENGTH) {
         /* Two bytes of arguments: not enough for the databody's length
@@ -2887,8 +3074,8 @@ build_gss_integ_bad_call(
         /* A databody too short to carry the seq_num it must begin with. */
         put32(msg, 2);
         put_bytes(msg, "\0\0", 2);
-        put32(msg, GSS_STUB_MIC_LEN);
-        put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+        put32(msg, mic_len);
+        put_bytes(msg, mic, mic_len);
         return;
     }
 
@@ -2899,8 +3086,8 @@ build_gss_integ_bad_call(
     if (mode == INTEG_BAD_LONG_BODY) {
         put32(msg, databody.len + 4096);
         put_bytes(msg, databody.data, databody.len);
-        put32(msg, GSS_STUB_MIC_LEN);
-        put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+        put32(msg, mic_len);
+        put_bytes(msg, mic, mic_len);
         return;
     }
 
@@ -2912,9 +3099,9 @@ build_gss_integ_bad_call(
     }
 
     /* INTEG_BAD_LONG_CKSUM */
-    gss_stub_mic(databody.data, databody.len, mic);
+    mic_len = mech_mic(databody.data, databody.len, mic);
     put32(msg, 4096);
-    put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+    put_bytes(msg, mic, mic_len);
 } /* build_gss_integ_bad_call */
 
 /*
@@ -2976,7 +3163,6 @@ check_integ_reply(
     int            with_args)
 {
     struct wirebuf args;
-    uint8_t        expect[GSS_STUB_MIC_LEN];
     uint32_t       db_len, db_pad, ck_len;
 
     if (len < 8) {
@@ -2989,13 +3175,14 @@ check_integ_reply(
         return 0;
     }
 
+    /* The checksum length is the mechanism's business, so it is read rather
+     * than asserted; what matters is that it verifies. */
     ck_len = get32(results + 4 + db_pad);
-    if (ck_len != GSS_STUB_MIC_LEN || 4 + db_pad + 4 + ck_len > len) {
+    if (ck_len == 0 || 4 + db_pad + 4 + ck_len > len) {
         return 0;
     }
 
-    gss_stub_mic(results + 4, db_len, expect);
-    if (memcmp(expect, results + 4 + db_pad + 4, GSS_STUB_MIC_LEN)) {
+    if (mech_verify(results + 4, db_len, results + 4 + db_pad + 4, ck_len)) {
         return 0;
     }
 
@@ -3020,6 +3207,55 @@ check_integ_reply(
 } /* check_integ_reply */
 
 /*
+ * The privacy counterpart: the reply body is rpc_gss_priv_data, a single
+ * opaque holding the sealed token of seq_num || results.
+ *
+ * Checking this is what stops the reply direction being taken on trust.  A
+ * server that answered a sealed call with a cleartext body would satisfy every
+ * other assertion in the suite -- the client got MSG_ACCEPTED/SUCCESS with the
+ * right results -- while having silently dropped the confidentiality the
+ * caller asked for.  Under privacy that is not a degraded reply, it is the
+ * payload in the clear on the wire.
+ */
+static int
+check_priv_reply(
+    const uint8_t *results,
+    uint32_t       len,
+    uint32_t       seq,
+    int            with_args)
+{
+    struct wirebuf args;
+    uint8_t        plain[2048];
+    uint32_t       tok_len;
+    size_t         pl;
+
+    if (len < 4) {
+        return 0;
+    }
+
+    tok_len = get32(results);
+    if (tok_len == 0 || 4 + tok_len > len) {
+        return 0;
+    }
+
+    pl = mech_unseal(results + 4, tok_len, plain, sizeof(plain));
+    if (pl < 4) {
+        return 0;
+    }
+
+    if (get32(plain) != seq) {
+        return 0;
+    }
+
+    if (!with_args) {
+        return pl == 4;
+    }
+
+    build_args(&args, TGT_TSCALARS);
+    return pl - 4 == args.len && memcmp(plain + 4, args.data, args.len) == 0;
+} /* check_priv_reply */
+
+/*
  * Build an RPCSEC_GSS_DESTROY control message.  RFC 2203 sec 5.4: framed like
  * a data request, but with gss_proc set to DESTROY, NULLPROC in the header and
  * no procedure arguments.
@@ -3032,7 +3268,8 @@ build_gss_destroy_call(
     uint32_t        seq,
     int             gss_verf)
 {
-    uint8_t  mic[GSS_STUB_MIC_LEN];
+    uint8_t  mic[MIC_MAX];
+    size_t   mic_len;
     uint32_t cred_len;
 
     msg->len = 0;
@@ -3046,10 +3283,10 @@ build_gss_destroy_call(
                             seq, GSS_SVC_NONE, &handle);
 
     if (gss_verf) {
-        gss_stub_mic(msg->data, gss_signed_len(cred_len), mic);
+        mic_len = mech_mic(msg->data, gss_signed_len(cred_len), mic);
         put32(msg, RPCSEC_GSS_FLAVOR);
-        put32(msg, GSS_STUB_MIC_LEN);
-        put_bytes(msg, mic, GSS_STUB_MIC_LEN);
+        put32(msg, mic_len);
+        put_bytes(msg, mic, mic_len);
     } else {
         put32(msg, 0);                      /* verf AUTH_NONE */
         put32(msg, 0);
@@ -3130,6 +3367,8 @@ defect_is_gss(uint8_t defect)
         case DEF_GSSPRIVDATAVALID:
         case DEF_GSSPRIVSEALCORRUPT:
         case DEF_GSSPRIVSEQMISMATCH:
+        case DEF_GSSPRIVSPLITACROSSFRAGMENTS:
+        case DEF_GSSPRIVEMPTYARGS:
         case DEF_GSSDESTROYCONTEXT:
         case DEF_GSSDESTROYUNAUTHENTICATED:
         case DEF_GSSSEQABOVEMAX:
@@ -3321,7 +3560,12 @@ run_gss_case(
             }
             outcome = gss_exchange(evpl, fd, &msg, NULL, NULL);
 
-            evpl_rpc2_set_gss_provider(g_thread, gss_stub_provider(), NULL);
+            evpl_rpc2_set_gss_provider(g_thread,
+                                       g_krb5 ? (g_krb5_noiov
+                                                 ? krb5_local_provider_noiov()
+                                                 : krb5_local_provider())
+                                              : gss_stub_provider(),
+                                       g_krb5 ? krb5_local_arg(g_krb5) : NULL);
             return outcome;
 
         case DEF_GSSCREDVERSIONWRONG:
@@ -3370,8 +3614,61 @@ run_gss_case(
             return gss_exchange(evpl, fd, &msg, NULL, NULL);
 
         case DEF_GSSPRIVDATAVALID:
+        {
+            uint8_t  results[2048];
+            uint32_t results_len = sizeof(results);
+
             build_gss_priv_call(&msg, 0x47535360, handle, 1, 1, 1, 1);
-            return gss_exchange(evpl, fd, &msg, NULL, NULL);
+            outcome = gss_exchange(evpl, fd, &msg, results, &results_len);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+            /* Not just "did it answer" -- did it answer SEALED.  A cleartext
+             * body here would satisfy every other assertion while putting the
+             * payload on the wire in the open. */
+            return check_priv_reply(results, results_len, 1, 1)
+                   ? EXP_SUCCESS : ACT_MALFORMED;
+        }
+
+        case DEF_GSSPRIVSPLITACROSSFRAGMENTS:
+        {
+            uint8_t  results[2048];
+            uint32_t results_len = sizeof(results);
+
+            build_gss_priv_call(&msg, 0x47535363, handle, 1, 1, 1, 1);
+
+            /* Split inside the sealed token so it arrives in two buffers.
+             * This is the only case that reaches rpc2's gather path: privacy
+             * needs the whole token contiguous for gss_unwrap, so a scattered
+             * one has to be collected first, and until now nothing made a
+             * token arrive scattered. */
+            evpl_test_abort_if(msg.len < 60, "privacy call unexpectedly short");
+            outcome = gss_exchange_split(evpl, fd, &msg, msg.len - 40,
+                                         results, &results_len);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+            return check_priv_reply(results, results_len, 1, 1)
+                   ? EXP_SUCCESS : ACT_MALFORMED;
+        }
+
+        case DEF_GSSPRIVEMPTYARGS:
+        {
+            uint8_t  results[2048];
+            uint32_t results_len = sizeof(results);
+
+            /* NULLPROC under privacy: the token seals a seq_num and nothing
+             * else, so the reply's sealed body must be exactly four bytes.  A
+             * server that padded it would still unseal correctly, which is why
+             * the length is the assertion. */
+            build_gss_priv_call(&msg, 0x47535364, handle, 1, 1, 1, 0);
+            outcome = gss_exchange(evpl, fd, &msg, results, &results_len);
+            if (outcome != EXP_SUCCESS) {
+                return outcome;
+            }
+            return check_priv_reply(results, results_len, 1, 0)
+                   ? EXP_SUCCESS : ACT_MALFORMED;
+        }
 
         case DEF_GSSPRIVSEALCORRUPT:
             build_gss_priv_call(&msg, 0x47535361, handle, 1, 1, 0, 1);
@@ -3605,6 +3902,17 @@ run_defect_case(
 
     if (defect_is_gss(c->defect)) {
         if (!defect_case_first_time(c->defect, c->param)) {
+            g_results.defect_skipped++;
+            return;
+        }
+
+        /* A real mechanism has no behaviour switch, so the cases that steer
+         * the mechanism rather than the wire only run against the stub.
+         * Everything else runs under both: a bit flipped in a real MIC is
+         * just as invalid as one flipped in the stub's, and the
+         * sequence-window and framing defects never involve the mechanism at
+         * all. */
+        if (g_krb5 && gss_case_needs_stub(c->defect)) {
             g_results.defect_skipped++;
             return;
         }
@@ -3875,11 +4183,29 @@ main(
     struct evpl_thread_config *tcfg;
     uint64_t                   drain_deadline;
     int                        opt, rc, failed;
+    int                        use_krb5   = 0;
+    int                        krb5_noiov = 0;
+    const char                *krb5_why   = NULL;
 
     conformance_evpl_config();
 
-    while ((opt = getopt(argc, argv, "r:p:")) != -1) {
+    while ((opt = getopt(argc, argv, "r:p:kK")) != -1) {
         switch (opt) {
+            case 'k':
+                /* Drive the same cases against real Kerberos instead of the
+                 * stub.  The realm is minted in-process, so this needs no KDC
+                 * -- but it does need krb5, and a host without it skips. */
+                use_krb5 = 1;
+                break;
+            case 'K':
+                /* As -k, but with the provider's scattered MIC entry point
+                 * withheld, which is what puts rpc2 on its gathering
+                 * fallback.  Which of the two runs is otherwise a property of
+                 * the host's krb5 rather than of the test, and the fallback
+                 * is the path with the size ceiling. */
+                use_krb5   = 1;
+                krb5_noiov = 1;
+                break;
             case 'r':
                 rc = evpl_protocol_lookup(&proto, optarg);
                 if (rc) {
@@ -3943,7 +4269,27 @@ main(
     /* Register the deterministic GSS provider so the RPCSEC_GSS cases have a
      * mechanism to talk to.  Without one, libevpl rejects flavor-6 calls with
      * AUTH_REJECTEDCRED before reaching any of the framing under test. */
-    evpl_rpc2_set_gss_provider(g_thread, gss_stub_provider(), NULL);
+    if (use_krb5) {
+        g_krb5 = krb5_local_create(&krb5_why);
+
+        if (!g_krb5) {
+            /* No realm to be had.  Skipping is the honest outcome: the stub
+             * run already covered the framing, and reporting a pass for a
+             * mechanism that never ran would be worse than saying so. */
+            evpl_test_info("skipping: krb5 unavailable (%s)",
+                           krb5_why ? krb5_why : "unknown");
+            return 77;
+        }
+
+        g_krb5_noiov = krb5_noiov;
+
+        evpl_rpc2_set_gss_provider(g_thread,
+                                   krb5_noiov ? krb5_local_provider_noiov()
+                                              : krb5_local_provider(),
+                                   krb5_local_arg(g_krb5));
+    } else {
+        evpl_rpc2_set_gss_provider(g_thread, gss_stub_provider(), NULL);
+    }
 
     evpl_rpc2_server_attach(g_thread, server, g_server_private);
 

--- a/src/rpc2/tests/gss_stub.c
+++ b/src/rpc2/tests/gss_stub.c
@@ -113,6 +113,37 @@ gss_stub_seal(
     return plain_len + GSS_STUB_SEAL_OVERHEAD;
 } /* gss_stub_seal */
 
+int
+gss_stub_unseal(
+    const void *token,
+    size_t      token_len,
+    void       *out)
+{
+    const uint8_t *tok   = token;
+    uint8_t       *plain = out;
+    uint8_t        mic[GSS_STUB_MIC_LEN];
+    uint32_t       plain_len;
+    size_t         i;
+
+    if (token_len < GSS_STUB_SEAL_OVERHEAD) {
+        return -1;
+    }
+
+    plain_len = ((uint32_t) tok[0] << 24) | ((uint32_t) tok[1] << 16) |
+        ((uint32_t) tok[2] << 8) | tok[3];
+
+    if ((size_t) plain_len + GSS_STUB_SEAL_OVERHEAD != token_len) {
+        return -1;
+    }
+
+    for (i = 0; i < plain_len; i++) {
+        plain[i] = tok[4 + i] ^ gss_stub_keystream(i);
+    }
+
+    gss_stub_mic(plain, plain_len, mic);
+    return memcmp(mic, tok + 4 + plain_len, GSS_STUB_MIC_LEN) == 0 ? 0 : -1;
+} /* gss_stub_unseal */
+
 /* Per-context cookie.  Only its existence matters to libevpl, which treats it
  * as opaque; the stub keeps a marker so destroy() can assert it owns it. */
 struct gss_stub_ctx {
@@ -286,24 +317,13 @@ gss_stub_unwrap(
     size_t      out_cap,
     size_t     *r_out_len)
 {
-    const uint8_t *tok = in;
-    uint8_t        mic[GSS_STUB_MIC_LEN];
-    uint8_t       *plain = out;
-    uint32_t       plain_len;
-    size_t         i;
+    size_t plain_len;
 
     if (in_len < GSS_STUB_SEAL_OVERHEAD) {
         return -1;
     }
 
-    plain_len = ((uint32_t) tok[0] << 24) | ((uint32_t) tok[1] << 16) |
-        ((uint32_t) tok[2] << 8) | tok[3];
-
-    /* The length is inside the token, so a truncated or oversized claim is
-     * itself evidence of tampering rather than something to trust. */
-    if ((size_t) plain_len + GSS_STUB_SEAL_OVERHEAD != in_len) {
-        return -1;
-    }
+    plain_len = in_len - GSS_STUB_SEAL_OVERHEAD;
 
     /* A plaintext is never larger than its token, so a caller that sized the
      * buffer from the token always has room; refuse rather than truncate if
@@ -312,14 +332,7 @@ gss_stub_unwrap(
         return -1;
     }
 
-    for (i = 0; i < plain_len; i++) {
-        plain[i] = tok[4 + i] ^ gss_stub_keystream(i);
-    }
-
-    /* Tamper-evidence: a flipped bit anywhere in the sealed body changes the
-     * recovered plaintext, and the MIC over that plaintext no longer matches. */
-    gss_stub_mic(plain, plain_len, mic);
-    if (memcmp(mic, tok + 4 + plain_len, GSS_STUB_MIC_LEN) != 0) {
+    if (gss_stub_unseal(in, in_len, out)) {
         return -1;
     }
 

--- a/src/rpc2/tests/gss_stub.h
+++ b/src/rpc2/tests/gss_stub.h
@@ -109,6 +109,15 @@ gss_stub_seal(
     void       *out,
     size_t      out_cap);
 
+/* The inverse, so a driver can open a reply the stub sealed.  Writes at most
+ * (token_len - GSS_STUB_SEAL_OVERHEAD) bytes.  Returns 0 on success, non-zero
+ * if the token is malformed or its MIC does not verify. */
+int
+gss_stub_unseal(
+    const void *token,
+    size_t      token_len,
+    void       *out);
+
 const struct evpl_rpc2_gss_provider *
 gss_stub_provider(
     void);

--- a/src/rpc2/tests/krb5_local.c
+++ b/src/rpc2/tests/krb5_local.c
@@ -1,0 +1,862 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <krb5.h>
+#include <gssapi/gssapi.h>
+#include <gssapi/gssapi_krb5.h>
+
+#if defined(__has_include)
+#if __has_include(<gssapi/gssapi_ext.h>)
+#include <gssapi/gssapi_ext.h>
+#endif /* __has_include */
+#endif /* defined(__has_include) */
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_rpc2.h"
+#include "evpl/evpl_rpc2_gss.h"
+#include "krb5_local.h"
+
+/*
+ * Exported by libkrb5 but not declared in its public headers.  These are what
+ * mint a ticket without a KDC: the first seals the ticket's encrypted part
+ * under the service key, the second serialises the result.  Both have been
+ * stable exports for the life of MIT krb5, and the failure mode if a release
+ * ever drops them is a test that does not link -- not a runtime surprise.
+ */
+extern krb5_error_code krb5_encrypt_tkt_part(
+    krb5_context,
+    const krb5_keyblock *,
+    krb5_ticket *);
+
+extern krb5_error_code encode_krb5_ticket(
+    const krb5_ticket *,
+    krb5_data **);
+
+#define KRB5_LOCAL_REALM   "TEST.LIBEVPL"
+#define KRB5_LOCAL_SERVICE "libevpl"
+#define KRB5_LOCAL_HOST    "localhost"
+#define KRB5_LOCAL_USER    "conformance"
+
+struct krb5_local {
+    krb5_context   ctx;
+    krb5_principal client;
+    krb5_principal server;
+    krb5_keytab    keytab;
+    krb5_ccache    ccache;
+
+    /* The initiator's context, established lazily by the first init_token. */
+    gss_cred_id_t  init_cred;
+    gss_ctx_id_t   init_ctx;
+
+    /* The acceptor's credential; contexts are per-exchange and owned by rpc2
+     * through the provider's gss_ctx cookie. */
+    gss_cred_id_t  accept_cred;
+
+    int            iov_enabled;
+};
+
+/* ------------------------------------------------------------------ */
+/* Realm construction                                                   */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Mint the service ticket a KDC would have issued, and leave it in the
+ * initiator's memory ccache.  This is the whole trick: an AP-REQ needs only
+ * the service ticket, and the service key is ours, so nothing has to be asked
+ * of anybody.
+ */
+static int
+krb5_local_mint(
+    struct krb5_local   *kl,
+    const krb5_keyblock *svckey)
+{
+    krb5_enc_tkt_part enc;
+    krb5_ticket       tkt;
+    krb5_creds        creds;
+    krb5_keyblock     seskey;
+    krb5_data        *tktdata = NULL;
+    krb5_timestamp    now;
+    int               rc = -1;
+
+    memset(&enc, 0, sizeof(enc));
+    memset(&tkt, 0, sizeof(tkt));
+    memset(&creds, 0, sizeof(creds));
+    memset(&seskey, 0, sizeof(seskey));
+
+    if (krb5_c_make_random_key(kl->ctx, svckey->enctype, &seskey)) {
+        return -1;
+    }
+
+    if (krb5_timeofday(kl->ctx, &now)) {
+        goto out;
+    }
+
+    enc.flags                        = TKT_FLG_INITIAL;
+    enc.session                      = &seskey;
+    enc.client                       = kl->client;
+    enc.times.authtime               = now;
+    enc.times.starttime              = now;
+    enc.times.endtime                = now + 3600;
+    enc.transited.tr_type            = KRB5_DOMAIN_X500_COMPRESS;
+    enc.transited.tr_contents.data   = NULL;
+    enc.transited.tr_contents.length = 0;
+
+    tkt.server    = kl->server;
+    tkt.enc_part2 = &enc;
+
+    if (krb5_encrypt_tkt_part(kl->ctx, svckey, &tkt)) {
+        goto out;
+    }
+
+    if (encode_krb5_ticket(&tkt, &tktdata)) {
+        goto out;
+    }
+
+    creds.client       = kl->client;
+    creds.server       = kl->server;
+    creds.keyblock     = seskey;
+    creds.times        = enc.times;
+    creds.ticket_flags = enc.flags;
+    creds.ticket       = *tktdata;
+
+    if (krb5_cc_initialize(kl->ctx, kl->ccache, kl->client)) {
+        goto out;
+    }
+
+    if (krb5_cc_store_cred(kl->ctx, kl->ccache, &creds)) {
+        goto out;
+    }
+
+    rc = 0;
+
+ out:
+    if (tktdata) {
+        krb5_free_data(kl->ctx, tktdata);
+    }
+    if (tkt.enc_part.ciphertext.data) {
+        free(tkt.enc_part.ciphertext.data);
+    }
+    krb5_free_keyblock_contents(kl->ctx, &seskey);
+    return rc;
+} /* krb5_local_mint */
+
+struct krb5_local *
+krb5_local_create(const char **reason)
+{
+    struct krb5_local *kl;
+    krb5_keyblock      svckey;
+    krb5_keytab_entry  kte;
+    OM_uint32          maj, min;
+    const char        *why = "krb5 unavailable";
+
+    kl = calloc(1, sizeof(*kl));
+
+    if (!kl) {
+        goto fail;
+    }
+
+    kl->init_cred   = GSS_C_NO_CREDENTIAL;
+    kl->accept_cred = GSS_C_NO_CREDENTIAL;
+    kl->init_ctx    = GSS_C_NO_CONTEXT;
+    kl->iov_enabled = 1;
+
+    memset(&svckey, 0, sizeof(svckey));
+    memset(&kte, 0, sizeof(kte));
+
+    /* Each case shakes hands again, so the same client sends many AP-REQs
+     * within a second.  The replay cache exists to refuse exactly that, and
+     * here it would be refusing the test rather than an attacker -- and would
+     * write cache files besides, which a self-contained realm should not. */
+    setenv("KRB5RCACHETYPE", "none", 1);
+
+    if (krb5_init_context(&kl->ctx)) {
+        why = "krb5_init_context failed";
+        goto fail;
+    }
+
+    if (krb5_build_principal(kl->ctx, &kl->client, strlen(KRB5_LOCAL_REALM),
+                             KRB5_LOCAL_REALM, KRB5_LOCAL_USER, NULL) ||
+        krb5_build_principal(kl->ctx, &kl->server, strlen(KRB5_LOCAL_REALM),
+                             KRB5_LOCAL_REALM, KRB5_LOCAL_SERVICE,
+                             KRB5_LOCAL_HOST, NULL)) {
+        why = "krb5_build_principal failed";
+        goto fail;
+    }
+
+    /* AES-256 rather than whatever the host's default happens to be, so the
+     * enctype is a property of the test and not of /etc/krb5.conf. */
+    if (krb5_c_make_random_key(kl->ctx, ENCTYPE_AES256_CTS_HMAC_SHA1_96,
+                               &svckey)) {
+        why = "no aes256 support";
+        goto fail;
+    }
+
+    if (krb5_kt_resolve(kl->ctx, "MEMORY:evpl_krb5_local", &kl->keytab) ||
+        krb5_cc_resolve(kl->ctx, "MEMORY:evpl_krb5_local", &kl->ccache)) {
+        why = "MEMORY: keytab/ccache unavailable";
+        goto fail;
+    }
+
+    kte.principal = kl->server;
+    kte.vno       = 1;
+    kte.key       = svckey;
+
+    if (krb5_kt_add_entry(kl->ctx, kl->keytab, &kte)) {
+        why = "krb5_kt_add_entry failed";
+        goto fail;
+    }
+
+    if (krb5_local_mint(kl, &svckey)) {
+        why = "could not mint a service ticket";
+        goto fail;
+    }
+
+    maj = gss_krb5_import_cred(&min, kl->ccache, NULL, NULL, &kl->init_cred);
+
+    if (GSS_ERROR(maj)) {
+        why = "gss_krb5_import_cred (initiator) failed";
+        goto fail;
+    }
+
+    maj = gss_krb5_import_cred(&min, NULL, kl->server, kl->keytab,
+                               &kl->accept_cred);
+
+    if (GSS_ERROR(maj)) {
+        why = "gss_krb5_import_cred (acceptor) failed";
+        goto fail;
+    }
+
+    krb5_free_keyblock_contents(kl->ctx, &svckey);
+
+    return kl;
+
+ fail:
+    if (reason) {
+        *reason = why;
+    }
+    if (kl) {
+        krb5_local_destroy(kl);
+    }
+    return NULL;
+} /* krb5_local_create */
+
+void
+krb5_local_destroy(struct krb5_local *kl)
+{
+    OM_uint32 min;
+
+    if (!kl) {
+        return;
+    }
+
+    if (kl->init_ctx != GSS_C_NO_CONTEXT) {
+        gss_delete_sec_context(&min, &kl->init_ctx, GSS_C_NO_BUFFER);
+    }
+    if (kl->init_cred != GSS_C_NO_CREDENTIAL) {
+        gss_release_cred(&min, &kl->init_cred);
+    }
+    if (kl->accept_cred != GSS_C_NO_CREDENTIAL) {
+        gss_release_cred(&min, &kl->accept_cred);
+    }
+
+    if (kl->ctx) {
+        if (kl->keytab) {
+            krb5_kt_close(kl->ctx, kl->keytab);
+        }
+        if (kl->ccache) {
+            krb5_cc_destroy(kl->ctx, kl->ccache);
+        }
+        if (kl->client) {
+            krb5_free_principal(kl->ctx, kl->client);
+        }
+        if (kl->server) {
+            krb5_free_principal(kl->ctx, kl->server);
+        }
+        krb5_free_context(kl->ctx);
+    }
+
+    free(kl);
+} /* krb5_local_destroy */
+
+void *
+krb5_local_arg(struct krb5_local *kl)
+{
+    return kl;
+} /* krb5_local_arg */
+
+int
+krb5_local_have_iov(void)
+{
+#ifdef GSS_IOV_BUFFER_TYPE_MIC_TOKEN
+    return 1;
+#else  /* ifdef GSS_IOV_BUFFER_TYPE_MIC_TOKEN */
+    return 0;
+#endif /* ifdef GSS_IOV_BUFFER_TYPE_MIC_TOKEN */
+} /* krb5_local_have_iov */
+
+void
+krb5_local_set_iov_enabled(
+    struct krb5_local *kl,
+    int                enabled)
+{
+    kl->iov_enabled = enabled;
+} /* krb5_local_set_iov_enabled */
+
+/* ------------------------------------------------------------------ */
+/* Initiator                                                            */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Establish (or re-establish) the initiator context.
+ *
+ * RPCSEC_GSS creates one security context per handshake, and the driver runs
+ * a handshake per case, so each case needs its own: a MIC only verifies
+ * against the acceptor context grown from the same AP-REQ.  Cases that skip
+ * the handshake entirely -- a DATA call naming a handle the server never
+ * issued, say -- still have to put SOMETHING in the verifier, so one is
+ * created on demand for them too and the token thrown away.
+ */
+static int
+krb5_local_new_context(
+    struct krb5_local *kl,
+    void             **token,
+    size_t            *token_len)
+{
+    OM_uint32       maj, min, flags;
+    gss_name_t      target = GSS_C_NO_NAME;
+    gss_buffer_desc nb, tok = GSS_C_EMPTY_BUFFER;
+    char            name[256];
+    int             rc = -1;
+
+    snprintf(name, sizeof(name), "%s/%s@%s", KRB5_LOCAL_SERVICE,
+             KRB5_LOCAL_HOST, KRB5_LOCAL_REALM);
+
+    nb.value  = name;
+    nb.length = strlen(name);
+
+    maj = gss_import_name(&min, &nb, (gss_OID) GSS_KRB5_NT_PRINCIPAL_NAME,
+                          &target);
+
+    if (GSS_ERROR(maj)) {
+        return -1;
+    }
+
+    /* Start from nothing: a stale context would sign with the wrong session
+     * key for the acceptor context this handshake is about to create. */
+    if (kl->init_ctx != GSS_C_NO_CONTEXT) {
+        gss_delete_sec_context(&min, &kl->init_ctx, GSS_C_NO_BUFFER);
+        kl->init_ctx = GSS_C_NO_CONTEXT;
+    }
+
+    maj = gss_init_sec_context(&min, kl->init_cred, &kl->init_ctx, target,
+                               GSS_C_NO_OID,
+                               GSS_C_INTEG_FLAG | GSS_C_CONF_FLAG |
+                               GSS_C_SEQUENCE_FLAG,
+                               0, GSS_C_NO_CHANNEL_BINDINGS, GSS_C_NO_BUFFER,
+                               NULL, &tok, &flags, NULL);
+
+    if (!GSS_ERROR(maj) && tok.length) {
+        if (token) {
+            *token = malloc(tok.length);
+            if (*token) {
+                memcpy(*token, tok.value, tok.length);
+                *token_len = tok.length;
+                rc         = 0;
+            }
+        } else {
+            rc = 0;
+        }
+    }
+
+    gss_release_buffer(&min, &tok);
+    gss_release_name(&min, &target);
+    return rc;
+} /* krb5_local_new_context */
+
+int
+krb5_local_init_token(
+    struct krb5_local *kl,
+    void             **token,
+    size_t            *token_len)
+{
+    return krb5_local_new_context(kl, token, token_len);
+} /* krb5_local_init_token */
+
+/* Whatever context is current, creating one if a case never shook hands. */
+static int
+krb5_local_ensure_context(struct krb5_local *kl)
+{
+    if (kl->init_ctx != GSS_C_NO_CONTEXT) {
+        return 0;
+    }
+
+    return krb5_local_new_context(kl, NULL, NULL);
+} /* krb5_local_ensure_context */
+
+static int
+krb5_local_buf_out(
+    gss_buffer_desc *in,
+    void           **out,
+    size_t          *out_len)
+{
+    *out = malloc(in->length ? in->length : 1);
+
+    if (!*out) {
+        return -1;
+    }
+
+    memcpy(*out, in->value, in->length);
+    *out_len = in->length;
+    return 0;
+} /* krb5_local_buf_out */
+
+int
+krb5_local_get_mic(
+    struct krb5_local *kl,
+    const void        *msg,
+    size_t             msg_len,
+    void             **mic,
+    size_t            *mic_len)
+{
+    OM_uint32       maj, min;
+    gss_buffer_desc in, out = GSS_C_EMPTY_BUFFER;
+    int             rc;
+
+    if (krb5_local_ensure_context(kl)) {
+        return -1;
+    }
+
+    in.value  = (void *) msg;
+    in.length = msg_len;
+
+    maj = gss_get_mic(&min, kl->init_ctx, GSS_C_QOP_DEFAULT, &in, &out);
+
+    if (GSS_ERROR(maj)) {
+        return -1;
+    }
+
+    rc = krb5_local_buf_out(&out, mic, mic_len);
+    gss_release_buffer(&min, &out);
+    return rc;
+} /* krb5_local_get_mic */
+
+int
+krb5_local_verify_mic(
+    struct krb5_local *kl,
+    const void        *msg,
+    size_t             msg_len,
+    const void        *mic,
+    size_t             mic_len)
+{
+    OM_uint32       maj, min;
+    gss_buffer_desc in, tok;
+
+    if (krb5_local_ensure_context(kl)) {
+        return -1;
+    }
+
+    in.value   = (void *) msg;
+    in.length  = msg_len;
+    tok.value  = (void *) mic;
+    tok.length = mic_len;
+
+    maj = gss_verify_mic(&min, kl->init_ctx, &in, &tok, NULL);
+
+    return GSS_ERROR(maj) ? -1 : 0;
+} /* krb5_local_verify_mic */
+
+int
+krb5_local_wrap(
+    struct krb5_local *kl,
+    const void        *in_buf,
+    size_t             in_len,
+    void             **out,
+    size_t            *out_len)
+{
+    OM_uint32       maj, min;
+    gss_buffer_desc in, o = GSS_C_EMPTY_BUFFER;
+    int             conf, rc;
+
+    if (krb5_local_ensure_context(kl)) {
+        return -1;
+    }
+
+    in.value  = (void *) in_buf;
+    in.length = in_len;
+
+    maj = gss_wrap(&min, kl->init_ctx, 1, GSS_C_QOP_DEFAULT, &in, &conf, &o);
+
+    if (GSS_ERROR(maj)) {
+        return -1;
+    }
+
+    rc = krb5_local_buf_out(&o, out, out_len);
+    gss_release_buffer(&min, &o);
+    return rc;
+} /* krb5_local_wrap */
+
+int
+krb5_local_unwrap(
+    struct krb5_local *kl,
+    const void        *in_buf,
+    size_t             in_len,
+    void             **out,
+    size_t            *out_len)
+{
+    OM_uint32       maj, min;
+    gss_buffer_desc in, o = GSS_C_EMPTY_BUFFER;
+    int             conf, rc;
+    gss_qop_t       qop;
+
+    if (krb5_local_ensure_context(kl)) {
+        return -1;
+    }
+
+    in.value  = (void *) in_buf;
+    in.length = in_len;
+
+    maj = gss_unwrap(&min, kl->init_ctx, &in, &o, &conf, &qop);
+
+    if (GSS_ERROR(maj)) {
+        return -1;
+    }
+
+    rc = krb5_local_buf_out(&o, out, out_len);
+    gss_release_buffer(&min, &o);
+    return rc;
+} /* krb5_local_unwrap */
+
+/* ------------------------------------------------------------------ */
+/* Acceptor: the provider rpc2 calls into                               */
+/*                                                                      */
+/* Deliberately the same shape as a production provider (chimera's      */
+/* nfs_gss.c): the point of running rpc2's framing against this is that */
+/* it is a real mechanism behaving as one, not a stub with predictable  */
+/* answers.                                                             */
+/* ------------------------------------------------------------------ */
+
+struct krb5_local_ctx {
+    gss_ctx_id_t ctx;
+};
+
+static int
+krb5_local_accept(
+    void       *arg,
+    void      **gss_ctx,
+    const void *in_token,
+    size_t      in_len,
+    void      **out_token,
+    size_t     *out_len,
+    int        *complete,
+    char       *principal,
+    size_t      principal_sz)
+{
+    struct krb5_local     *kl = arg;
+    struct krb5_local_ctx *lc = *gss_ctx;
+    OM_uint32              maj, min, flags;
+    gss_buffer_desc        in, out = GSS_C_EMPTY_BUFFER, nb = GSS_C_EMPTY_BUFFER;
+    gss_name_t             src = GSS_C_NO_NAME;
+
+    if (!lc) {
+        lc = calloc(1, sizeof(*lc));
+        if (!lc) {
+            return -1;
+        }
+        lc->ctx  = GSS_C_NO_CONTEXT;
+        *gss_ctx = lc;
+    }
+
+    in.value  = (void *) in_token;
+    in.length = in_len;
+
+    maj = gss_accept_sec_context(&min, &lc->ctx, kl->accept_cred, &in,
+                                 GSS_C_NO_CHANNEL_BINDINGS, &src, NULL,
+                                 &out, &flags, NULL, NULL);
+
+    if (GSS_ERROR(maj)) {
+        /* A rejection may still carry a token the peer should see; rpc2
+         * relays it and frees it. */
+        if (out.length && krb5_local_buf_out(&out, out_token, out_len) == 0) {
+            gss_release_buffer(&min, &out);
+            return -1;
+        }
+        gss_release_buffer(&min, &out);
+        return -1;
+    }
+
+    *complete = (maj == GSS_S_COMPLETE);
+
+    if (*complete && src != GSS_C_NO_NAME) {
+        if (gss_display_name(&min, src, &nb, NULL) == GSS_S_COMPLETE) {
+            size_t n = nb.length < principal_sz - 1 ? nb.length
+                                                    : principal_sz - 1;
+            memcpy(principal, nb.value, n);
+            principal[n] = '\0';
+            gss_release_buffer(&min, &nb);
+        }
+    }
+
+    gss_release_name(&min, &src);
+
+    *out_token = NULL;
+    *out_len   = 0;
+
+    if (out.length) {
+        krb5_local_buf_out(&out, out_token, out_len);
+    }
+
+    gss_release_buffer(&min, &out);
+
+    return 0;
+} /* krb5_local_accept */
+
+static int
+krb5_local_p_get_mic(
+    void       *arg,
+    void       *gss_ctx,
+    const void *msg,
+    size_t      msg_len,
+    void      **mic,
+    size_t     *mic_len)
+{
+    struct krb5_local_ctx *lc = gss_ctx;
+    OM_uint32              maj, min;
+    gss_buffer_desc        in, out = GSS_C_EMPTY_BUFFER;
+    int                    rc;
+
+    (void) arg;
+
+    in.value  = (void *) msg;
+    in.length = msg_len;
+
+    maj = gss_get_mic(&min, lc->ctx, GSS_C_QOP_DEFAULT, &in, &out);
+
+    if (GSS_ERROR(maj)) {
+        return -1;
+    }
+
+    rc = krb5_local_buf_out(&out, mic, mic_len);
+    gss_release_buffer(&min, &out);
+    return rc;
+} /* krb5_local_p_get_mic */
+
+static int
+krb5_local_p_verify_mic(
+    void       *arg,
+    void       *gss_ctx,
+    const void *msg,
+    size_t      msg_len,
+    const void *mic,
+    size_t      mic_len)
+{
+    struct krb5_local_ctx *lc = gss_ctx;
+    OM_uint32              maj, min;
+    gss_buffer_desc        in, tok;
+
+    (void) arg;
+
+    in.value   = (void *) msg;
+    in.length  = msg_len;
+    tok.value  = (void *) mic;
+    tok.length = mic_len;
+
+    maj = gss_verify_mic(&min, lc->ctx, &in, &tok, NULL);
+
+    return GSS_ERROR(maj) ? -1 : 0;
+} /* krb5_local_p_verify_mic */
+
+#ifdef GSS_IOV_BUFFER_TYPE_MIC_TOKEN
+
+/* The scattered form.  This is the entry point that lets rpc2 verify a krb5i
+ * databody where it already lies in the receive buffers instead of gathering
+ * an NFS-WRITE-sized payload into one block. */
+static int
+krb5_local_p_verify_mic_iov(
+    void                    *arg,
+    void                    *gss_ctx,
+    const struct evpl_iovec *iov,
+    int                      niov,
+    const void              *mic,
+    size_t                   mic_len)
+{
+    struct krb5_local_ctx *lc = gss_ctx;
+    gss_iov_buffer_desc    stack[16], *bufs = stack;
+    OM_uint32              maj, min;
+    int                    i, rc = -1;
+
+    (void) arg;
+
+    if (niov + 1 > (int) (sizeof(stack) / sizeof(stack[0]))) {
+        bufs = calloc(niov + 1, sizeof(*bufs));
+        if (!bufs) {
+            return -1;
+        }
+    }
+
+    for (i = 0; i < niov; i++) {
+        bufs[i].type          = GSS_IOV_BUFFER_TYPE_DATA;
+        bufs[i].buffer.value  = evpl_iovec_data(&iov[i]);
+        bufs[i].buffer.length = evpl_iovec_length(&iov[i]);
+    }
+
+    bufs[niov].type          = GSS_IOV_BUFFER_TYPE_MIC_TOKEN;
+    bufs[niov].buffer.value  = (void *) mic;
+    bufs[niov].buffer.length = mic_len;
+
+    maj = gss_verify_mic_iov(&min, lc->ctx, NULL, bufs, niov + 1);
+
+    rc = GSS_ERROR(maj) ? -1 : 0;
+
+    if (bufs != stack) {
+        free(bufs);
+    }
+
+    return rc;
+} /* krb5_local_p_verify_mic_iov */
+
+#endif /* ifdef GSS_IOV_BUFFER_TYPE_MIC_TOKEN */
+
+static int
+krb5_local_p_wrap(
+    void       *arg,
+    void       *gss_ctx,
+    const void *in_buf,
+    size_t      in_len,
+    void       *out,
+    size_t      out_cap,
+    size_t     *r_out_len)
+{
+    struct krb5_local_ctx *lc = gss_ctx;
+    OM_uint32              maj, min;
+    gss_buffer_desc        in, o = GSS_C_EMPTY_BUFFER;
+    int                    conf;
+
+    (void) arg;
+
+    in.value   = (void *) in_buf;
+    in.length  = in_len;
+    *r_out_len = 0;
+
+    maj = gss_wrap(&min, lc->ctx, 1, GSS_C_QOP_DEFAULT, &in, &conf, &o);
+
+    if (GSS_ERROR(maj)) {
+        return -1;
+    }
+
+    /* The mechanism owns o and the caller owns out; refuse rather than
+     * truncate if the caller sized its buffer too small, since a silently
+     * short token is exactly the kind of thing this suite exists to catch. */
+    if (o.length > out_cap) {
+        gss_release_buffer(&min, &o);
+        return -1;
+    }
+
+    memcpy(out, o.value, o.length);
+    *r_out_len = o.length;
+    gss_release_buffer(&min, &o);
+    return 0;
+} /* krb5_local_p_wrap */
+
+static int
+krb5_local_p_unwrap(
+    void       *arg,
+    void       *gss_ctx,
+    const void *in_buf,
+    size_t      in_len,
+    void       *out,
+    size_t      out_cap,
+    size_t     *r_out_len)
+{
+    struct krb5_local_ctx *lc = gss_ctx;
+    OM_uint32              maj, min;
+    gss_buffer_desc        in, o = GSS_C_EMPTY_BUFFER;
+    int                    conf;
+    gss_qop_t              qop;
+
+    (void) arg;
+
+    in.value   = (void *) in_buf;
+    in.length  = in_len;
+    *r_out_len = 0;
+
+    maj = gss_unwrap(&min, lc->ctx, &in, &o, &conf, &qop);
+
+    if (GSS_ERROR(maj)) {
+        return -1;
+    }
+
+    /* The mechanism owns o and the caller owns out; refuse rather than
+     * truncate if the caller sized its buffer too small, since a silently
+     * short token is exactly the kind of thing this suite exists to catch. */
+    if (o.length > out_cap) {
+        gss_release_buffer(&min, &o);
+        return -1;
+    }
+
+    memcpy(out, o.value, o.length);
+    *r_out_len = o.length;
+    gss_release_buffer(&min, &o);
+    return 0;
+} /* krb5_local_p_unwrap */
+
+static void
+krb5_local_p_destroy(
+    void *arg,
+    void *gss_ctx)
+{
+    struct krb5_local_ctx *lc = gss_ctx;
+    OM_uint32              min;
+
+    (void) arg;
+
+    if (!lc) {
+        return;
+    }
+
+    if (lc->ctx != GSS_C_NO_CONTEXT) {
+        gss_delete_sec_context(&min, &lc->ctx, GSS_C_NO_BUFFER);
+    }
+
+    free(lc);
+} /* krb5_local_p_destroy */
+
+static const struct evpl_rpc2_gss_provider krb5_local_vtable = {
+    .accept     = krb5_local_accept,
+    .get_mic    = krb5_local_p_get_mic,
+    .verify_mic = krb5_local_p_verify_mic,
+    .wrap       = krb5_local_p_wrap,
+    .unwrap     = krb5_local_p_unwrap,
+#ifdef GSS_IOV_BUFFER_TYPE_MIC_TOKEN
+    .verify_mic_iov = krb5_local_p_verify_mic_iov,
+#endif /* ifdef GSS_IOV_BUFFER_TYPE_MIC_TOKEN */
+    .destroy        = krb5_local_p_destroy,
+};
+
+/* The same vtable with the scattered entry point withheld, so a test can
+ * drive rpc2's gathering fallback on a host that does have the IOV
+ * extension -- otherwise which path runs is a property of the build. */
+static const struct evpl_rpc2_gss_provider krb5_local_vtable_noiov = {
+    .accept     = krb5_local_accept,
+    .get_mic    = krb5_local_p_get_mic,
+    .verify_mic = krb5_local_p_verify_mic,
+    .wrap       = krb5_local_p_wrap,
+    .unwrap     = krb5_local_p_unwrap,
+    .destroy    = krb5_local_p_destroy,
+};
+
+const struct evpl_rpc2_gss_provider *
+krb5_local_provider(void)
+{
+    return &krb5_local_vtable;
+} /* krb5_local_provider */
+
+const struct evpl_rpc2_gss_provider *
+krb5_local_provider_noiov(void)
+{
+    return &krb5_local_vtable_noiov;
+} /* krb5_local_provider_noiov */

--- a/src/rpc2/tests/krb5_local.h
+++ b/src/rpc2/tests/krb5_local.h
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Ben Jarvis
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * A self-contained Kerberos realm for tests: real MIT krb5, no KDC.
+ *
+ * gss_stub.c exists because a real mechanism cannot be told to fail on demand,
+ * and the defect taxonomy is most of what the RPCSEC_GSS model asserts.  This
+ * is the other half of the picture: it cannot fail on command, but everything
+ * it does is real -- real AES keys, real AP-REQ tokens, real MICs -- so it is
+ * what says that libevpl's framing and an actual GSS mechanism interoperate.
+ * The two are complementary and both are registered.
+ *
+ * The trick is that a KDC's only job in this exchange is to issue a service
+ * ticket.  Owning the service key means the ticket can be minted directly, so
+ * both ends run the real gssapi_krb5 mechanism with nothing outside the
+ * process: no KDC, no realm, no keytab file, no ccache file.
+ *
+ * Because rpc2 implements only the ACCEPTOR half of RPCSEC_GSS (a real client
+ * initiates via rpc.gssd), a driver has to play the initiator itself.  Both
+ * halves are exposed here: the provider for evpl_rpc2_set_gss_provider(), and
+ * the initiator entry points a driver needs to build a call the acceptor will
+ * accept.
+ */
+#pragma once
+
+#include <stddef.h>
+
+struct evpl_rpc2_gss_provider;
+struct krb5_local;
+
+/*
+ * Stand up the realm.  Returns NULL when krb5 is unavailable or refuses --
+ * callers should skip rather than fail, the same way the KVM kerberos tests
+ * do.  `reason` (optional) receives a static string explaining a NULL.
+ */
+struct krb5_local *
+krb5_local_create(
+    const char **reason);
+
+void
+krb5_local_destroy(
+    struct krb5_local *kl);
+
+/* The acceptor, for evpl_rpc2_set_gss_provider(). */
+const struct evpl_rpc2_gss_provider *
+krb5_local_provider(
+    void);
+
+/* The same provider with verify_mic_iov withheld, so a test can drive rpc2's
+ * gathering fallback even on a host whose krb5 has the IOV extension. */
+const struct evpl_rpc2_gss_provider *
+krb5_local_provider_noiov(
+    void);
+
+void *
+krb5_local_arg(
+    struct krb5_local *kl);
+
+/*
+ * Whether this build's krb5 offers gss_verify_mic_iov().  The provider only
+ * advertises verify_mic_iov when it does, which is what lets a test drive both
+ * the scattered path and the gathering fallback rather than whichever one the
+ * host happens to have.
+ */
+int
+krb5_local_have_iov(
+    void);
+
+/* Ask the provider to hide verify_mic_iov, forcing rpc2's gather fallback. */
+void
+krb5_local_set_iov_enabled(
+    struct krb5_local *kl,
+    int                enabled);
+
+/*
+ * Initiator side.  The AP-REQ to put in an RPCSEC_GSS_INIT call; the caller
+ * frees it with free().
+ */
+int
+krb5_local_init_token(
+    struct krb5_local *kl,
+    void             **token,
+    size_t            *token_len);
+
+/* A real MIC over msg, as the initiator.  Caller frees with free(). */
+int
+krb5_local_get_mic(
+    struct krb5_local *kl,
+    const void        *msg,
+    size_t             msg_len,
+    void             **mic,
+    size_t            *mic_len);
+
+/* Verify a MIC the acceptor produced (a reply verifier). */
+int
+krb5_local_verify_mic(
+    struct krb5_local *kl,
+    const void        *msg,
+    size_t             msg_len,
+    const void        *mic,
+    size_t             mic_len);
+
+/* Seal/unseal as the initiator, for krb5p. */
+int
+krb5_local_wrap(
+    struct krb5_local *kl,
+    const void        *in,
+    size_t             in_len,
+    void             **out,
+    size_t            *out_len);
+
+int
+krb5_local_unwrap(
+    struct krb5_local *kl,
+    const void        *in,
+    size_t             in_len,
+    void             **out,
+    size_t            *out_len);

--- a/src/rpc2/tests/krb5_local_none.c
+++ b/src/rpc2/tests/krb5_local_none.c
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * krb5_local for builds without MIT krb5.
+ *
+ * Compiled in place of krb5_local.c so the driver needs no conditional
+ * compilation of its own: asking for the Kerberos mechanism on a host that
+ * has none simply reports why, and the caller skips.  Keeping the branch in
+ * the build rather than in the code means the krb5 path is either wholly
+ * present or wholly absent, never half-compiled.
+ */
+
+#include <stddef.h>
+
+#include "krb5_local.h"
+
+struct krb5_local *
+krb5_local_create(const char **reason)
+{
+    if (reason) {
+        *reason = "built without MIT krb5";
+    }
+    return NULL;
+} /* krb5_local_create */
+
+void
+krb5_local_destroy(struct krb5_local *kl)
+{
+    (void) kl;
+} /* krb5_local_destroy */
+
+const struct evpl_rpc2_gss_provider *
+krb5_local_provider(void)
+{
+    return NULL;
+} /* krb5_local_provider */
+
+const struct evpl_rpc2_gss_provider *
+krb5_local_provider_noiov(void)
+{
+    return NULL;
+} /* krb5_local_provider_noiov */
+
+void *
+krb5_local_arg(struct krb5_local *kl)
+{
+    (void) kl;
+    return NULL;
+} /* krb5_local_arg */
+
+int
+krb5_local_have_iov(void)
+{
+    return 0;
+} /* krb5_local_have_iov */
+
+void
+krb5_local_set_iov_enabled(
+    struct krb5_local *kl,
+    int                enabled)
+{
+    (void) kl;
+    (void) enabled;
+} /* krb5_local_set_iov_enabled */
+
+int
+krb5_local_init_token(
+    struct krb5_local *kl,
+    void             **token,
+    size_t            *token_len)
+{
+    (void) kl;
+    (void) token;
+    (void) token_len;
+    return -1;
+} /* krb5_local_init_token */
+
+int
+krb5_local_get_mic(
+    struct krb5_local *kl,
+    const void        *msg,
+    size_t             msg_len,
+    void             **mic,
+    size_t            *mic_len)
+{
+    (void) kl;
+    (void) msg;
+    (void) msg_len;
+    (void) mic;
+    (void) mic_len;
+    return -1;
+} /* krb5_local_get_mic */
+
+int
+krb5_local_verify_mic(
+    struct krb5_local *kl,
+    const void        *msg,
+    size_t             msg_len,
+    const void        *mic,
+    size_t             mic_len)
+{
+    (void) kl;
+    (void) msg;
+    (void) msg_len;
+    (void) mic;
+    (void) mic_len;
+    return -1;
+} /* krb5_local_verify_mic */
+
+int
+krb5_local_wrap(
+    struct krb5_local *kl,
+    const void        *in,
+    size_t             in_len,
+    void             **out,
+    size_t            *out_len)
+{
+    (void) kl;
+    (void) in;
+    (void) in_len;
+    (void) out;
+    (void) out_len;
+    return -1;
+} /* krb5_local_wrap */
+
+int
+krb5_local_unwrap(
+    struct krb5_local *kl,
+    const void        *in,
+    size_t             in_len,
+    void             **out,
+    size_t            *out_len)
+{
+    (void) kl;
+    (void) in;
+    (void) in_len;
+    (void) out;
+    (void) out_len;
+    return -1;
+} /* krb5_local_unwrap */

--- a/src/rpc2/tests/quint/defects.qnt
+++ b/src/rpc2/tests/quint/defects.qnt
@@ -108,6 +108,8 @@ module rpc2_defects {
         | GssPrivDataValid            /* krb5p: well-formed priv_data      */
         | GssPrivSealCorrupt          /* krb5p: token will not unseal      */
         | GssPrivSeqMismatch          /* krb5p: sealed seq != cred seq     */
+        | GssPrivSplitAcrossFragments /* krb5p: token arrives scattered    */
+        | GssPrivEmptyArgs            /* krb5p: NULLPROC, seq-only token   */
         | GssDestroyContext           /* DESTROY of a context we hold      */
         | GssDestroyUnauthenticated   /* DESTROY with no valid header MIC  */
         /* --- RPCSEC_GSS replay window (RFC 2203 section 5.3.3.1) ------- */
@@ -329,6 +331,19 @@ module rpc2_defects {
          * -- and it fails argument decoding like any other. */
         | GssPrivSeqMismatch => GarbageArgs
 
+        /* A sealed call split across record-mark fragments arrives as several
+         * buffers, and gss_unwrap needs one.  RFC 2203 says nothing about
+         * this -- it is a property of how the token is carried, not of the
+         * service -- so the requirement is simply that framing must not change
+         * the answer. */
+        | GssPrivSplitAcrossFragments => Success
+
+        /* NULLPROC under privacy: the token seals a seq_num and no arguments.
+         * Mandatory (RFC 5531 section 11.1) and the first krb5p call a real
+         * client makes, so the empty inner call is a case rather than an
+         * edge. */
+        | GssPrivEmptyArgs => Success
+
         /* RFC 2203 section 5.4: the client retires a context with a control
          * message carrying gss_proc RPCSEC_GSS_DESTROY over NULLPROC and no
          * arguments; "the server sends a response as it would to a data
@@ -490,6 +505,7 @@ module rpc2_defects {
         GssMicWrong, GssSeqReplayed,
         GssIntegDataValid, GssIntegChecksumWrong, GssIntegSeqMismatch,
         GssPrivDataValid, GssPrivSealCorrupt, GssPrivSeqMismatch,
+        GssPrivSplitAcrossFragments, GssPrivEmptyArgs,
         GssDestroyContext, GssDestroyUnauthenticated,
         GssSeqAboveMax, GssSeqWindowJump, GssSeqTooOld, GssSeqOutOfOrder,
         GssCredTruncated, GssCredHandleOverruns,

--- a/src/rpc2/tests/quint/itf_to_cases.py
+++ b/src/rpc2/tests/quint/itf_to_cases.py
@@ -91,6 +91,7 @@ DEFECTS = [
     "AuthSysValid",
     "GssIntegDataValid", "GssIntegChecksumWrong", "GssIntegSeqMismatch",
     "GssPrivDataValid", "GssPrivSealCorrupt", "GssPrivSeqMismatch",
+    "GssPrivSplitAcrossFragments", "GssPrivEmptyArgs",
     "GssDestroyContext", "GssDestroyUnauthenticated",
     "GssSeqAboveMax", "GssSeqWindowJump", "GssSeqTooOld", "GssSeqOutOfOrder",
     "GssCredTruncated", "GssCredHandleOverruns",


### PR DESCRIPTION
The RPCSEC_GSS model has a rich taxonomy — context establishment, the RFC 2203 replay window, credential and integrity framing, krb5p, DESTROY — and every case of it runs against `gss_stub.c`. That is the right default, and `gss_stub.h` says why: most of what the model asserts is a *rejection*, and a real mechanism cannot be told to reject on command.

But it leaves one thing unsaid. The stub's MIC is an FNV hash **the driver computes for itself**, so both sides of every check come from the same few lines of test code. That establishes which bytes rpc2 signs only in the sense that rpc2 and the test agree — it cannot catch the two of them agreeing on the wrong ones. Nothing in the suite said libevpl's framing and an actual GSS mechanism interoperate; the only thing that did was booting a guest kernel with `rpc.gssd` in chimera's KVM suite.

## Real Kerberos, no KDC

A KDC's only job in this exchange is to issue a service ticket. Owning the service key means the ticket can be minted directly — `krb5_encrypt_tkt_part` + `encode_krb5_ticket`, both long-standing `libkrb5` exports — and dropped in a `MEMORY:` ccache with the matching key in a `MEMORY:` keytab. No KDC, no realm, no files, nothing outside the process. Everything after that is real: real AES-256 keys, real AP-REQ tokens, real MICs.

## The cases do not change

What changes is who signs. The message builders take their MIC from whichever mechanism is in force, and **the MIC length becomes a return value rather than a constant** — a real mechanism's is neither fixed nor the stub's, and a receiver that assumed otherwise is exactly the sort of thing this is here to catch.

The six cases that steer the mechanism rather than the wire (`GssInitMechFails`, `GssInitContinues`, `GssIntegReplyMicFails`…) stay stub-only. The rest run under both — including the bad-MIC and sequence-window defects, since a bit flipped in a real MIC is just as invalid as one flipped in the stub's.

## Flavors as separate ctest instances

So a failure names the mechanism, rather than one run looping over several:

| instance | |
|---|---|
| `conformance_STREAM_SOCKET_TCP` | the stub, unchanged |
| `conformance_krb5_STREAM_SOCKET_TCP` | real krb5 |
| `conformance_krb5_gather_STREAM_SOCKET_TCP` | real krb5, scattered MIC withheld |

The third exists because `gss_verify_mic_iov` is an MIT extension: whether rpc2 takes its zero-copy path or its gathering fallback would otherwise be a property of the host's krb5 rather than of the test — and the fallback is the one with a size ceiling. Withholding the entry point makes both reachable everywhere.

Only over TCP: what changes is who computes the MICs, not the transport.

## Optional throughout

Without krb5 the build compiles `krb5_local_none.c` in place of `krb5_local.c`, so the driver needs no conditional compilation of its own; the extra instances are not registered; and asking for the mechanism anyway skips (77) rather than failing.

## Verification

Both baselines on the same host, back to back:

```
stub:  155 cases run, 149 matched spec, 6 known divergences, 0 unexpected  PASSED
krb5:  149 cases run, 146 matched spec, 3 known divergences, 0 unexpected  PASSED
krb5 (gather fallback): 149 run, 146 matched, 0 unexpected                 PASSED
```

149 vs 155 is exactly the six behaviour-injection cases skipped. 21 real Kerberos contexts are established through rpc2's RPCSEC_GSS framing during the run, which the server logs as `rpcsec_gss: context established for principal 'conformance@TEST.LIBEVPL'`. Full rpc2 suite: 51/51.

## One caveat worth a reviewer's eye

`krb5_encrypt_tkt_part` and `encode_krb5_ticket` are exported by `libkrb5` but not declared in its public headers, so `krb5_local.c` declares them itself. Samba and other test harnesses do the same, and the failure mode if a future MIT release drops them is a test that does not link — not a runtime surprise — but it is a supported-in-practice rather than supported-in-contract dependency.