### PR TITLE
ci: pin the GITHUB_TOKEN scope for the two remaining jobs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -423,6 +423,9 @@ jobs:
     if: always()
     needs: [test, static-analysis, macos]
     runs-on: ubuntu-24.04
+    # It reads `needs` and nothing else -- no checkout, no API call -- so the
+    # token it runs with can be empty.
+    permissions: {}
     steps:
       - name: Check matrix results
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
     branches: ["main"]
   pull_request:
 
+# The docs build only reads the tree, so the GITHUB_TOKEN needs nothing
+# beyond that.  Without an explicit block a job inherits whatever the
+# repository default happens to be.  Publishing is pages.yml's job.
+permissions:
+  contents: read
+
 jobs:
   # Build job
   build:


### PR DESCRIPTION
CodeQL's `actions/missing-workflow-permissions` flags every job that runs with
whatever GITHUB_TOKEN scopes the repository default hands out. `build-test.yml`
already set permissions on each of its jobs bar one, and `ci.yml` set none.

- `ci.yml`'s `build` job checks out the tree and builds the docs site, so it
  gets a workflow-level `contents: read`. Publishing stays `pages.yml`'s job.
- `build-test.yml`'s `ci-complete` gate reads `needs.*.result` and nothing
  else — no checkout, no API call — so it gets `permissions: {}`.

Closes code scanning alerts
[#3](https://github.com/chimera-nas/libevpl/security/code-scanning/3) (ci.yml) and
[#7](https://github.com/chimera-nas/libevpl/security/code-scanning/7) (build-test.yml).
