### PR TITLE
rpc2/tests: a non-blocking loopback connect is not connected yet on Darwin

### DIFF
--- a/src/rpc2/tests/conformance.c
+++ b/src/rpc2/tests/conformance.c
@@ -2184,7 +2184,20 @@ send_all(
             len -= n;
             continue;
         }
-        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        /* ENOTCONN is "the connect has not finished yet", not a failure.  The
+         * socket is O_NONBLOCK (raw_socket_prepare), so connect() returns
+         * EINPROGRESS and the handshake completes asynchronously.  Linux
+         * finishes a loopback connect inside connect() itself, so the send
+         * that follows always has a connected socket and this never fires;
+         * Darwin does not, and returned ENOTCONN to the first send of every
+         * defect case -- 298 of them -- which this loop treated as fatal.
+         * The request was then never sent, so the case recorded STALLED
+         * waiting for a reply to a request the server never saw.  Retrying
+         * is safe: a connect that genuinely fails surfaces its own errno
+         * (ECONNREFUSED and friends) here rather than ENOTCONN, and the
+         * deadline below still bounds the wait. */
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK ||
+                      errno == ENOTCONN)) {
             evpl_continue(evpl);
             if (now_ms() > deadline) {
                 return -1;
@@ -2253,7 +2266,10 @@ read_outcome_full(
             return EXP_CLOSED;
         }
         if (n < 0) {
-            if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            /* ENOTCONN here is the same not-yet-connected case send_all
+             * describes, not a peer close. */
+            if (errno != EAGAIN && errno != EWOULDBLOCK &&
+                errno != ENOTCONN) {
                 return EXP_CLOSED;
             }
             evpl_continue(evpl);
@@ -2278,7 +2294,10 @@ read_outcome_full(
             return EXP_CLOSED;
         }
         if (n < 0) {
-            if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            /* ENOTCONN here is the same not-yet-connected case send_all
+             * describes, not a peer close. */
+            if (errno != EAGAIN && errno != EWOULDBLOCK &&
+                errno != ENOTCONN) {
                 return EXP_CLOSED;
             }
             evpl_continue(evpl);


### PR DESCRIPTION
`conformance_STREAM_SOCKET_TCP` failed **every** defect case on macOS — 155 of 155 unexpected, the first of them `NoDefect`, a well-formed request with nothing injected. The value phase passed all 1197 cases over the same transport, so the server was fine; the defect harness never got a request out.

## Cause

The harness talks to the server over a raw socket, and `raw_socket_prepare` puts that socket in `O_NONBLOCK`. `connect()` therefore returns `EINPROGRESS` and the handshake completes asynchronously.

**Linux finishes a loopback connect inside `connect()` itself**, so the send that follows always has a connected socket — which is exactly what the comment above `connect_raw` assumes, and it holds there:

```c
/* Loopback connect completes into the listen backlog without the server
 * having accepted yet, so EINPROGRESS here is success as far as writing
 * the request goes. */
```

**Darwin does not.** The first `send()` of each defect case returned `ENOTCONN`, `send_all` treated anything that was not `EAGAIN`/`EWOULDBLOCK` as fatal, and the request was never written. The case then waited out `REPLY_TIMEOUT_MS` for a reply to a request the server had never seen, and recorded `STALLED`.

Instrumented rather than inferred — one run:

```
DIAG send_all: errno=57 (Socket is not connected)   × 298
```

## Fix

`ENOTCONN` joins `EAGAIN`/`EWOULDBLOCK` as "not ready yet, pump and retry", in `send_all` and in both `recv` loops. Retrying is safe: a connect that genuinely fails reports its own errno here (`ECONNREFUSED` and friends), not `ENOTCONN`, and the existing deadline still bounds the wait.

The 40 cases that reported `MALFORMED_REPLY` rather than `STALLED` were the same fault seen through a socket that had since finished connecting; they go with it.

## Before / after

| | before | after |
|---|---|---|
| defect cases | 155 run, **0 matched**, 155 unexpected | 155 run, **149 matched**, 6 known divergences, **0 unexpected** |
| notifications | 116 accepted / 156 opened, **1 incoherent** | 156 accepted / 156 opened, **0 incoherent** |
| conformance variants | 2 of 12 failing | **12 of 12 pass** |

The accept accounting came out even on its own, confirming that mismatch was a downstream symptom: a case that gave up closed its connection before the server ever accepted it.

## Worth knowing: this test has never run in this repository's CI

It is registered only when `quint` **and** `python3` are both present:

```cmake
find_program(QUINT_EXECUTABLE quint)
find_program(PYTHON3_EXECUTABLE NAMES python3 python)
if(QUINT_EXECUTABLE AND PYTHON3_EXECUTABLE)
```

No libevpl CI job installs quint — not on macOS, not on Linux. So the suite builds and passes here with the conformance test silently absent. It runs in chimera, which supplies quint, and that is where this surfaced (chimera's macOS extended job). Making it run in this repo's own CI is a separate change, but it is the reason this went unnoticed.
