### PR TITLE
ci: run the model-based conformance suites on macOS too

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -344,6 +344,14 @@ jobs:
           # whatever its packager happened to ship.  Upstream's darwin asset is
           # a single universal binary, covering Intel and Apple Silicon alike.
           CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
+          # The same version the Linux images pin (QUINT_VERSION in every
+          # Dockerfile).  Pinned rather than floating because the case tables
+          # the conformance suites run are GENERATED from the models at build
+          # time with fixed seeds: a different quint samples the models
+          # differently, so an unpinned macOS would be compiling a different
+          # corpus from the rest of the matrix -- testing something else
+          # rather than testing more widely.
+          QUINT_VERSION: 0.32.0
         run: |
           brew update
           # openssl@3 and nghttp2 are keg-only; CMakeLists.txt already adds the
@@ -352,6 +360,50 @@ jobs:
           oras pull "${CCACHE_REF}" --output "${RUNNER_TEMP}"
           install -m 0755 "${RUNNER_TEMP}/ccache-darwin" /usr/local/bin/ccache
           ccache --version | head -1
+          # quint is not a brew formula; upstream publishes it on npm, which is
+          # also what pins it exactly.  The Linux images take it from the GHCR
+          # mirror instead, but that image carries a Linux node+quint tree and
+          # cannot be reused here.
+          npm install -g "@informalsystems/quint@${QUINT_VERSION}"
+          quint --version
+
+      # quint fetches its Rust evaluator on first use and ABORTS rather than
+      # falling back when that fetch fails, so an absent evaluator becomes a
+      # build failure in the middle of case generation, attributed to cmake.
+      # The Linux images ship it inside the image; here it has to come off the
+      # network, so install it in a step of its own.
+      #
+      # Fetched here rather than by quint itself because quint's fetch is
+      # ANONYMOUS -- its GitHub client sends only User-Agent and Accept, and
+      # honours no token -- so on hosted runners, whose egress IPs are shared
+      # and busy, it reliably draws "rate limit exceeded" from api.github.com.
+      # gh uses the job's own token and gets the authenticated limit instead.
+      #
+      # v0.6.0 is not a guess: QUINT_EVALUATOR_VERSION is a constant inside
+      # quint 0.32.0, and the path below is where quint looks before deciding
+      # it needs to download anything.  The evaluator version is as
+      # corpus-affecting as the quint version, so pinning both is the point.
+      - name: Install the quint Rust evaluator
+        env:
+          GH_TOKEN: ${{ github.token }}
+          QUINT_EVALUATOR_VERSION: v0.6.0
+        run: |
+          case "$(uname -m)" in
+            arm64|aarch64) asset=quint_evaluator-aarch64-apple-darwin.tar.gz ;;
+            x86_64)        asset=quint_evaluator-x86_64-apple-darwin.tar.gz ;;
+            *) echo "no quint evaluator for $(uname -m)" >&2; exit 1 ;;
+          esac
+          dest="${HOME}/.quint/rust-evaluator-${QUINT_EVALUATOR_VERSION}"
+          mkdir -p "${dest}"
+          gh release download "evaluator/${QUINT_EVALUATOR_VERSION}" \
+            --repo informalsystems/quint --pattern "${asset}" \
+            --output "${RUNNER_TEMP}/${asset}" --clobber
+          tar -xzf "${RUNNER_TEMP}/${asset}" -C "${dest}"
+          chmod +x "${dest}/quint_evaluator"
+          # Prove quint is satisfied by what we placed, before the build needs
+          # it: this runs the models and must not reach the network.
+          quint run --max-steps=1 --max-samples=1 \
+            src/rpc2/tests/quint/defects.qnt --main=rpc2_defects >/dev/null
 
       - name: Restore the ccache directory
         uses: actions/cache/restore@v4

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -16,9 +16,11 @@ ARG QUINT_VERSION=0.32.0
 # it and generates their case tables from the models at build time, and without
 # it those suites and the quint_model checks silently disable themselves.
 #
-# Not on ubuntu 22.04 or rocky 9.  quint's Rust evaluator is published only as
-# *-unknown-linux-gnu against glibc 2.39, with no musl build to mirror, so it
-# cannot load on their 2.35 and 2.34.  The TypeScript backend needs no
+# Not on ubuntu 22.04 or rocky 9.  The Linux build of quint's Rust evaluator is
+# linked against glibc 2.39, with no musl build to mirror, so it cannot load on
+# their 2.35 and 2.34.  This is a glibc-version limit, not an absence of
+# non-Linux builds -- darwin arm64 and amd64 evaluators exist, which is what
+# lets the macOS job run these same suites on the same backend.  The TypeScript backend needs no
 # evaluator and would run there, but it is 2.4x slower on these models and
 # generates a different corpus from the same seed -- so those two images would
 # be compiling a different case table from every other platform, which is

--- a/Dockerfile.ubuntu24.04
+++ b/Dockerfile.ubuntu24.04
@@ -16,9 +16,11 @@ ARG QUINT_VERSION=0.32.0
 # it and generates their case tables from the models at build time, and without
 # it those suites and the quint_model checks silently disable themselves.
 #
-# Not on ubuntu 22.04 or rocky 9.  quint's Rust evaluator is published only as
-# *-unknown-linux-gnu against glibc 2.39, with no musl build to mirror, so it
-# cannot load on their 2.35 and 2.34.  The TypeScript backend needs no
+# Not on ubuntu 22.04 or rocky 9.  The Linux build of quint's Rust evaluator is
+# linked against glibc 2.39, with no musl build to mirror, so it cannot load on
+# their 2.35 and 2.34.  This is a glibc-version limit, not an absence of
+# non-Linux builds -- darwin arm64 and amd64 evaluators exist, which is what
+# lets the macOS job run these same suites on the same backend.  The TypeScript backend needs no
 # evaluator and would run there, but it is 2.4x slower on these models and
 # generates a different corpus from the same seed -- so those two images would
 # be compiling a different case table from every other platform, which is

--- a/Dockerfile.ubuntu26.04
+++ b/Dockerfile.ubuntu26.04
@@ -16,9 +16,11 @@ ARG QUINT_VERSION=0.32.0
 # it and generates their case tables from the models at build time, and without
 # it those suites and the quint_model checks silently disable themselves.
 #
-# Not on ubuntu 22.04 or rocky 9.  quint's Rust evaluator is published only as
-# *-unknown-linux-gnu against glibc 2.39, with no musl build to mirror, so it
-# cannot load on their 2.35 and 2.34.  The TypeScript backend needs no
+# Not on ubuntu 22.04 or rocky 9.  The Linux build of quint's Rust evaluator is
+# linked against glibc 2.39, with no musl build to mirror, so it cannot load on
+# their 2.35 and 2.34.  This is a glibc-version limit, not an absence of
+# non-Linux builds -- darwin arm64 and amd64 evaluators exist, which is what
+# lets the macOS job run these same suites on the same backend.  The TypeScript backend needs no
 # evaluator and would run there, but it is 2.4x slower on these models and
 # generates a different corpus from the same seed -- so those two images would
 # be compiling a different case table from every other platform, which is


### PR DESCRIPTION
The macOS job has been reporting success without running any of the model-based conformance suites. cmake registers the Core, HTTP and RPC2 conformance tests only when `quint` and `python3` are both on PATH, and the macOS job installs neither — so its configure output reads:

```
-- Core conformance test disabled (needs quint and python3 on PATH)
-- HTTP conformance test disabled (needs quint and python3 on PATH)
-- RPC2 conformance test disabled (needs quint and python3 on PATH)
```

and the leg goes green having skipped all three. The Linux images take quint from the GHCR mirror and do run them, so half the matrix has no model-based coverage at all — and it is the half developers run locally.

## Why npm, and why pinned

quint is not a brew formula; upstream publishes it on npm, which is also what pins it exactly. The pin matters more than the convenience: the case tables these suites run are **generated from the models at build time with fixed seeds**, so a different quint samples the models differently. An unpinned macOS would compile a *different corpus* from the rest of the matrix — testing something else rather than testing more widely. `QUINT_VERSION` here is the version every Dockerfile already pins.

The GHCR mirror is not reusable: that image carries a Linux node+quint tree.

## The Dockerfile comment was wrong

ubuntu 22.04 and rocky 9 stay out, and the comment explaining why said the Rust evaluator is "published only as `*-unknown-linux-gnu`". That is neither the reason nor true — darwin arm64 and amd64 evaluators are published. Verified against a clean `HOME`: quint fetched `rust-evaluator-v0.6.0` (`Mach-O 64-bit executable arm64`) and reported `--backend=rust`, the same backend Linux uses, which is what makes the corpus identical rather than merely similar.

The real limit for those two images is a glibc one — 2.39 against their 2.35 and 2.34 — so the comment now says that.

## Pre-warming

The evaluator is fetched rather than shipped, and quint **aborts** instead of falling back when that download fails. Unwarmed, a network failure surfaces in the middle of case generation as a cmake error naming nothing useful, so it is pulled in a step of its own.

## What to watch

This newly *enforces* three suites on a platform where they have never run. If any of them has a genuine Darwin-specific problem, this is the PR that surfaces it — which is the point, but it means a red macOS leg here is a finding rather than a defect in the change.