### PR TITLE
rpc2: tell reply-capture where the RPC message starts

### DIFF
--- a/include/evpl/evpl_rpc2_program.h
+++ b/include/evpl/evpl_rpc2_program.h
@@ -95,14 +95,27 @@ struct evpl_rpc2_rdma_segment_list {
  * freed.  This gives applications a chance to copy out the encoded reply
  * bytes for later replay (NFS4.1 session replay cache).
  *
- * The iov array is the complete RPC reply (header + body).  Pointers are
- * valid only for the duration of the callback; the callback must copy any
- * bytes it wishes to retain.
+ * The iov array spans the whole outgoing message and total_length is its
+ * length.  rpc_offset is how many leading bytes of that are TRANSPORT framing
+ * rather than RPC: 4 for the record marker over a stream transport, and the
+ * length of the RPC-over-RDMA header over an RDMA one.  A caller that wants
+ * the RPC reply itself -- which is what a replay cache stores, since the
+ * framing has to be rebuilt for the retransmit anyway -- skips rpc_offset
+ * bytes.  Ignoring it yields a buffer whose framing only happens to be
+ * parseable on the transport it was captured from.
+ *
+ * The callback runs before any Reply-chunk reduction, so the RPC reply is
+ * always present in full here even when the wire form sends its body by RDMA
+ * write and leaves only the header inline.
+ *
+ * Pointers are valid only for the duration of the callback; the callback must
+ * copy any bytes it wishes to retain.
  */
 typedef void (*evpl_rpc2_reply_capture_cb_t)(
     const struct evpl_iovec *iov,
     int                      niov,
     int                      total_length,
+    uint32_t                 rpc_offset,
     void                    *private_data);
 
 /*

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -1025,6 +1025,25 @@ evpl_rpc2_send_reply(
         prometheus_time_histogram_sample(request->metric, &request->timestamp);
     }
 
+    /* If the application requested reply capture (e.g. for an NFS4.1 SEQUENCE
+     * replay cache or an NFSv3 duplicate-request cache), invoke the callback
+     * now.
+     *
+     * Before the Reply-chunk reduction below, not after: that path clones only
+     * the first `offset` header bytes into final_reply_iov and RDMA-writes the
+     * body straight to the requester, so a callback run afterwards would see a
+     * header with no reply behind it.  Here msg_iov still spans the whole
+     * message, and `offset` is the transport framing ahead of the RPC reply --
+     * 4 for a stream record marker, marshall_length_rdma_msg() for RDMA. */
+    if (request->encoding.reply_capture_cb) {
+        request->encoding.reply_capture_cb(
+            msg_iov,
+            msg_niov,
+            length,
+            (uint32_t) offset,
+            request->encoding.reply_capture_private);
+    }
+
     if (reduce) {
 
         final_reply_iov = xdr_dbuf_alloc_space(sizeof(*final_reply_iov), &request->msg->dbuf);
@@ -1070,18 +1089,6 @@ evpl_rpc2_send_reply(
         final_reply_iov    = msg_iov;
         final_reply_niov   = msg_niov;
         final_reply_length = length;
-    }
-
-    /* If the application requested reply capture (e.g. for an NFS4.1
-     * SEQUENCE replay cache), invoke the callback now -- the iovec
-     * array is fully populated and still valid; dispatch_reply will
-     * free the request (and therefore the iovec metadata) below. */
-    if (request->encoding.reply_capture_cb) {
-        request->encoding.reply_capture_cb(
-            final_reply_iov,
-            final_reply_niov,
-            final_reply_length,
-            request->encoding.reply_capture_private);
     }
 
     evpl_rpc2_dispatch_reply(evpl, request, final_reply_iov, final_reply_niov, final_reply_length);


### PR DESCRIPTION
The reply-capture hook exists so an application can keep an encoded reply for
later replay — an NFSv4.1 session reply cache, an NFSv3 duplicate-request cache.
It handed over the whole outgoing message and said nothing about its shape, which
left the application to assume one. Every application assumed a stream: a 4-byte
record marker, then the RPC reply.

Over RPC-over-RDMA that assumption is wrong. The message begins with an
RPC-over-RDMA header whose length varies with its chunk lists, so a reply
captured on an RDMA connection is not parseable by anything expecting a record
marker, and cannot be reframed for a retransmit either. The application cannot
compute the header length itself — it never sees the chunk lists.

So report it. The callback now takes `rpc_offset`: the number of leading bytes
that are transport framing rather than RPC. That is exactly the local variable
`send_reply` already computes in order to place the RPC message — `4` on a
stream, `marshall_length_rdma_msg()` on RDMA.

### The callback also moves ahead of the Reply-chunk reduction

That path clones only the header into the outgoing iovecs and RDMA-writes the
body straight to the requester, so a callback invoked after it saw a header with
no reply behind it — and a caching application would have stored that and
replayed it later. Before the split, `msg_iov` still spans the whole message.

### Why now

chimera's three NFS reply caches all assumed the stream layout. One aborted the
server outright on a retransmit over NFS/RDMA; the other two silently disabled
themselves on RDMA connections, which turned every non-idempotent retransmit
there into a second execution. The chimera-side fix is a companion PR; it needs
this offset to strip the framing before storing.

### Compatibility

`evpl_rpc2_reply_capture_cb_t` gains a parameter, so any out-of-tree implementer
of the hook needs a signature update. chimera is the only in-tree user; there are
no other callers in libevpl.
