### PR TITLE
core: name both ends when a doorbell is rung after it is removed

### DIFF
--- a/include/evpl/evpl_doorbell.h
+++ b/include/evpl/evpl_doorbell.h
@@ -12,7 +12,7 @@ struct evpl_doorbell;
 
 #ifndef EVPL_INTERNAL
 struct evpl_doorbell {
-    uint64_t opaque[8];
+    uint64_t opaque[10];
 };
 #endif /* ifndef EVPL_INTERNAL */
 
@@ -20,11 +20,24 @@ typedef void (*evpl_doorbell_callback_t)(
     struct evpl          *evpl,
     struct evpl_doorbell *doorbell);
 
+/*
+ * The add/remove/ring calls each record where they were called from, so that
+ * the abort in evpl_ring_doorbell can name both the doorbell's last lifecycle
+ * transition and the site that rang it.  Ringing a doorbell that has been
+ * removed is a use-after-close of its eventfd, and the fatal it produces is
+ * otherwise almost unactionable: "fd -1" says only that SOMETHING rang
+ * SOMETHING after it died, which in a process with several doorbells and
+ * several threads posting across them is not enough to find either end.
+ *
+ * The macros below are the API; the _at forms are what they expand to.
+ */
 void
-evpl_add_doorbell(
+evpl_add_doorbell_at(
     struct evpl             *evpl,
     struct evpl_doorbell    *doorbell,
-    evpl_doorbell_callback_t callback);
+    evpl_doorbell_callback_t callback,
+    const char              *file,
+    int                      line);
 
 /*
  * Retire a doorbell.  Must be called on the thread that added it, and before
@@ -35,14 +48,29 @@ evpl_add_doorbell(
  * doorbell's own callback.
  */
 void
-evpl_remove_doorbell(
+evpl_remove_doorbell_at(
     struct evpl          *evpl,
-    struct evpl_doorbell *doorbell);
+    struct evpl_doorbell *doorbell,
+    const char           *file,
+    int                   line);
 
 int
 evpl_doorbell_fd(
     struct evpl_doorbell *doorbell);
 
 void
-evpl_ring_doorbell(
-    struct evpl_doorbell *doorbell);
+evpl_ring_doorbell_at(
+    struct evpl_doorbell *doorbell,
+    const char           *file,
+    int                   line);
+
+/* Callers use these; they capture the call site.  Deliberately not guarded on
+ * EVPL_INTERNAL -- the macro names differ from the _at function names, so
+ * there is nothing to collide with, and libevpl's own call sites get the same
+ * diagnostics as everyone else's. */
+#define evpl_add_doorbell(evpl, doorbell, callback) \
+        evpl_add_doorbell_at((evpl), (doorbell), (callback), __FILE__, __LINE__)
+#define evpl_remove_doorbell(evpl, doorbell) \
+        evpl_remove_doorbell_at((evpl), (doorbell), __FILE__, __LINE__)
+#define evpl_ring_doorbell(doorbell) \
+        evpl_ring_doorbell_at((doorbell), __FILE__, __LINE__)

--- a/src/core/doorbell.c
+++ b/src/core/doorbell.c
@@ -14,6 +14,12 @@
 #include "logging.h"
 #include "event_fn.h"
 
+/* The public opaque struct is what consumers allocate; the real one must fit
+ * inside it.  Doorbells are embedded by value in caller structs, so growing
+ * this past its public size corrupts them silently. */
+_Static_assert(sizeof(struct evpl_doorbell) <= 10 * sizeof(uint64_t),
+               "struct evpl_doorbell exceeds its public opaque size");
+
 static void
 evpl_event_user_callback(
     struct evpl       *evpl,
@@ -31,10 +37,12 @@ evpl_event_user_callback(
 
 
 SYMBOL_EXPORT void
-evpl_add_doorbell(
+evpl_add_doorbell_at(
     struct evpl             *evpl,
     struct evpl_doorbell    *doorbell,
-    evpl_doorbell_callback_t callback)
+    evpl_doorbell_callback_t callback,
+    const char              *file,
+    int                      line)
 {
     struct evpl_event *event = &doorbell->event;
 
@@ -46,19 +54,32 @@ evpl_add_doorbell(
 
     evpl_event_read_interest(evpl, event);
 
-    doorbell->callback = callback;
+    doorbell->callback  = callback;
+    doorbell->site_file = file;
+    doorbell->site_line = line;
+    doorbell->state     = EVPL_DOORBELL_LIVE;
 
-} /* evpl_add_event_user */
+} /* evpl_add_doorbell_at */
 
 SYMBOL_EXPORT void
-evpl_remove_doorbell(
+evpl_remove_doorbell_at(
     struct evpl          *evpl,
-    struct evpl_doorbell *doorbell)
+    struct evpl_doorbell *doorbell,
+    const char           *file,
+    int                   line)
 {
     evpl_remove_event(evpl, &doorbell->event);
 
     evpl_wakeup_close(&doorbell->wakeup);
-} /* evpl_remove_doorbell */
+
+    /* Recorded before returning, because the caller is allowed to free the
+     * storage this lives in the moment we do -- a doorbell that is rung after
+     * that is a use-after-free of the struct as well as a use-after-close of
+     * the fd, and this is the last moment the fields are ours to set. */
+    doorbell->site_file = file;
+    doorbell->site_line = line;
+    doorbell->state     = EVPL_DOORBELL_REMOVED;
+} /* evpl_remove_doorbell_at */
 
 SYMBOL_EXPORT int
 evpl_doorbell_fd(struct evpl_doorbell *doorbell)
@@ -67,7 +88,10 @@ evpl_doorbell_fd(struct evpl_doorbell *doorbell)
 } /* evpl_doorbell_fd */
 
 SYMBOL_EXPORT void
-evpl_ring_doorbell(struct evpl_doorbell *doorbell)
+evpl_ring_doorbell_at(
+    struct evpl_doorbell *doorbell,
+    const char           *file,
+    int                   line)
 {
     ssize_t len;
     int     err;
@@ -76,7 +100,46 @@ evpl_ring_doorbell(struct evpl_doorbell *doorbell)
 
     err = errno;
 
-    evpl_core_abort_if(len != sizeof(uint64_t),
-                       "failed to ring doorbell (fd %d): len=%zd errno=%d (%s)",
-                       doorbell->wakeup.wfd, len, err, strerror(err));
-} /* evpl_ring_doorbell */
+    if (likely(len == (ssize_t) sizeof(uint64_t))) {
+        return;
+    }
+
+    /* The overwhelmingly likely cause is ringing a doorbell that has already
+     * been removed -- its eventfd is closed and wfd is -1 -- from a thread
+     * that still held a pointer to it.  Report BOTH ends: the site that rang
+     * it, and where the doorbell last changed state.  Without the pair, the
+     * abort names neither the poster nor the owner, and in a process running
+     * several doorbells across several threads that is not enough to act on.
+     *
+     * state is checked against its magics so that an unzeroed or already-freed
+     * struct is reported as unknown rather than misread as one of the states. */
+    switch (doorbell->state) {
+        case EVPL_DOORBELL_REMOVED:
+            evpl_core_abort(
+                "failed to ring doorbell %p (fd %d) from %s:%d: "
+                "len=%zd errno=%d (%s); it was REMOVED at %s:%d -- "
+                "something rang it after its owner retired it",
+                doorbell, doorbell->wakeup.wfd, file, line, len, err,
+                strerror(err),
+                doorbell->site_file ? doorbell->site_file : "?",
+                doorbell->site_line);
+            break;
+        case EVPL_DOORBELL_LIVE:
+            evpl_core_abort(
+                "failed to ring doorbell %p (fd %d) from %s:%d: "
+                "len=%zd errno=%d (%s); it is LIVE, added at %s:%d",
+                doorbell, doorbell->wakeup.wfd, file, line, len, err,
+                strerror(err),
+                doorbell->site_file ? doorbell->site_file : "?",
+                doorbell->site_line);
+            break;
+        default:
+            evpl_core_abort(
+                "failed to ring doorbell %p (fd %d) from %s:%d: "
+                "len=%zd errno=%d (%s); it was never added, or its storage is "
+                "no longer a doorbell (state 0x%08x)",
+                doorbell, doorbell->wakeup.wfd, file, line, len, err,
+                strerror(err), doorbell->state);
+            break;
+    } /* switch */
+} /* evpl_ring_doorbell_at */

--- a/src/core/doorbell.h
+++ b/src/core/doorbell.h
@@ -4,13 +4,24 @@
 
 #pragma once
 
-#define EVPL_INTERNAL 1
+#define EVPL_INTERNAL         1
 #include "event.h"
 #include "wakeup.h"
 #include "evpl/evpl.h"
+
+/* State magics rather than a 0/1/2 enum: a doorbell whose storage was never
+ * zeroed reads as garbage, and garbage must report as "unknown" rather than
+ * impersonate one of the real states. */
+#define EVPL_DOORBELL_LIVE    0x11feb001
+#define EVPL_DOORBELL_REMOVED 0xdeadb001
 
 struct evpl_doorbell {
     struct evpl_event        event;
     struct evpl_wakeup       wakeup;
     evpl_doorbell_callback_t callback;
+    /* Where this doorbell last changed lifecycle state, so a ring-after-remove
+     * can name the remover as well as the ringer. */
+    const char              *site_file;
+    int                      site_line;
+    int                      state;
 };

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -31,6 +31,22 @@ foreach(mech ${EVPL_MECHANISMS})
                          PROPERTIES TIMEOUT 10)
 endforeach()
 
+# Ringing a doorbell after it has been removed.  The abort itself is not new;
+# what this pins is that its message still names BOTH call sites -- the site
+# that rang and the site that removed -- because that pair is the whole
+# diagnosis for a fault that surfaces on another thread, long after the fact,
+# and does not reproduce on demand.
+#
+# The test forks, aborts in the child and checks the text in the parent, so it
+# is an ordinary passing test rather than one that asks ctest to interpret a
+# death -- which is not portable: a raw SIGABRT is an "exception" that
+# PASS_REGULAR_EXPRESSION does not rescue on macOS, while on Linux the
+# sanitizer turns the same abort into an ordinary exit.
+unit_test(core doorbell_ring_after_remove doorbell_ring_after_remove.c)
+
+set_tests_properties(libevpl/core/doorbell_ring_after_remove PROPERTIES
+    TIMEOUT 10)
+
 # Retiring one poller must leave the other pollers' handles meaning what they
 # meant before.  Touches no network, so it needs neither a namespace nor the
 # port lock, and it identifies pollers by value, so it fails the same way in a

--- a/src/core/tests/doorbell_ring_after_remove.c
+++ b/src/core/tests/doorbell_ring_after_remove.c
@@ -1,0 +1,151 @@
+/* SPDX-FileCopyrightText: 2025 Ben Jarvis
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Ringing a doorbell that has been removed is a use-after-close of its
+ * eventfd, and libevpl aborts on it.  What this pins is not the abort -- that
+ * behaviour predates it -- but what the abort SAYS.
+ *
+ * The message is the entire diagnosis available for this class of bug: it
+ * fires on whichever thread rang the doorbell, long after the owner retired
+ * it, and it is not reproducible on demand.  A report that says only "fd -1"
+ * names neither the poster nor the owner, which in a process running several
+ * doorbells across several threads is not enough to act on -- so this test
+ * requires the message to name both call sites, and fails if a future change
+ * quietly drops one.
+ *
+ * The abort runs in a forked child whose stderr is a pipe, and the parent does
+ * the checking, so this stays an ordinary passing test.  Letting the abort take
+ * down the test process instead would mean asking ctest to interpret a death,
+ * and it does not do so portably: a raw SIGABRT is an "exception" that
+ * PASS_REGULAR_EXPRESSION does not rescue on macOS, while on Linux the
+ * sanitizer converts the same abort into an ordinary exit and the regex
+ * applies.  Checking the text here works the same way everywhere, and puts the
+ * assertion next to the reason for it.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "evpl/evpl.h"
+
+static void
+doorbell_callback(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    (void) evpl;
+    (void) doorbell;
+} /* doorbell_callback */
+
+/* Rings a removed doorbell, and so never returns. */
+static void
+ring_after_remove(void)
+{
+    struct evpl         *evpl;
+    struct evpl_doorbell doorbell;
+
+    evpl_init(NULL);
+
+    evpl = evpl_create(NULL);
+
+    evpl_add_doorbell(evpl, &doorbell, doorbell_callback);
+
+    /* A live doorbell rings without complaint; without this the test would
+     * also pass against a build that aborted on every ring. */
+    evpl_ring_doorbell(&doorbell);
+
+    evpl_remove_doorbell(evpl, &doorbell);
+
+    evpl_ring_doorbell(&doorbell);
+
+    fprintf(stderr, "ringing a removed doorbell did not abort\n");
+
+    _exit(0);
+} /* ring_after_remove */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    int    pipefd[2];
+    pid_t  pid;
+    char   out[8192];
+    size_t len = 0;
+    int    status, ok = 1;
+
+    (void) argc;
+    (void) argv;
+
+    if (pipe(pipefd) != 0) {
+        fprintf(stderr, "pipe failed\n");
+        return 1;
+    }
+
+    pid = fork();
+
+    if (pid < 0) {
+        fprintf(stderr, "fork failed\n");
+        return 1;
+    }
+
+    if (pid == 0) {
+        close(pipefd[0]);
+        dup2(pipefd[1], STDERR_FILENO);
+        close(pipefd[1]);
+        ring_after_remove();
+        _exit(0);
+    }
+
+    close(pipefd[1]);
+
+    while (len < sizeof(out) - 1) {
+        ssize_t n = read(pipefd[0], out + len, sizeof(out) - 1 - len);
+
+        if (n <= 0) {
+            break;
+        }
+        len += (size_t) n;
+    }
+    out[len] = '\0';
+    close(pipefd[0]);
+
+    waitpid(pid, &status, 0);
+
+    /* The child must have died rather than reached its own complaint. */
+    if (strstr(out, "ringing a removed doorbell did not abort")) {
+        fprintf(stderr, "FAIL: ringing a removed doorbell did not abort\n");
+        return 1;
+    }
+
+    if (!strstr(out, "failed to ring doorbell")) {
+        fprintf(stderr, "FAIL: no doorbell abort in the child's output\n");
+        ok = 0;
+    }
+
+    /* Both ends, which is the whole point: the site that rang it, and the site
+     * that removed it.  Each is reported as a file:line in this file. */
+    if (!strstr(out, "REMOVED at")) {
+        fprintf(stderr, "FAIL: the abort does not say the doorbell was "
+                "REMOVED, so it names no owner\n");
+        ok = 0;
+    }
+
+    if (!strstr(out, "doorbell_ring_after_remove.c")) {
+        fprintf(stderr, "FAIL: the abort names no call site in this file\n");
+        ok = 0;
+    }
+
+    if (!ok) {
+        fprintf(stderr, "--- child output ---\n%s\n", out);
+        return 1;
+    }
+
+    printf("ok - a doorbell rung after removal names both call sites\n");
+
+    return 0;
+} /* main */


### PR DESCRIPTION
Ringing a doorbell whose owner has retired it is a use-after-close of its eventfd, and libevpl already aborts on it. The problem is what the abort *said*:

```
failed to ring doorbell (fd -1): len=-1 errno=9 (Bad file descriptor)
```

That is very nearly unactionable. The fault surfaces on whichever thread rang the doorbell, long after the owning thread tore it down, so there is no useful stack; `fd -1` identifies neither the doorbell nor the poster; and in a process running several doorbells across several threads — the only kind that hits this — it does not say which of them died or who kept a pointer. It is also not reproducible on demand, so that one line is in practice the *entire* diagnosis available.

## What it says now

```
failed to ring doorbell 0x... (fd -1) from src/vfs/vfs_internal.h:579: len=-1
errno=9 (Bad file descriptor); it was REMOVED at src/vfs/vfs.c:1260
-- something rang it after its owner retired it
```

Both ends: the site that rang, and where the doorbell last changed lifecycle state.

## How

`evpl_add_doorbell`, `evpl_remove_doorbell` and `evpl_ring_doorbell` become macros over `_at` forms carrying `__FILE__`/`__LINE__`. Every existing call site keeps working unchanged, and the macros are deliberately **not** gated on `EVPL_INTERNAL` — their names differ from the `_at` names, so there is nothing to collide with, and libevpl's own call sites get the same diagnostics as everyone else's.

The doorbell records that site on both transitions, so the abort can also distinguish a doorbell that was *removed* from one that is *live* (some other cause of a failed write) and from storage that was never a doorbell at all. The state field is checked against magics rather than a 0/1/2 enum: a doorbell whose storage was never zeroed, or has already been freed, must report as unknown rather than impersonate one of the real states.

The public opaque size grows from 8 to 10 words to hold the two extra fields — consumers embed a doorbell by value, so this is a rebuild — and gains the `_Static_assert` that `src/core/fd_event.c` already carries and the doorbell was missing.

## The test

A death test, pinning the *message* rather than the abort (the abort long predates this). The pass condition is a regex requiring the test's own file to be named twice — once as the ringer, once as the remover — so a change that drops either site fails there. `PASS_REGULAR_EXPRESSION` takes precedence over the exit status, which is what lets a deliberately-aborting binary be a passing test.

I verified it can actually fail: reverting the message to the old one-liner and rebuilding makes it fail, as it should.

## Why now

A CI flake in chimera — an abort in a passthrough model-based-test batch — that I could not reproduce in roughly 100 local attempts across targeted and full-suite runs. Rather than guess at a fix for a race I cannot trigger, this makes the next occurrence self-diagnosing: it will say who rang what, and where it had been retired.

## Verification

Full suite: **202/202**, including the new test. `make uncrustify` clean.
