### PR TITLE
rpc2: RPCSEC_GSS on the client side

### DIFF
--- a/include/evpl/evpl_rpc2.h
+++ b/include/evpl/evpl_rpc2.h
@@ -17,6 +17,7 @@ struct evpl_iovec;
 struct evpl_rpc2_program;
 struct evpl_rpc2_call;
 struct evpl_rpc2_gss_context;
+struct evpl_rpc2_gss_client;
 
 /*
  * Verifier structure for RPC authentication.
@@ -77,6 +78,11 @@ struct evpl_rpc2_cred {
         const char *principal;
         uint32_t    service;
         void       *gss_ctx;
+        /* Client side: the established context a call travels under.  Set by
+         * a caller building a credential to SEND; NULL in the credential a
+         * server RECEIVES, where the three fields above describe the peer
+         * instead. */
+        struct evpl_rpc2_gss_client *client;
     } gss;
 };
 

--- a/include/evpl/evpl_rpc2_gss.h
+++ b/include/evpl/evpl_rpc2_gss.h
@@ -72,6 +72,26 @@ struct evpl_rpc2_gss_provider {
         char       *principal,
         size_t      principal_sz);
 
+    /*
+     * Initiator half of context establishment (gss_init_sec_context), the
+     * mirror of accept() above.  A provider that only ever answers calls
+     * leaves this NULL; one that also makes them supplies it.
+     *
+     * target names the service to authenticate to ("nfs@host" style).
+     * in_token is the acceptor's last output, NULL on the first leg.  On
+     * return *complete is 1 when the context is ready and 0 when another leg
+     * is needed, and *out_token is the token to send (freed by the caller).
+     */
+    int  (*init)(
+        void       *provider_arg,
+        void      **gss_ctx,
+        const char *target,
+        const void *in_token,
+        size_t      in_len,
+        void      **out_token,
+        size_t     *out_len,
+        int        *complete);
+
     /* Compute a MIC (gss_get_mic) over msg; used for reply verifiers. */
     int (*get_mic)(
         void       *provider_arg,
@@ -157,6 +177,58 @@ struct evpl_rpc2_gss_provider {
         void *provider_arg,
         void *gss_ctx);
 };
+
+/*
+ * A client-side RPCSEC_GSS context.
+ *
+ * Opaque and owned by rpc2.  Created by establishing a context with a peer --
+ * an RPC exchange in its own right, hence the callback -- and then named in an
+ * evpl_rpc2_cred so that ordinary calls travel under it.  One context serves
+ * any number of calls on the connection it was established over; the sequence
+ * number RFC 2203 requires is maintained inside it.
+ */
+struct evpl_rpc2_gss_client;
+struct evpl_rpc2_program;
+struct evpl_rpc2_conn;
+
+typedef void (*evpl_rpc2_gss_client_callback_t)(
+    struct evpl_rpc2_gss_client *client,
+    int                          status,
+    void                        *private_data);
+
+/*
+ * Establish a context against `conn`, then hand it back through `callback`.
+ *
+ * service is one of EVPL_RPC2_GSS_SVC_*: none authenticates each call,
+ * integrity signs its arguments and results, privacy seals them.  target names
+ * the peer service the provider should authenticate to.
+ *
+ * The handshake is carried on the program's NULL procedure, as RFC 2203
+ * section 5.2 requires, so the program must be one the peer serves.  status is
+ * 0 on success; on failure the client is NULL and nothing needs freeing.
+ */
+void
+evpl_rpc2_gss_client_create(
+    struct evpl                          *evpl,
+    struct evpl_rpc2_program             *program,
+    struct evpl_rpc2_conn                *conn,
+    const struct evpl_rpc2_gss_provider  *provider,
+    void                                 *provider_arg,
+    uint32_t                              service,
+    const char                           *target,
+    evpl_rpc2_gss_client_callback_t       callback,
+    void                                 *private_data);
+
+/*
+ * Retire a context.  Sends RPCSEC_GSS_DESTROY so the peer can drop its half
+ * (RFC 2203 section 5.4) and releases the local one.  Best effort: the peer
+ * expires contexts on its own schedule, so a destroy that never arrives costs
+ * the peer a timeout rather than correctness.
+ */
+void
+evpl_rpc2_gss_client_destroy(
+    struct evpl                 *evpl,
+    struct evpl_rpc2_gss_client *client);
 
 /*
  * Register a GSS provider on an rpc2 thread.  Must be called before the

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -1421,7 +1421,13 @@ evpl_rpc2_gss_wr_opaque(
     if (*p + padded > end) {
         return -1;
     }
-    memcpy(*p, data, len);
+    /* A zero-length opaque is a legal encoding and its data pointer is then
+     * meaningless -- an establishment leg with no token to send is exactly
+     * that -- so the copy is conditional on there being something to copy. */
+    if (len) {
+        memcpy(*p, data, len);
+    }
+
     if (padded > len) {
         memset(*p + len, 0, padded - len);
     }
@@ -4731,7 +4737,6 @@ evpl_rpc2_call_full(
 
             req_iov    = &gss_wrapped_iov;
             req_niov   = 1;
-            req_length = wrapped_len;
             pay_length = wrapped_len - program->reserve;
         }
 

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -112,6 +112,20 @@ struct evpl_rpc2_request {
      * gss_handle + gss_seq let the reply path re-find the context (under the
      * global lock) to compute the integrity checksum over the results. */
     int                                   gss_authenticated;
+    /* Client side: set on the NULLPROC exchange that establishes a context,
+     * so its reply is parsed as rpc_gss_init_res by the handshake rather than
+     * handed to the program's (void) NULLPROC result decoder. */
+    struct evpl_rpc2_gss_client          *gss_client_init;
+    /* A reply nobody is waiting for: the DESTROY sent while retiring a
+     * context.  Its client is freed as soon as it is sent, so the reply -- or
+     * the error completion teardown synthesises for it -- must not reach back
+     * for one. */
+    int                                   gss_discard_reply;
+    /* The context this call travelled under, and the sequence number it
+     * carried: the reply is wrapped around the same number, and checking that
+     * is what stops a reply being replayed onto a different call. */
+    struct evpl_rpc2_gss_client          *gss_client;
+    uint32_t                              gss_client_seq;
     uint32_t                              gss_service;
     uint32_t                              gss_handle;
     uint32_t                              gss_seq;
@@ -1269,6 +1283,19 @@ static struct evpl_rpc2_gss_context *evpl_rpc2_gss_table       = NULL;
 static pthread_mutex_t               evpl_rpc2_gss_lock        = PTHREAD_MUTEX_INITIALIZER;
 static uint32_t                      evpl_rpc2_gss_next_handle = 0;
 
+/*
+ * Ceiling on a peer-minted context handle we will hold as a client.  The
+ * handle is opaque to us -- this server mints a uint32, others mint what they
+ * like -- so the only requirement is that it be large enough for real
+ * implementations and bounded so a hostile length cannot size an allocation.
+ */
+#define EVPL_RPC2_GSS_MAX_HANDLE 64
+
+/* Ceiling on a MIC we will emit as a call verifier.  krb5 aes256 is 28 bytes;
+ * this is loose because it only sizes a stack buffer, and a mechanism whose
+ * MIC does not fit is refused rather than truncated. */
+#define EVPL_RPC2_GSS_MAX_MIC    128
+
 /* Decoded rpc_gss_cred_t (version 1). */
 struct evpl_rpc2_gss_cred {
     uint32_t       version;
@@ -1277,6 +1304,44 @@ struct evpl_rpc2_gss_cred {
     uint32_t       service;
     const uint8_t *handle;
     uint32_t       handle_len;
+};
+
+/*
+ * A client-side RPCSEC_GSS context.
+ *
+ * The server keeps its half in evpl_rpc2_gss_context, keyed by a handle it
+ * minted; this is the initiator's mirror.  It owns the mechanism context, the
+ * handle the acceptor gave back, and the sequence number RFC 2203 section
+ * 5.3.1 requires every call to carry and never repeat.
+ *
+ * Deliberately per-connection rather than per-thread: a context is established
+ * over one connection and the acceptor scopes it there, so sharing one across
+ * connections would present a handle the peer does not recognise.
+ */
+struct evpl_rpc2_gss_client {
+    const struct evpl_rpc2_gss_provider *provider;
+    void                                *provider_arg;
+    void                                *gss_ctx;
+    uint32_t                             service;
+    /* Next sequence number.  Starts at 1: zero is legal but wastes the one
+     * value a peer's replay window starts out having already seen. */
+    uint32_t                             seq;
+    uint8_t                              handle[EVPL_RPC2_GSS_MAX_HANDLE];
+    uint32_t                             handle_len;
+
+    /* Live only while the handshake is in flight. */
+    struct evpl_rpc2_program            *program;
+    struct evpl_rpc2_conn               *conn;
+    char                                *target;
+    evpl_rpc2_gss_client_callback_t      callback;
+    void                                *callback_arg;
+    int                                  established;
+    /* The mechanism reported GSS_S_COMPLETE on the leg we last sent.  With a
+     * service ticket in hand krb5 finishes in one, so the acceptor's reply is
+     * an acknowledgement rather than a token to feed back -- and feeding it
+     * back anyway would start a second context, leaving us signing with one
+     * the acceptor never agreed to. */
+    int                                  mech_complete;
 };
 
 /* --- minimal big-endian XDR cursors over contiguous byte buffers --- */
@@ -2396,6 +2461,615 @@ evpl_rpc2_gss_handle_call(
     return 1;
 } /* evpl_rpc2_gss_handle_call */
 
+/* =================== RPCSEC_GSS, initiator side =========================
+ *
+ * Everything above answers calls; this makes them.  The two halves share the
+ * wire format and the cursors, and nothing else: an acceptor is driven by what
+ * arrives, an initiator by what it decides to send, so the state each keeps is
+ * different and lives apart.
+ *
+ * What a client owes per RFC 2203, and what is implemented here:
+ *
+ *   - a context, established over the program's NULL procedure (sec 5.2)
+ *   - an rpc_gss_cred_t on every call naming that context, the service, and a
+ *     sequence number that never repeats (sec 5.3.1)
+ *   - a verifier that is a MIC over the call header through the credential,
+ *     which is what binds the sequence number to the request (sec 5.3.1)
+ *   - under integrity or privacy, arguments reframed as rpc_gss_integ_data or
+ *     rpc_gss_priv_data, and results unwrapped symmetrically (sec 5.3.2)
+ */
+
+/* Build the rpc_gss_cred_t body for a call.  Returns its length, or 0 if it
+ * would not fit -- which cannot happen for any handle we accepted. */
+static uint32_t
+evpl_rpc2_gss_client_cred_blob(
+    struct evpl_rpc2_gss_client *gc,
+    uint32_t                     proc,
+    uint32_t                     seq,
+    uint8_t                     *out,
+    uint32_t                     out_cap)
+{
+    uint8_t *p   = out;
+    uint8_t *end = out + out_cap;
+
+    if (evpl_rpc2_gss_wr_u32(&p, end, RPCSEC_GSS_VERS_1) ||
+        evpl_rpc2_gss_wr_u32(&p, end, proc) ||
+        evpl_rpc2_gss_wr_u32(&p, end, seq) ||
+        evpl_rpc2_gss_wr_u32(&p, end, gc->service) ||
+        evpl_rpc2_gss_wr_opaque(&p, end, gc->handle, gc->handle_len)) {
+        return 0;
+    }
+
+    return (uint32_t) (p - out);
+} /* evpl_rpc2_gss_client_cred_blob */
+
+/*
+ * Parse an rpc_gss_init_res from a reply body:
+ *   { opaque handle<>; unsigned major; unsigned minor; unsigned seq_window;
+ *     opaque gss_token<>; }
+ *
+ * Returns 0 on a well-formed response, -1 otherwise.  A mechanism-level
+ * failure is well-formed -- major says so -- and is reported through *major
+ * rather than as a parse error, because the two call for different answers.
+ */
+static int
+evpl_rpc2_gss_client_parse_init_res(
+    struct evpl_rpc2_gss_client *gc,
+    const uint8_t               *body,
+    uint32_t                     len,
+    uint32_t                    *r_major,
+    const uint8_t              **r_token,
+    uint32_t                    *r_token_len)
+{
+    const uint8_t *p   = body;
+    const uint8_t *end = body + len;
+    const uint8_t *hand;
+    uint32_t       hlen, minor, window;
+
+    if (evpl_rpc2_gss_rd_opaque(&p, end, &hand, &hlen) ||
+        evpl_rpc2_gss_rd_u32(&p, end, r_major) ||
+        evpl_rpc2_gss_rd_u32(&p, end, &minor) ||
+        evpl_rpc2_gss_rd_u32(&p, end, &window) ||
+        evpl_rpc2_gss_rd_opaque(&p, end, r_token, r_token_len)) {
+        return -1;
+    }
+
+    if (hlen > EVPL_RPC2_GSS_MAX_HANDLE) {
+        evpl_rpc2_debug("rpcsec_gss: peer handle is %u bytes, over the %u we hold",
+                        hlen, EVPL_RPC2_GSS_MAX_HANDLE);
+        return -1;
+    }
+
+    /* Adopt the handle from every leg: RFC 2203 sec 5.2.2 lets the acceptor
+     * change it between legs, and the last one is the one that counts. */
+    memcpy(gc->handle, hand, hlen);
+    gc->handle_len = hlen;
+
+    return 0;
+} /* evpl_rpc2_gss_client_parse_init_res */
+
+/*
+ * Reframe call arguments for the integrity service:
+ *   rpc_gss_integ_data { opaque databody<>; opaque checksum<>; }
+ * with databody = seq_num || args and checksum a MIC over it.
+ *
+ * The mirror of evpl_rpc2_gss_wrap_reply_integrity, and deliberately shaped
+ * the same way -- headroom preserved at the front, the caller's iovecs
+ * released, one contiguous result -- because the two are the same
+ * transformation seen from opposite ends, and a difference between them would
+ * be a bug in one of them.
+ */
+static int
+evpl_rpc2_gss_wrap_call_integrity(
+    struct evpl                 *evpl,
+    struct evpl_rpc2_gss_client *gc,
+    uint32_t                     seq,
+    struct evpl_iovec           *msg_iov,
+    int                          msg_niov,
+    int                          length,
+    int                          reserve,
+    struct evpl_iovec           *out_iov,
+    int                         *out_length)
+{
+    uint32_t bodylen = length - reserve;
+    uint32_t db_len  = 4 + bodylen;
+    uint32_t db_pad  = evpl_rpc2_gss_pad4(db_len);
+    uint32_t cap, newbodylen;
+    uint8_t *p, *databody, *cksum_pos, *pp;
+    void    *mic     = NULL;
+    size_t   mic_len = 0;
+
+    cap = reserve + 4 + db_pad + 4 + EVPL_RPC2_GSS_MAX_MIC;
+
+    if (evpl_iovec_alloc(evpl, cap, 8, 1, 0, out_iov) != 1) {
+        return -1;
+    }
+
+    p  = (uint8_t *) out_iov->data + reserve;
+    pp = p;
+
+    if (evpl_rpc2_gss_wr_u32(&pp, p + 4, db_len)) {
+        goto fail;
+    }
+
+    databody = p + 4;
+    pp       = databody;
+
+    if (evpl_rpc2_gss_wr_u32(&pp, databody + 4, seq)) {
+        goto fail;
+    }
+
+    if (bodylen &&
+        evpl_rpc2_iov_gather(msg_iov, msg_niov, reserve, databody + 4, bodylen)) {
+        goto fail;
+    }
+
+    if (db_pad > db_len) {
+        memset(databody + db_len, 0, db_pad - db_len);
+    }
+
+    if (gc->provider->get_mic(gc->provider_arg, gc->gss_ctx, databody, db_len,
+                              &mic, &mic_len) || !mic ||
+        mic_len > EVPL_RPC2_GSS_MAX_MIC) {
+        if (mic) {
+            free(mic);
+        }
+        goto fail;
+    }
+
+    cksum_pos = databody + db_pad;
+    pp        = cksum_pos;
+
+    if (evpl_rpc2_gss_wr_opaque(&pp, cksum_pos + 4 +
+                                evpl_rpc2_gss_pad4((uint32_t) mic_len),
+                                mic, mic_len)) {
+        free(mic);
+        goto fail;
+    }
+
+    free(mic);
+
+    newbodylen      = 4 + db_pad + 4 + evpl_rpc2_gss_pad4((uint32_t) mic_len);
+    out_iov->length = reserve + newbodylen;
+    *out_length     = reserve + newbodylen;
+
+    evpl_iovecs_release(evpl, msg_iov, msg_niov);
+    return 0;
+
+ fail:
+    evpl_iovec_release(evpl, out_iov);
+    return -1;
+} /* evpl_rpc2_gss_wrap_call_integrity */
+
+/*
+ * The privacy counterpart: rpc_gss_priv_data, one opaque holding the sealed
+ * token of seq_num || args.  Staged contiguously first because the mechanism
+ * seals one block, then sealed straight into the outgoing buffer -- the same
+ * caller-owned-output shape the reply path uses, so the token is never copied
+ * out of mechanism storage.
+ */
+static int
+evpl_rpc2_gss_wrap_call_privacy(
+    struct evpl                 *evpl,
+    struct evpl_rpc2_gss_client *gc,
+    uint32_t                     seq,
+    struct evpl_iovec           *msg_iov,
+    int                          msg_niov,
+    int                          length,
+    int                          reserve,
+    struct evpl_iovec           *out_iov,
+    int                         *out_length)
+{
+    uint32_t          bodylen = length - reserve;
+    uint32_t          pt_len  = 4 + bodylen;
+    struct evpl_iovec plain_iov;
+    uint8_t          *pt, *pp, *tok;
+    size_t            token_len = 0;
+    uint32_t          cap, newbodylen;
+
+    if (evpl_iovec_alloc(evpl, pt_len, 8, 1, 0, &plain_iov) != 1) {
+        return -1;
+    }
+
+    pt = plain_iov.data;
+    pp = pt;
+
+    if (evpl_rpc2_gss_wr_u32(&pp, pt + 4, seq) ||
+        (bodylen &&
+         evpl_rpc2_iov_gather(msg_iov, msg_niov, reserve, pt + 4, bodylen))) {
+        evpl_iovec_release(evpl, &plain_iov);
+        return -1;
+    }
+
+    cap = reserve + 4 + evpl_rpc2_gss_pad4(pt_len + EVPL_RPC2_GSS_SEAL_MAX);
+
+    if (evpl_iovec_alloc(evpl, cap, 8, 1, 0, out_iov) != 1) {
+        evpl_iovec_release(evpl, &plain_iov);
+        return -1;
+    }
+
+    tok = (uint8_t *) out_iov->data + reserve + 4;
+
+    if (gc->provider->wrap(gc->provider_arg, gc->gss_ctx, pt, pt_len, tok,
+                           cap - reserve - 4, &token_len) || token_len == 0) {
+        evpl_iovec_release(evpl, &plain_iov);
+        evpl_iovec_release(evpl, out_iov);
+        return -1;
+    }
+
+    evpl_iovec_release(evpl, &plain_iov);
+
+    pp = (uint8_t *) out_iov->data + reserve;
+
+    if (evpl_rpc2_gss_wr_u32(&pp, pp + 4, (uint32_t) token_len)) {
+        evpl_iovec_release(evpl, out_iov);
+        return -1;
+    }
+
+    newbodylen = 4 + evpl_rpc2_gss_pad4((uint32_t) token_len);
+
+    if (newbodylen > 4 + token_len) {
+        memset(tok + token_len, 0, newbodylen - 4 - token_len);
+    }
+
+    out_iov->length = reserve + newbodylen;
+    *out_length     = reserve + newbodylen;
+
+    evpl_iovecs_release(evpl, msg_iov, msg_niov);
+    return 0;
+} /* evpl_rpc2_gss_wrap_call_privacy */
+
+/*
+ * Unwrap a reply the peer wrapped, and repoint (*iov_p, *niov_p, *len_p) at
+ * the results inside it.
+ *
+ * The acceptor's mirror of this checks a sequence number the initiator chose;
+ * here the initiator checks one the acceptor echoed, and it is the same
+ * number.  A reply carrying a different one is a reply to some other call --
+ * which on a connection that multiplexes is worth catching, because the xid
+ * alone would not notice a peer that answered the wrong request under the
+ * right identifier.
+ */
+static int
+evpl_rpc2_gss_unwrap_reply(
+    struct evpl                 *evpl,
+    struct evpl_rpc2_gss_client *gc,
+    uint32_t                     seq,
+    struct xdr_dbuf             *dbuf,
+    struct evpl_iovec          **iov_p,
+    int                         *niov_p,
+    int                         *len_p)
+{
+    struct evpl_iovec *iov  = *iov_p;
+    int                niov = *niov_p;
+    uint8_t            lenbuf[4];
+    const uint8_t     *lp;
+    uint32_t           outer, embedded, inner_len;
+    struct evpl_iovec *inner;
+    struct evpl_iovec  flat;
+    int                ninner, rc = -1;
+
+    if (evpl_rpc2_iov_gather(iov, niov, 0, lenbuf, 4)) {
+        return -1;
+    }
+
+    lp = lenbuf;
+
+    if (evpl_rpc2_gss_rd_u32(&lp, lenbuf + 4, &outer) || outer < 4) {
+        return -1;
+    }
+
+    if (4 + (uint64_t) outer > (uint64_t) (uint32_t) *len_p) {
+        return -1;
+    }
+
+    inner = xdr_dbuf_alloc_space(sizeof(*inner), dbuf);
+
+    if (!inner) {
+        return -1;
+    }
+
+    /* Both services put a length-prefixed blob first, so the gather is
+     * common; what differs is whether the bytes are the plaintext (integrity,
+     * where the checksum follows and is verified) or a token to unseal. */
+    if (evpl_iovec_alloc(evpl, outer, 8, 1, 0, &flat) != 1) {
+        return -1;
+    }
+
+    if (evpl_rpc2_iov_gather(iov, niov, 4, flat.data, outer)) {
+        goto out;
+    }
+
+    if (gc->service == EVPL_RPC2_GSS_SVC_INTEGRITY) {
+        uint32_t       ck_off = 4 + evpl_rpc2_gss_pad4(outer);
+        uint32_t       ck_len;
+        const uint8_t *ck;
+        uint8_t        ckbuf[EVPL_RPC2_GSS_MAX_MIC];
+
+        if (evpl_rpc2_iov_gather(iov, niov, ck_off, lenbuf, 4)) {
+            goto out;
+        }
+
+        lp = lenbuf;
+        evpl_rpc2_gss_rd_u32(&lp, lenbuf + 4, &ck_len);
+
+        if (ck_len == 0 || ck_len > sizeof(ckbuf) ||
+            evpl_rpc2_iov_gather(iov, niov, ck_off + 4, ckbuf, ck_len)) {
+            goto out;
+        }
+
+        ck = ckbuf;
+
+        if (gc->provider->verify_mic(gc->provider_arg, gc->gss_ctx,
+                                     flat.data, outer, ck, ck_len)) {
+            evpl_rpc2_debug("rpcsec_gss: reply checksum did not verify");
+            goto out;
+        }
+
+        if (evpl_iovec_alloc(evpl, outer, 8, 1, 0, inner) != 1) {
+            goto out;
+        }
+
+        memcpy(inner->data, flat.data, outer);
+        inner->length = outer;
+        inner_len     = outer;
+    } else {
+        size_t plain_len = 0;
+
+        if (evpl_iovec_alloc(evpl, outer, 8, 1, 0, inner) != 1) {
+            goto out;
+        }
+
+        if (gc->provider->unwrap(gc->provider_arg, gc->gss_ctx, flat.data,
+                                 outer, inner->data, outer, &plain_len) ||
+            plain_len < 4) {
+            evpl_rpc2_debug("rpcsec_gss: reply would not unseal");
+            evpl_iovec_release(evpl, inner);
+            goto out;
+        }
+
+        inner->length = (uint32_t) plain_len;
+        inner_len     = (uint32_t) plain_len;
+    }
+
+    lp = inner->data;
+    evpl_rpc2_gss_rd_u32(&lp, (const uint8_t *) inner->data + 4, &embedded);
+
+    if (embedded != seq) {
+        evpl_rpc2_debug("rpcsec_gss: reply seq %u, expected %u", embedded, seq);
+        evpl_iovec_release(evpl, inner);
+        goto out;
+    }
+
+    /* Past the echoed seq lie the results themselves. */
+    inner->data   = (uint8_t *) inner->data + 4;
+    inner->length = inner_len - 4;
+
+    ninner  = 1;
+    *iov_p  = inner;
+    *niov_p = ninner;
+    *len_p  = (int) (inner_len - 4);
+    rc      = 0;
+
+ out:
+    evpl_iovec_release(evpl, &flat);
+    return rc;
+} /* evpl_rpc2_gss_unwrap_reply */
+
+/* Forward: the handshake sends ordinary calls, which the sender defines. */
+static int
+evpl_rpc2_call_gss_init(
+    struct evpl                 *evpl,
+    struct evpl_rpc2_gss_client *gc,
+    const void                  *token,
+    size_t                       token_len,
+    uint32_t                     proc);
+
+static void
+evpl_rpc2_gss_client_fail(
+    struct evpl                 *evpl,
+    struct evpl_rpc2_gss_client *gc)
+{
+    evpl_rpc2_gss_client_callback_t cb  = gc->callback;
+    void                           *arg = gc->callback_arg;
+
+    if (gc->gss_ctx && gc->provider->destroy) {
+        gc->provider->destroy(gc->provider_arg, gc->gss_ctx);
+    }
+    free(gc->target);
+    free(gc);
+
+    if (cb) {
+        cb(NULL, -1, arg);
+    }
+} /* evpl_rpc2_gss_client_fail */
+
+/*
+ * One leg of the handshake has come back.  Feed the acceptor's token to the
+ * mechanism; either it is satisfied, or it produces another token to send.
+ *
+ * Called from the client reply path, which routes here rather than to the
+ * program's result decoder because these results are an rpc_gss_init_res and
+ * the procedure carrying them is NULLPROC, whose results are void.
+ */
+static void
+evpl_rpc2_gss_client_init_reply(
+    struct evpl                 *evpl,
+    struct evpl_rpc2_gss_client *gc,
+    const uint8_t               *body,
+    uint32_t                     body_len,
+    int                          status)
+{
+    const uint8_t *token     = NULL;
+    uint32_t       token_len = 0;
+    uint32_t       major     = 0;
+    void          *out       = NULL;
+    size_t         out_len   = 0;
+    int            complete  = 0;
+
+    if (status) {
+        evpl_rpc2_debug("rpcsec_gss: context establishment refused, status=%d",
+                        status);
+        evpl_rpc2_gss_client_fail(evpl, gc);
+        return;
+    }
+
+    if (evpl_rpc2_gss_client_parse_init_res(gc, body, body_len, &major,
+                                            &token, &token_len)) {
+        evpl_rpc2_debug("rpcsec_gss: malformed rpc_gss_init_res (%u bytes)",
+                        body_len);
+        evpl_rpc2_gss_client_fail(evpl, gc);
+        return;
+    }
+
+    /* GSS_S_COMPLETE is 0; anything else with the error bits set is the
+     * acceptor telling us the mechanism refused, which no amount of further
+     * legs will fix. */
+    if (major & 0xffff0000u) {
+        evpl_rpc2_debug("rpcsec_gss: acceptor rejected the context, major=0x%x",
+                        major);
+        evpl_rpc2_gss_client_fail(evpl, gc);
+        return;
+    }
+
+    if (gc->mech_complete) {
+        /* Already established locally; the reply only carried the handle,
+         * which parse_init_res has taken. */
+        complete = 1;
+    } else if (gc->provider->init(gc->provider_arg, &gc->gss_ctx, gc->target,
+                                  token_len ? token : NULL, token_len,
+                                  &out, &out_len, &complete)) {
+        evpl_rpc2_debug("rpcsec_gss: initiator rejected the acceptor's token");
+        evpl_rpc2_gss_client_fail(evpl, gc);
+        return;
+    }
+
+    gc->mech_complete = complete;
+
+    if (!complete) {
+        /* Another leg.  RFC 2203 sec 5.2.2: continuation legs carry
+         * RPCSEC_GSS_CONTINUE_INIT and the handle the acceptor gave us. */
+        if (evpl_rpc2_call_gss_init(evpl, gc, out, out_len,
+                                    RPCSEC_GSS_CONTINUE_INIT)) {
+            free(out);
+            evpl_rpc2_gss_client_fail(evpl, gc);
+            return;
+        }
+        free(out);
+        return;
+    }
+
+    if (out) {
+        /* A final token the acceptor does not need: the context is complete
+         * on our side and the peer said it was complete on its own. */
+        free(out);
+    }
+
+    gc->established = 1;
+    gc->seq         = 1;
+
+    if (gc->callback) {
+        gc->callback(gc, 0, gc->callback_arg);
+    }
+} /* evpl_rpc2_gss_client_init_reply */
+
+SYMBOL_EXPORT void
+evpl_rpc2_gss_client_create(
+    struct evpl                         *evpl,
+    struct evpl_rpc2_program            *program,
+    struct evpl_rpc2_conn               *conn,
+    const struct evpl_rpc2_gss_provider *provider,
+    void                                *provider_arg,
+    uint32_t                             service,
+    const char                          *target,
+    evpl_rpc2_gss_client_callback_t      callback,
+    void                                *private_data)
+{
+    struct evpl_rpc2_gss_client *gc;
+    void                        *token     = NULL;
+    size_t                       token_len = 0;
+    int                          complete  = 0;
+
+    evpl_rpc2_abort_if(!provider || !provider->init,
+                       "evpl_rpc2_gss_client_create: provider has no initiator");
+
+    gc = calloc(1, sizeof(*gc));
+
+    gc->provider     = provider;
+    gc->provider_arg = provider_arg;
+    gc->service      = service;
+    gc->program      = program;
+    gc->conn         = conn;
+    gc->target       = target ? strdup(target) : NULL;
+    gc->callback     = callback;
+    gc->callback_arg = private_data;
+
+    /* First leg: no acceptor token yet. */
+    if (provider->init(provider_arg, &gc->gss_ctx, gc->target, NULL, 0,
+                       &token, &token_len, &complete)) {
+        evpl_rpc2_debug("rpcsec_gss: initiator would not start a context");
+        evpl_rpc2_gss_client_fail(evpl, gc);
+        return;
+    }
+
+    gc->mech_complete = complete;
+
+    if (evpl_rpc2_call_gss_init(evpl, gc, token, token_len, RPCSEC_GSS_INIT)) {
+        free(token);
+        evpl_rpc2_gss_client_fail(evpl, gc);
+        return;
+    }
+
+    free(token);
+} /* evpl_rpc2_gss_client_create */
+
+SYMBOL_EXPORT void
+evpl_rpc2_gss_client_destroy(
+    struct evpl                 *evpl,
+    struct evpl_rpc2_gss_client *client)
+{
+    if (!client) {
+        return;
+    }
+
+    /* Best effort: tell the peer so it can drop its half now rather than at
+     * expiry (RFC 2203 sec 5.4).  A DESTROY that never lands costs the peer a
+     * timeout, not correctness, so its failure is not worth reporting. */
+    if (client->established) {
+        evpl_rpc2_call_gss_init(evpl, client, NULL, 0, RPCSEC_GSS_DESTROY);
+    }
+
+    /* A call made under this context may still be outstanding -- the caller
+     * is entitled to retire a context without first draining what it carried,
+     * and the DESTROY just queued is itself such a call.  Their replies still
+     * have to be dispatched, so the back-references are cleared rather than
+     * the requests cancelled: a reply that arrives after this point is
+     * delivered unwrapped and unverified, which is what an unprotected reply
+     * to a context that no longer exists is. */
+    if (client->conn) {
+        struct evpl_rpc2_request *request, *tmp;
+
+        HASH_ITER(hh, client->conn->pending_calls, request, tmp)
+        {
+            if (request->gss_client == client) {
+                request->gss_client = NULL;
+            }
+
+            if (request->gss_client_init == client) {
+                request->gss_client_init   = NULL;
+                request->gss_discard_reply = 1;
+            }
+        }
+    }
+
+    if (client->gss_ctx && client->provider->destroy) {
+        client->provider->destroy(client->provider_arg, client->gss_ctx);
+    }
+
+    free(client->target);
+    free(client);
+} /* evpl_rpc2_gss_client_destroy */
+
 SYMBOL_EXPORT void
 evpl_rpc2_set_gss_provider(
     struct evpl_rpc2_thread             *thread,
@@ -2516,6 +3190,45 @@ evpl_rpc2_client_handle_reply(
     int                      error;
     int                      chunk_unclaimed = 0;
     struct evpl             *evpl            = thread->evpl;
+    struct evpl_iovec       *gss_opened_iov  = NULL;
+
+    /*
+     * A context-establishment reply.  Its results are an rpc_gss_init_res, and
+     * the procedure that carried them is NULLPROC, whose results the program's
+     * generated decoder knows to be void -- so it has to be intercepted here,
+     * before dispatch, rather than decoded as the call's own output.
+     */
+    if (request->gss_discard_reply) {
+        evpl_rpc2_request_free(thread, request);
+        return;
+    }
+
+    if (request->gss_client_init) {
+        struct evpl_rpc2_gss_client *gc = request->gss_client_init;
+        uint8_t                      body[512];
+        uint32_t                     body_len = 0;
+
+        if (!status && reply_length > 0) {
+            body_len = (uint32_t) reply_length;
+            if (body_len > sizeof(body) ||
+                evpl_rpc2_iov_gather(reply_iov, reply_niov, 0, body, body_len)) {
+                body_len = 0;
+                status   = -1;
+            }
+        }
+
+        /* DESTROY is fire and forget: the context is already being torn down
+         * locally, so there is nothing an answer could change. */
+        if (!gc->established || gc->callback) {
+            evpl_rpc2_gss_client_init_reply(evpl, gc, body, body_len, status);
+        }
+
+        /* The reply iovecs belong to request->msg, which request_free
+         * releases; releasing them here as well would drop the reference
+         * twice. */
+        evpl_rpc2_request_free(thread, request);
+        return;
+    }
 
     if (request->read_chunk.niov) {
         /* Since server has replied, it will have finished reading our read chunk.
@@ -2556,6 +3269,24 @@ evpl_rpc2_client_handle_reply(
         request->write_chunk.length = 0;
     }
 
+    /* A reply to a wrapped call is wrapped too (RFC 2203 sec 5.3.3.2/5.3.3.3),
+    * so it has to be opened before the program's decoder sees it -- which
+    * would otherwise be handed rpc_gss_integ_data where it expects results. */
+    if (request->gss_client && !status &&
+        request->gss_client->service != EVPL_RPC2_GSS_SVC_NONE) {
+        if (evpl_rpc2_gss_unwrap_reply(evpl, request->gss_client,
+                                       request->gss_client_seq,
+                                       &request->msg->dbuf, &reply_iov,
+                                       &reply_niov, &reply_length)) {
+            status = EVPL_RPC2_REPLY_DENIED;
+        } else {
+            /* The opened results live in a buffer of their own rather than in
+             * the ones the reply arrived in, so they have to be dropped
+             * separately -- and only once the decoder has read them. */
+            gss_opened_iov = reply_iov;
+        }
+    }
+
     error = request->program->recv_reply_dispatch(evpl, conn, &request->msg->dbuf,
                                                   request->proc,
                                                   &request->read_chunk,
@@ -2563,6 +3294,10 @@ evpl_rpc2_client_handle_reply(
                                                   status,
                                                   request->callback,
                                                   request->callback_arg);
+
+    if (gss_opened_iov) {
+        evpl_iovec_release(evpl, gss_opened_iov);
+    }
 
     if (chunk_unclaimed) {
         evpl_iovecs_release_internal(evpl, request->read_chunk.iov,
@@ -3743,6 +4478,88 @@ evpl_rpc2_client_disconnect(
     evpl_close(thread->evpl, conn->bind);
 } /* evpl_rpc2_client_destroy */
 
+static int
+evpl_rpc2_call_full(
+    struct evpl                 *evpl,
+    struct evpl_rpc2_program    *program,
+    struct evpl_rpc2_conn       *conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     procedure,
+    struct evpl_iovec           *req_iov,
+    int                          req_niov,
+    int                          req_length,
+    struct evpl_rpc2_rdma_chunk *rdma_chunk,
+    int                          max_rdma_write_chunk,
+    struct evpl_iovec           *write_chunk_iov,
+    int                          write_chunk_niov,
+    int                          max_rdma_reply_chunk,
+    void                        *callback,
+    void                        *private_data,
+    struct evpl_rpc2_gss_client *gss_init_client,
+    const uint8_t               *gss_init_cred,
+    uint32_t                     gss_init_cred_len,
+    int                          gss_discard);
+
+/*
+ * Send one context-establishment leg on the program's NULL procedure.
+ *
+ * RFC 2203 sec 5.2: the GSS token travels as rpc_gss_init_arg -- a lone opaque
+ * in the call arguments -- and the credential carries the procedure and the
+ * handle so far.  DESTROY reuses the same shape with no token, which is why it
+ * is sent from here rather than from a path of its own.
+ */
+static int
+evpl_rpc2_call_gss_init(
+    struct evpl                 *evpl,
+    struct evpl_rpc2_gss_client *gc,
+    const void                  *token,
+    size_t                       token_len,
+    uint32_t                     proc)
+{
+    uint8_t           cred_buf[32 + EVPL_RPC2_GSS_MAX_HANDLE];
+    uint32_t          cred_len;
+    struct evpl_iovec arg_iov;
+    uint8_t          *p, *end;
+    uint32_t          arg_len = 4 + evpl_rpc2_gss_pad4((uint32_t) token_len);
+    int               reserve = gc->program->reserve;
+    int               rc;
+
+    /* A DESTROY names the context and carries no token; the sequence number it
+     * spends is a real one from the window, because the acceptor authenticates
+     * it exactly like any other call (sec 5.4). */
+    cred_len = evpl_rpc2_gss_client_cred_blob(gc, proc,
+                                              proc == RPCSEC_GSS_DESTROY ?
+                                              gc->seq++ : 0,
+                                              cred_buf, sizeof(cred_buf));
+    if (!cred_len) {
+        return -1;
+    }
+
+    if (evpl_iovec_alloc(evpl, reserve + arg_len, 8, 1, 0, &arg_iov) != 1) {
+        return -1;
+    }
+
+    p   = (uint8_t *) arg_iov.data + reserve;
+    end = p + arg_len;
+
+    if (evpl_rpc2_gss_wr_opaque(&p, end, token, token_len)) {
+        evpl_iovec_release(evpl, &arg_iov);
+        return -1;
+    }
+
+    arg_iov.length = reserve + arg_len;
+
+    rc = evpl_rpc2_call_full(evpl, gc->program, gc->conn, NULL, 0,
+                             &arg_iov, 1, reserve + arg_len,
+                             NULL, 0, NULL, 0, 0, NULL, NULL,
+                             gc, cred_buf, cred_len,
+                             proc == RPCSEC_GSS_DESTROY);
+
+    /* arg_iov is consumed by the call path (marshalling moves it inline and
+     * the send holds what it needs), so it must not be released here. */
+    return rc;
+} /* evpl_rpc2_call_gss_init */
+
 SYMBOL_EXPORT int
 evpl_rpc2_call(
     struct evpl                 *evpl,
@@ -3761,22 +4578,57 @@ evpl_rpc2_call(
     void                        *callback,
     void                        *private_data)
 {
-    struct evpl_rpc2_thread  *thread = conn->thread;
-    struct evpl_rpc2_request *request;
-    struct evpl_rpc2_msg     *msg;
-    struct rpc_msg            rpc_msg;
-    struct rdma_msg           rdma_msg;
-    struct evpl_iovec         hdr_iov, hdr_out_iov;
-    struct xdr_read_list      read_list;
-    struct xdr_write_list     write_list;
-    struct xdr_rdma_segment   write_chunk_segment;
-    struct xdr_write_chunk    reply_chunk;
-    struct xdr_rdma_segment   reply_chunk_segment;
-    int                       transport_hdr_len, rpc_len, i;
-    int                       out_niov   = 1;
-    int                       pay_length = req_length - program->reserve;
-    int                       total_length;
-    int                       rdma = conn->rdma;
+    return evpl_rpc2_call_full(evpl, program, conn, cred, procedure, req_iov,
+                               req_niov, req_length, rdma_chunk,
+                               max_rdma_write_chunk, write_chunk_iov,
+                               write_chunk_niov, max_rdma_reply_chunk,
+                               callback, private_data, NULL, 0, 0, 0);
+} /* evpl_rpc2_call */
+
+static int
+evpl_rpc2_call_full(
+    struct evpl                 *evpl,
+    struct evpl_rpc2_program    *program,
+    struct evpl_rpc2_conn       *conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     procedure,
+    struct evpl_iovec           *req_iov,
+    int                          req_niov,
+    int                          req_length,
+    struct evpl_rpc2_rdma_chunk *rdma_chunk,
+    int                          max_rdma_write_chunk,
+    struct evpl_iovec           *write_chunk_iov,
+    int                          write_chunk_niov,
+    int                          max_rdma_reply_chunk,
+    void                        *callback,
+    void                        *private_data,
+    struct evpl_rpc2_gss_client *gss_init_client,
+    const uint8_t               *gss_init_cred,
+    uint32_t                     gss_init_cred_len,
+    int                          gss_discard)
+{
+    struct evpl_rpc2_thread     *thread = conn->thread;
+    struct evpl_rpc2_request    *request;
+    struct evpl_rpc2_msg        *msg;
+    struct rpc_msg               rpc_msg;
+    struct rdma_msg              rdma_msg;
+    struct evpl_iovec            hdr_iov, hdr_out_iov;
+    struct xdr_read_list         read_list;
+    struct xdr_write_list        write_list;
+    struct xdr_rdma_segment      write_chunk_segment;
+    struct xdr_write_chunk       reply_chunk;
+    struct xdr_rdma_segment      reply_chunk_segment;
+    int                          transport_hdr_len, rpc_len, i;
+    struct evpl_rpc2_gss_client *gss_client   = NULL;
+    uint32_t                     gss_seq      = 0;
+    uint32_t                     gss_cred_len = 0;
+    uint8_t                      gss_cred_buf[32 + EVPL_RPC2_GSS_MAX_HANDLE];
+    uint8_t                      gss_verf_buf[EVPL_RPC2_GSS_MAX_MIC];
+    struct evpl_iovec            gss_wrapped_iov;
+    int                          out_niov   = 1;
+    int                          pay_length = req_length - program->reserve;
+    int                          total_length;
+    int                          rdma = conn->rdma;
 
     /* Allocate request for the exchange */
     request = evpl_rpc2_request_alloc(thread);
@@ -3788,12 +4640,14 @@ evpl_rpc2_call(
     msg          = evpl_rpc2_msg_alloc(thread);
     request->msg = msg;
 
-    request->conn         = conn;
-    request->program      = program;
-    request->xid          = conn->next_xid++;
-    request->proc         = procedure;
-    request->callback     = callback;
-    request->callback_arg = private_data;
+    request->conn              = conn;
+    request->gss_client_init   = gss_init_client;
+    request->gss_discard_reply = gss_discard;
+    request->program           = program;
+    request->xid               = conn->next_xid++;
+    request->proc              = procedure;
+    request->callback          = callback;
+    request->callback_arg      = private_data;
 
     HASH_ADD(hh, conn->pending_calls, xid, sizeof(request->xid), request);
 
@@ -3816,9 +4670,157 @@ evpl_rpc2_call(
         rpc_msg.body.cbody.cred.authsys.gid             = cred->authsys.gid;
         rpc_msg.body.cbody.cred.authsys.num_gids        = cred->authsys.num_gids;
         rpc_msg.body.cbody.cred.authsys.gids            = cred->authsys.gids;
+    } else if (cred && cred->flavor == EVPL_RPC2_AUTH_RPCSEC_GSS &&
+               cred->gss.client) {
+        struct evpl_rpc2_gss_client *gc = cred->gss.client;
+
+        /* An established context: DATA, carrying the next sequence number.
+         * RFC 2203 sec 5.3.1 -- the number must never repeat on a context,
+         * which is why it lives in the context and not in the caller. */
+        gss_client   = gc;
+        gss_seq      = gc->seq++;
+        gss_cred_len = evpl_rpc2_gss_client_cred_blob(gc, RPCSEC_GSS_DATA,
+                                                      gss_seq, gss_cred_buf,
+                                                      sizeof(gss_cred_buf));
+        if (!gss_cred_len) {
+            evpl_rpc2_request_free(thread, request);
+            return -1;
+        }
+
+        /*
+         * Under integrity or privacy the arguments do not travel as
+         * themselves: they are reframed around the same sequence number the
+         * credential carries, which is what ties the two together and what
+         * the acceptor checks.  Done here, before the header is sized, so
+         * everything downstream measures the wrapped payload.
+         *
+         * RDMA is excluded for the same reason the acceptor excludes it: the
+         * payload does not travel inline, so there is nothing at this layer to
+         * wrap.
+         */
+        if (!rdma && gc->service != EVPL_RPC2_GSS_SVC_NONE) {
+            int wrapped_len = 0;
+            int rc;
+
+            /* Allocated straight into the variable that will carry it, not
+             * into a temporary that is then copied: an iovec records where it
+             * lives, and moving one to another address is what the trace
+             * build's canary exists to catch. */
+            if (gc->service == EVPL_RPC2_GSS_SVC_INTEGRITY) {
+                rc = evpl_rpc2_gss_wrap_call_integrity(evpl, gc, gss_seq,
+                                                       req_iov, req_niov,
+                                                       req_length,
+                                                       program->reserve,
+                                                       &gss_wrapped_iov,
+                                                       &wrapped_len);
+            } else {
+                rc = evpl_rpc2_gss_wrap_call_privacy(evpl, gc, gss_seq,
+                                                     req_iov, req_niov,
+                                                     req_length,
+                                                     program->reserve,
+                                                     &gss_wrapped_iov,
+                                                     &wrapped_len);
+            }
+
+            if (rc) {
+                evpl_rpc2_debug("rpcsec_gss: could not wrap call arguments "
+                                "for service %u", gc->service);
+                evpl_rpc2_request_free(thread, request);
+                return -1;
+            }
+
+            req_iov    = &gss_wrapped_iov;
+            req_niov   = 1;
+            req_length = wrapped_len;
+            pay_length = wrapped_len - program->reserve;
+        }
+
+        rpc_msg.body.cbody.cred.flavor          = RPCSEC_GSS;
+        rpc_msg.body.cbody.cred.rpcsec_gss.data = gss_cred_buf;
+        rpc_msg.body.cbody.cred.rpcsec_gss.len  = gss_cred_len;
+        rpc_msg.body.cbody.verf.flavor          = RPCSEC_GSS;
+    } else if (gss_init_client) {
+        memcpy(gss_cred_buf, gss_init_cred, gss_init_cred_len);
+        gss_cred_len = gss_init_cred_len;
+        /* A context-establishment leg.  The credential names the procedure
+        * (INIT / CONTINUE_INIT / DESTROY) and the handle so far; there is no
+        * verifier yet, because there is not yet a context to sign with. */
+        rpc_msg.body.cbody.cred.flavor          = RPCSEC_GSS;
+        rpc_msg.body.cbody.cred.rpcsec_gss.data = gss_cred_buf;
+        rpc_msg.body.cbody.cred.rpcsec_gss.len  = gss_cred_len;
     } else {
         rpc_msg.body.cbody.cred.flavor = AUTH_NONE;
     }
+
+    /*
+     * The call verifier is a MIC over the header from the xid through the
+     * credential -- everything the acceptor must be able to trust, and
+     * nothing that follows it.  The signed prefix does not depend on the
+     * verifier, so it can be computed before the verifier exists: marshal to
+     * learn the bytes, sign them, then marshal again with the real verifier
+     * in place.  Two passes over a header of a few dozen bytes.
+     */
+    if (gss_client && gss_client->provider->get_mic) {
+        struct evpl_iovec probe_iov;
+        uint32_t          signed_len = 24 + 8 + evpl_rpc2_gss_pad4(gss_cred_len);
+        void             *mic        = NULL;
+        size_t            mic_len    = 0;
+
+        struct evpl_iovec probe_out;
+        int               probe_niov = 1;
+        int               rc;
+
+        if (evpl_iovec_alloc(evpl, signed_len + 512, 8, 1, 0, &probe_iov) != 1) {
+            evpl_rpc2_request_free(thread, request);
+            return -1;
+        }
+
+        /* Marshal with an AUTH_NONE verifier: the signed prefix ends at the
+         * credential, so the verifier's own encoding cannot affect it, and
+         * leaving the RPCSEC_GSS verifier fields unset here would hand the
+         * marshaller a length it never assigned. */
+        rpc_msg.body.cbody.verf.flavor = AUTH_NONE;
+
+        marshall_rpc_msg(&rpc_msg, &probe_iov, &probe_out, &probe_niov,
+                         NULL, 0);
+
+        rc = gss_client->provider->get_mic(gss_client->provider_arg,
+                                           gss_client->gss_ctx,
+                                           probe_out.data, signed_len,
+                                           &mic, &mic_len);
+
+        /* Both halves are ours: probe_out is the marshaller's view of what it
+         * wrote, probe_iov the buffer it wrote into.  On the send path the
+         * latter reference is spent by evpl_sendv, but these bytes never go
+         * anywhere -- they exist only to be signed. */
+        evpl_iovec_release_internal(evpl, &probe_out);
+        evpl_iovec_release_internal(evpl, &probe_iov);
+
+        if (rc) {
+            evpl_rpc2_request_free(thread, request);
+            return -1;
+        }
+
+        if (mic_len > sizeof(gss_verf_buf)) {
+            free(mic);
+            evpl_rpc2_request_free(thread, request);
+            return -1;
+        }
+
+        memcpy(gss_verf_buf, mic, mic_len);
+        free(mic);
+
+        rpc_msg.body.cbody.verf.flavor          = RPCSEC_GSS;
+        rpc_msg.body.cbody.verf.rpcsec_gss.data = gss_verf_buf;
+        rpc_msg.body.cbody.verf.rpcsec_gss.len  = (uint32_t) mic_len;
+    }
+
+    /* Recorded here rather than with the rest of the request fields: the
+     * credential branch above is what decides whether this call travels under
+     * a context at all, and copying the pointer before that ran would leave
+     * every reply looking unwrapped. */
+    request->gss_client     = gss_client;
+    request->gss_client_seq = gss_seq;
 
     rpc_len = marshall_length_rpc_msg(&rpc_msg);
 

--- a/src/rpc2/tests/CMakeLists.txt
+++ b/src/rpc2/tests/CMakeLists.txt
@@ -66,6 +66,32 @@ macro(unit_test_rpc2_instance test_name protocol port)
     endforeach()
 endmacro()
 
+# As unit_test_rpc2_instance, but the instance carries extra arguments and so
+# needs a name of its own -- one binary driven several ways, where a bare
+# per-protocol name would collide.
+macro(unit_test_rpc2_instance_args inst_name protocol port bin_name)
+    foreach(mech ${EVPL_MECHANISMS})
+        set(_test libevpl/rpc2/${inst_name}_${protocol}_${mech})
+
+        if(LIBEVPL_NETNS_TESTING)
+            add_test(NAME ${_test}
+                     COMMAND ${LIBEVPL_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                             ${RPC2_TEST_EXE_${bin_name}} -r ${protocol}
+                             -p ${port} ${ARGN})
+        else()
+            add_test(NAME ${_test}
+                     COMMAND ${RPC2_TEST_EXE_${bin_name}} -r ${protocol}
+                             -p ${port} ${ARGN})
+        endif()
+
+        set_tests_properties(${_test} PROPERTIES
+            SKIP_RETURN_CODE 77
+            RESOURCE_LOCK evpl_net
+            ENVIRONMENT "TEST_FILE=${RPC2_TEST_SRC_${bin_name}};EVPL_TEST_CORE_MECH=${mech}"
+            TIMEOUT 30)
+    endforeach()
+endmacro()
+
 # As unit_test_rpc2_instance, but for a transport that names its peer rather
 # than addressing it -- AF_UNIX or inproc.  Neither contends for a port, so
 # neither needs a network namespace or the shared "evpl_net" lock, and both run
@@ -136,6 +162,19 @@ unit_test_rpc2(rdma_ddp rdma_ddp.x rdma_ddp.c)
 unit_test_rpc2(multifrag hello_world.x multifrag.c)
 unit_test_rpc2(client_xid hello_world.x client_xid.c)
 
+# Client-side RPCSEC_GSS.  Needs a real mechanism -- the whole point is that
+# the initiator and the acceptor are not the same few lines of test code -- so
+# it is registered only where krb5 is available, and skips (77) at runtime if
+# the library is present but cannot mint a ticket.
+if(KRB5_GSSAPI_FOUND)
+    unit_test_rpc2(client_gss hello_world.x client_gss.c krb5_local.c)
+    target_include_directories(evpl_rpc2_client_gss PRIVATE
+                               ${KRB5_GSSAPI_INCLUDE_DIRS})
+    target_link_directories(evpl_rpc2_client_gss PRIVATE
+                            ${KRB5_GSSAPI_LIBRARY_DIRS})
+    target_link_libraries(evpl_rpc2_client_gss ${KRB5_GSSAPI_LIBRARIES})
+endif()
+
 # Add test instances for STREAM_SOCKET_TCP
 unit_test_rpc2_instance(hello_world STREAM_SOCKET_TCP 8100)
 unit_test_rpc2_instance(builtin_bool STREAM_SOCKET_TCP 8101)
@@ -143,6 +182,17 @@ unit_test_rpc2_instance(rdma_ddp STREAM_SOCKET_TCP 8102)
 # multifrag is TCP-only: RDMA bypasses rpc2_segment_callback entirely.
 unit_test_rpc2_instance(multifrag STREAM_SOCKET_TCP 8103)
 unit_test_rpc2_instance(client_xid STREAM_SOCKET_TCP 8104)
+
+# One instance per service: the credential and verifier are common to all
+# three, but what rides on top of them is not, so a failure should name which.
+if(KRB5_GSSAPI_FOUND)
+    unit_test_rpc2_instance_args(client_gss_none STREAM_SOCKET_TCP 8210
+                                 client_gss -s none)
+    unit_test_rpc2_instance_args(client_gss_integrity STREAM_SOCKET_TCP 8211
+                                 client_gss -s integrity)
+    unit_test_rpc2_instance_args(client_gss_privacy STREAM_SOCKET_TCP 8212
+                                 client_gss -s privacy)
+endif()
 
 # Add test instances for DATAGRAM_TCP_RDMA
 unit_test_rpc2_instance(hello_world DATAGRAM_TCP_RDMA 8200)

--- a/src/rpc2/tests/CMakeLists.txt
+++ b/src/rpc2/tests/CMakeLists.txt
@@ -375,7 +375,22 @@ if(QUINT_EXECUTABLE AND PYTHON3_EXECUTABLE)
 
     add_custom_target(client_cases DEPENDS ${CLIENT_CASES})
 
-    unit_test_rpc2(conformance_client hello_world.x conformance_client.c)
+    # krb5_local supplies the acceptor half for the protected reply cases; the
+    # _none variant lets the same source compile and self-skip them where
+    # kerberos is absent.
+    if(KRB5_GSSAPI_FOUND)
+        unit_test_rpc2(conformance_client hello_world.x conformance_client.c
+                       krb5_local.c)
+        target_include_directories(evpl_rpc2_conformance_client PRIVATE
+                                   ${KRB5_GSSAPI_INCLUDE_DIRS})
+        target_link_directories(evpl_rpc2_conformance_client PRIVATE
+                                ${KRB5_GSSAPI_LIBRARY_DIRS})
+        target_link_libraries(evpl_rpc2_conformance_client
+                              ${KRB5_GSSAPI_LIBRARIES})
+    else()
+        unit_test_rpc2(conformance_client hello_world.x conformance_client.c
+                       krb5_local_none.c)
+    endif()
     target_sources(evpl_rpc2_conformance_client PRIVATE ${CLIENT_CASES})
     target_include_directories(evpl_rpc2_conformance_client
                                PRIVATE ${QUINT_WORK_DIR})

--- a/src/rpc2/tests/client_gss.c
+++ b/src/rpc2/tests/client_gss.c
@@ -1,0 +1,320 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Client-side RPCSEC_GSS: establish a context and make a call under it.
+ *
+ * Everything else in this suite exercises the acceptor -- the conformance
+ * driver hand-builds GSS calls on a raw socket precisely because rpc2 could
+ * not make them.  This drives the initiator instead, through the ordinary
+ * generated client stub, so what it proves is that a caller can ask for
+ * RPCSEC_GSS and have the library do the rest: the NULLPROC handshake, the
+ * credential and sequence number on every call, and the verifier binding them
+ * to the message.
+ *
+ * Both ends run in this process over the same evpl, which is what makes the
+ * test hermetic: the acceptor is libevpl's own, the mechanism is real MIT
+ * Kerberos with a ticket minted in-process (see krb5_local.c), and no KDC,
+ * realm or keytab file exists anywhere.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_rpc2.h"
+#include "evpl/evpl_rpc2_gss.h"
+
+#include "core/test_log.h"
+#include "test_common.h"
+
+#include "krb5_local.h"
+#include "hello_world_xdr.h"
+
+static enum evpl_protocol_id proto = EVPL_STREAM_SOCKET_TCP;
+static int                   port  = 8000;
+
+struct test_state {
+    struct HELLO_V1             *prog;
+    struct evpl                 *evpl;
+    struct evpl_rpc2_conn       *conn;
+    struct evpl_rpc2_gss_client *gss;
+    uint32_t                     service;
+    int                          server_saw_gss;
+    int                          complete;
+    int                          passed;
+    int                          after_destroy_fired;
+};
+
+static void
+server_recv_greet(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct Hello              *call,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct test_state *state = private_data;
+    struct Hello       reply;
+
+    /*
+     * The point of the test: the acceptor must see an authenticated
+     * RPCSEC_GSS caller, not AUTH_NONE.  A client that quietly fell back
+     * would still get its echo, so checking the credential here is what makes
+     * the difference observable.
+     */
+    if (cred && cred->flavor == EVPL_RPC2_AUTH_RPCSEC_GSS) {
+        state->server_saw_gss = 1;
+        evpl_test_info("server: call authenticated as '%s', service %u",
+                       cred->gss.principal ? cred->gss.principal : "(none)",
+                       cred->gss.service);
+        evpl_test_abort_if(cred->gss.service != state->service,
+                           "server saw service %u, client asked for %u",
+                           cred->gss.service, state->service);
+    } else {
+        evpl_test_error("server: call was NOT RPCSEC_GSS (flavor %u)",
+                        cred ? cred->flavor : 0);
+    }
+
+    reply.id = 100;
+    xdr_set_str_static(&reply, greeting, "sealed hello", strlen("sealed hello"));
+
+    evpl_test_abort_if(state->prog->send_reply_GREET(evpl, NULL, &reply,
+                                                     encoding),
+                       "server: failed to send reply");
+} /* server_recv_greet */
+
+static void
+client_recv_reply(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct Hello                *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct test_state *state = private_data;
+
+    if (status) {
+        evpl_test_error("client: call failed, status %d", status);
+        state->complete = 1;
+        return;
+    }
+
+    evpl_test_abort_if(reply->id != 100, "reply id %u", reply->id);
+
+    state->passed   = state->server_saw_gss;
+    state->complete = 1;
+} /* client_recv_reply */
+
+/*
+ * The second phase's completion.  What it reports is not interesting -- the
+ * context it travelled under is gone by the time the reply lands, so an
+ * unprotected reply to a context that no longer exists is the honest answer
+ * either way.  What matters is that the call completes at all rather than
+ * dereferencing the context that was freed underneath it.
+ */
+static void
+client_recv_after_destroy(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct Hello                *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct test_state *state = private_data;
+
+    evpl_test_info("client: in-flight call completed with status %d after the "
+                   "context was retired", status);
+
+    state->after_destroy_fired = 1;
+} /* client_recv_after_destroy */
+
+/* The context is ready (or was refused); either way the test moves on. */
+static void
+gss_ready(
+    struct evpl_rpc2_gss_client *client,
+    int                          status,
+    void                        *private_data)
+{
+    struct test_state    *state = private_data;
+    struct evpl_rpc2_cred cred;
+    struct Hello          request;
+
+    if (status || !client) {
+        evpl_test_error("client: context establishment failed");
+        state->complete = 1;
+        return;
+    }
+
+    evpl_test_info("client: context established");
+    state->gss = client;
+
+    memset(&cred, 0, sizeof(cred));
+    cred.flavor      = EVPL_RPC2_AUTH_RPCSEC_GSS;
+    cred.gss.service = state->service;
+    cred.gss.client  = client;
+
+    request.id = 42;
+    xdr_set_str_static(&request, greeting, "hello", strlen("hello"));
+
+    state->prog->send_call_GREET(&state->prog->rpc2, state->evpl, state->conn,
+                                 &cred, &request, 0, 0, NULL, 0, 0,
+                                 client_recv_reply, state);
+} /* gss_ready */
+
+static void
+usage(const char *p)
+{
+    fprintf(stderr, "usage: %s [-r proto] [-p port] [-s none|integrity|privacy]\n", p);
+    exit(1);
+} /* usage */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct evpl              *evpl;
+    struct evpl_rpc2_thread  *thread;
+    struct evpl_rpc2_server  *server;
+    struct evpl_endpoint     *endpoint;
+    struct HELLO_V1           prog;
+    struct evpl_rpc2_program *programs[1];
+    struct test_state         state = { 0 };
+    struct krb5_local        *kl;
+    const char               *why = NULL;
+    int                       opt;
+
+    state.service = EVPL_RPC2_GSS_SVC_NONE;
+
+    /* Before getopt, not after: evpl_protocol_lookup() brings the shared state
+    * up on its own, and a configuration handed over after that is too late. */
+    test_evpl_config();
+
+    while ((opt = getopt(argc, argv, "r:p:s:")) != -1) {
+        switch (opt) {
+            case 'r':
+                if (evpl_protocol_lookup(&proto, optarg)) {
+                    fprintf(stderr, "unknown protocol '%s'\n", optarg);
+                    return 1;
+                }
+                break;
+            case 'p':
+                port = atoi(optarg);
+                break;
+            case 's':
+                if (!strcmp(optarg, "none")) {
+                    state.service = EVPL_RPC2_GSS_SVC_NONE;
+                } else if (!strcmp(optarg, "integrity")) {
+                    state.service = EVPL_RPC2_GSS_SVC_INTEGRITY;
+                } else if (!strcmp(optarg, "privacy")) {
+                    state.service = EVPL_RPC2_GSS_SVC_PRIVACY;
+                } else {
+                    usage(argv[0]);
+                }
+                break;
+            default:
+                usage(argv[0]);
+        } /* switch */
+    }
+
+    kl = krb5_local_create(&why);
+    if (!kl) {
+        /* No usable Kerberos on this host: skip rather than fail, matching how
+         * the conformance suite treats the same absence. */
+        evpl_test_info("skipping: %s", why ? why : "krb5 unavailable");
+        return 77;
+    }
+
+    evpl = evpl_create(NULL);
+
+    HELLO_V1_init(&prog);
+    prog.recv_call_GREET = server_recv_greet;
+    programs[0]          = &prog.rpc2;
+    state.prog           = &prog;
+    state.evpl           = evpl;
+
+    server   = evpl_rpc2_server_init(programs, 1);
+    endpoint = evpl_endpoint_create(test_address(proto, "0.0.0.0", argv[0]), port);
+
+    evpl_rpc2_server_start(server, proto, endpoint);
+
+    thread = evpl_rpc2_thread_init(evpl, programs, 1, NULL, NULL);
+
+    /* The acceptor half: the same mechanism, so both ends of the handshake
+     * are real even though neither leaves the process. */
+    evpl_rpc2_set_gss_provider(thread, krb5_local_provider(),
+                               krb5_local_arg(kl));
+
+    evpl_rpc2_server_attach(thread, server, &state);
+
+    state.conn = evpl_rpc2_client_connect(thread, proto, endpoint, NULL, 0, NULL);
+    evpl_test_abort_if(!state.conn, "client connect failed");
+
+    evpl_rpc2_gss_client_create(evpl, &prog.rpc2, state.conn,
+                                krb5_local_initiator_provider(), kl,
+                                state.service, "hello@localhost",
+                                gss_ready, &state);
+
+    while (!state.complete) {
+        evpl_continue(evpl);
+    }
+
+    /*
+     * Retiring a context with a call still outstanding.  A caller is entitled
+     * to do this -- and evpl_rpc2_gss_client_destroy's own DESTROY is itself
+     * such a call -- so the reply path must not be left holding a pointer to
+     * the freed context.  Nothing here waits for the reply: the call is put on
+     * the wire and the context pulled out from under it deliberately.
+     */
+    if (state.gss) {
+        struct evpl_rpc2_cred cred;
+        struct Hello          request;
+
+        memset(&cred, 0, sizeof(cred));
+        cred.flavor      = EVPL_RPC2_AUTH_RPCSEC_GSS;
+        cred.gss.service = state.service;
+        cred.gss.client  = state.gss;
+
+        request.id = 43;
+        xdr_set_str_static(&request, greeting, "bye", strlen("bye"));
+
+        prog.send_call_GREET(&prog.rpc2, evpl, state.conn, &cred,
+                             &request, 0, 0, NULL, 0, 0,
+                             client_recv_after_destroy, &state);
+
+        evpl_rpc2_gss_client_destroy(evpl, state.gss);
+        state.gss = NULL;
+
+        for (int i = 0; i < 20 && !state.after_destroy_fired; i++) {
+            evpl_continue(evpl);
+        }
+
+        if (!state.after_destroy_fired) {
+            evpl_test_error("the call outstanding across the retirement was "
+                            "never completed");
+            state.passed = 0;
+        }
+    }
+
+    evpl_rpc2_server_stop(server);
+    evpl_rpc2_client_disconnect(thread, state.conn);
+    evpl_rpc2_server_detach(thread, server);
+    evpl_rpc2_thread_destroy(thread);
+    evpl_rpc2_server_destroy(server);
+    krb5_local_destroy(kl);
+    evpl_destroy(evpl);
+
+    if (!state.passed) {
+        evpl_test_error("client GSS call did not complete authenticated");
+        return 1;
+    }
+
+    evpl_test_info("client GSS (service %u) OK", state.service);
+    return 0;
+} /* main */

--- a/src/rpc2/tests/conformance_client.c
+++ b/src/rpc2/tests/conformance_client.c
@@ -81,6 +81,9 @@ raw_socket_prepare(int fd)
 
 #include "evpl/evpl.h"
 #include "evpl/evpl_rpc2.h"
+#include "evpl/evpl_rpc2_gss.h"
+
+#include "krb5_local.h"
 
 #include "core/test_log.h"
 #include "test_common.h"
@@ -103,6 +106,7 @@ static int port = 8000;
 #define RPC_AUTH_BADCRED    1
 #define RPC_AUTH_NONE       0
 #define RPC_AUTH_SYS        1
+#define RPC_RPCSEC_GSS      6
 
 /* hello_world.x, which this test reuses unmodified. */
 #define HELLO_PROG          42
@@ -203,6 +207,18 @@ defect_name(int d)
         case CDEF_REPLYGARBAGEBODY:          return "ReplyGarbageBody";
         case CDEF_REPLYSTRINGLENOVERFLOW:    return "ReplyStringLenOverflow";
         case CDEF_REPLYSTRINGLENBEYONDMESSAGE: return "ReplyStringLenBeyondMessage";
+        case CDEF_GSSINTEGREPLYVALID:        return "GssIntegReplyValid";
+        case CDEF_GSSPRIVREPLYVALID:         return "GssPrivReplyValid";
+        case CDEF_GSSINTEGREPLYCHECKSUMBAD:  return "GssIntegReplyChecksumBad";
+        case CDEF_GSSPRIVREPLYSEALCORRUPT:   return "GssPrivReplySealCorrupt";
+        case CDEF_GSSINTEGREPLYSEQMISMATCH:  return "GssIntegReplySeqMismatch";
+        case CDEF_GSSPRIVREPLYSEQMISMATCH:   return "GssPrivReplySeqMismatch";
+        case CDEF_GSSINTEGREPLYLENGTHBEYONDMESSAGE:
+            return "GssIntegReplyLengthBeyondMessage";
+        case CDEF_GSSINTEGREPLYCHECKSUMMISSING:
+            return "GssIntegReplyChecksumMissing";
+        case CDEF_GSSINTEGREPLYUNPROTECTED:  return "GssIntegReplyUnprotected";
+        case CDEF_GSSPRIVREPLYUNPROTECTED:   return "GssPrivReplyUnprotected";
         default:                             return "?";
     } /* switch */
 } /* defect_name */
@@ -805,6 +821,58 @@ read_exact(
     return READ_OK;
 } /* read_exact */
 
+/* rpc_gss_proc_t (RFC 2203 sec 5.1) */
+#define GSS_PROC_DATA          0
+#define GSS_PROC_INIT          1
+#define GSS_PROC_CONTINUE_INIT 2
+#define GSS_PROC_DESTROY       3
+
+static int
+deliver(
+    struct evpl              *evpl,
+    const struct client_case *c,
+    const struct wirebuf     *msg);
+
+/*
+ * Whether this call is a context retirement.
+ *
+ *   header:  xid, mtype, rpcvers, prog, vers, proc   (24 bytes)
+ *   cred:    flavor, length, rpc_gss_cred_vers_1 { version, gss_proc, ... }
+ */
+static int
+call_is_gss_destroy(
+    const uint8_t *call,
+    uint32_t       len)
+{
+    uint32_t cred_len;
+
+    if (len < 32 + 8 || get32(call + 24) != RPC_RPCSEC_GSS) {
+        return 0;
+    }
+
+    cred_len = get32(call + 28);
+
+    if (cred_len < 8 || (uint64_t) 32 + cred_len > len) {
+        return 0;
+    }
+
+    return get32(call + 36) == GSS_PROC_DESTROY;
+} /* call_is_gss_destroy */
+
+static int
+answer_gss_destroy(
+    struct evpl *evpl,
+    uint32_t     xid)
+{
+    struct wirebuf     msg;
+    struct client_case one = { 0, CDLV_ONEWRITE, 0, 0, -1 };
+
+    msg.len = 0;
+    put_accepted_header(&msg, xid);
+
+    return deliver(evpl, &one, &msg);
+} /* answer_gss_destroy */
+
 /*
  * Read one record-marked message the client sent, returning only CALLs.
  *
@@ -844,6 +912,18 @@ read_call(
         }
 
         if (len >= 8 && get32(buf + 4) == RPC_CALL) {
+            /* A context being retired is not a call any case is waiting for.
+             * It is answered and skipped here for the same reason the client's
+             * own PROG_UNAVAIL replies are: whichever case happens to be
+             * reading when it arrives would otherwise mistake it for its own
+             * call and desync every case after it. */
+            if (call_is_gss_destroy(buf, len)) {
+                if (answer_gss_destroy(evpl, get32(buf))) {
+                    return READ_EOF;
+                }
+                continue;
+            }
+
             *out_len = len;
             *out_xid = get32(buf);
             return READ_OK;
@@ -1038,6 +1118,430 @@ probe_connection(struct evpl *evpl)
 
     return cs->fired == 1 && cs->status == 0 && cs->matched;
 } /* probe_connection */
+
+/* ------------------------------------------------------------------ *
+* RPCSEC_GSS replies: the harness as an acceptor
+*
+* Everything above is an unprotected call, so the client's GSS receive path --
+* the one that has to open a wrapped reply before its decoder ever sees
+* results -- is unreachable from here.  Reaching it means the hostile server
+* has to hold up its end of a real context: answer the client's
+* RPCSEC_GSS_INIT with an rpc_gss_init_res (RFC 2203 sec 5.2.3), then wrap
+* what it sends back the way the negotiated service requires.
+*
+* krb5_local's acceptor half is used unmodified, so the checksums the client
+* verifies are real ones from a real mechanism.  That is what makes a
+* deliberately corrupted checksum meaningful: it is corrupt relative to a
+* mechanism that would otherwise have accepted it, not relative to a stub
+* that was going to say yes regardless.
+* ------------------------------------------------------------------ */
+
+#define GSS_HANDLE_VALUE 0x5eed1234u
+#define GSS_SEQ_WINDOW   64
+
+static struct krb5_local                   *g_kl;
+static const struct evpl_rpc2_gss_provider *g_acc;
+static void                                *g_acc_ctx;
+static struct evpl_rpc2_gss_client         *g_gss;
+static int                                  g_gss_ready;
+static int                                  g_gss_failed;
+static int                                  g_gss_skipped;
+
+/* Which service each GSS defect is expressed under.  The wrapping is what the
+ * case is about, so the service is a property of the defect rather than a
+ * separate dimension: an unsealable token has no meaning under integrity. */
+static int
+gss_case_service(int defect)
+{
+    switch (defect) {
+        case CDEF_GSSINTEGREPLYVALID:
+        case CDEF_GSSINTEGREPLYCHECKSUMBAD:
+        case CDEF_GSSINTEGREPLYSEQMISMATCH:
+        case CDEF_GSSINTEGREPLYLENGTHBEYONDMESSAGE:
+        case CDEF_GSSINTEGREPLYCHECKSUMMISSING:
+        case CDEF_GSSINTEGREPLYUNPROTECTED:
+            return EVPL_RPC2_GSS_SVC_INTEGRITY;
+        case CDEF_GSSPRIVREPLYVALID:
+        case CDEF_GSSPRIVREPLYSEALCORRUPT:
+        case CDEF_GSSPRIVREPLYSEQMISMATCH:
+        case CDEF_GSSPRIVREPLYUNPROTECTED:
+            return EVPL_RPC2_GSS_SVC_PRIVACY;
+        default:
+            return -1;
+    } /* switch */
+} /* gss_case_service */
+
+static int
+is_gss_case(int defect)
+{
+    return gss_case_service(defect) >= 0;
+} /* is_gss_case */
+
+static void
+gss_ready_cb(
+    struct evpl_rpc2_gss_client *client,
+    int                          status,
+    void                        *arg)
+{
+    (void) arg;
+
+    if (status) {
+        g_gss_failed = 1;
+    } else {
+        g_gss       = client;
+        g_gss_ready = 1;
+    }
+} /* gss_ready_cb */
+
+/*
+ * Answer one leg of the client's context establishment.
+ *
+ * The call is NULLPROC with an RPCSEC_GSS credential naming the procedure;
+ * its argument is the initiator's token as a counted opaque.  The reply is
+ * MSG_ACCEPTED/SUCCESS whose results are the rpc_gss_init_res, and -- once the
+ * context is complete -- whose verifier is a MIC over the advertised
+ * seq_window (RFC 2203 sec 5.2.3.1).
+ *
+ */
+static int
+gss_answer_init_leg(
+    struct evpl   *evpl,
+    const uint8_t *call,
+    uint32_t       len,
+    uint32_t       xid,
+    int           *complete)
+{
+    struct wirebuf     msg;
+    struct client_case one = { 0, CDLV_ONEWRITE, 0, 0, -1 };
+    const uint8_t     *token;
+    void              *out_token = NULL;
+    void              *mic       = NULL;
+    size_t             out_len   = 0, mic_len = 0;
+    uint32_t           off, cred_len, verf_len, token_len, window_be;
+    char               principal[256];
+
+    /* xid, mtype, rpcvers, prog, vers, proc, then the two opaque_auths. */
+    off = 24;
+    if (len < off + 8) {
+        return -1;
+    }
+    cred_len = get32(call + off + 4);
+
+    if (cred_len < 16 || (uint64_t) off + 8 + cred_len > len) {
+        return -1;
+    }
+
+    off += 8 + ((cred_len + 3) & ~3u);
+
+    if (len < off + 8) {
+        return -1;
+    }
+    verf_len = get32(call + off + 4);
+    off     += 8 + ((verf_len + 3) & ~3u);
+
+    if (len < off + 4) {
+        return -1;
+    }
+    token_len = get32(call + off);
+    token     = call + off + 4;
+
+    if ((uint64_t) off + 4 + token_len > len) {
+        return -1;
+    }
+
+    if (g_acc->accept(krb5_local_arg(g_kl), &g_acc_ctx, token, token_len,
+                      &out_token, &out_len, complete,
+                      principal, sizeof(principal))) {
+        return -1;
+    }
+
+    msg.len = 0;
+    put32(&msg, xid);
+    put32(&msg, RPC_REPLY);
+    put32(&msg, RPC_MSG_ACCEPTED);
+
+    window_be = htonl(GSS_SEQ_WINDOW);
+
+    if (*complete &&
+        g_acc->get_mic(krb5_local_arg(g_kl), g_acc_ctx, &window_be,
+                       sizeof(window_be), &mic, &mic_len) == 0) {
+        put32(&msg, RPC_RPCSEC_GSS);
+        put32(&msg, (uint32_t) mic_len);
+        put_bytes(&msg, mic, (uint32_t) mic_len);
+        free(mic);
+    } else {
+        put32(&msg, RPC_AUTH_NONE);
+        put32(&msg, 0);
+    }
+
+    put32(&msg, RPC_SUCCESS);
+
+    /* rpc_gss_init_res: handle, major, minor, seq_window, token. */
+    put32(&msg, 4);
+    put32(&msg, GSS_HANDLE_VALUE);
+    put32(&msg, *complete ? 0 /* GSS_S_COMPLETE */ : 1 /* CONTINUE_NEEDED */);
+    put32(&msg, 0);
+    put32(&msg, GSS_SEQ_WINDOW);
+    put32(&msg, (uint32_t) out_len);
+    if (out_len) {
+        put_bytes(&msg, out_token, (uint32_t) out_len);
+    }
+
+    free(out_token);
+
+    return deliver(evpl, &one, &msg);
+} /* gss_answer_init_leg */
+
+/* Bring up a context on the current connection under `service`, playing the
+ * acceptor by hand.  Returns 0 once the client reports it established. */
+static int
+gss_establish(
+    struct evpl *evpl,
+    uint32_t     service)
+{
+    uint8_t  buf[4096];
+    uint32_t len, xid;
+    int      complete = 0, guard;
+
+    g_gss_ready  = 0;
+    g_gss_failed = 0;
+    g_acc_ctx    = NULL;
+
+    evpl_rpc2_gss_client_create(evpl, &g_prog.rpc2, g_conn,
+                                krb5_local_initiator_provider(),
+                                krb5_local_arg(g_kl), service,
+                                "conformance@localhost", gss_ready_cb, NULL);
+
+    for (guard = 0; guard < 8 && !g_gss_ready && !g_gss_failed; guard++) {
+        if (read_call(evpl, buf, sizeof(buf), &len, &xid) != READ_OK) {
+            return -1;
+        }
+
+        if (gss_answer_init_leg(evpl, buf, len, xid, &complete)) {
+            return -1;
+        }
+
+        evpl_continue(evpl);
+        evpl_continue(evpl);
+    }
+
+    return g_gss_ready ? 0 : -1;
+} /* gss_establish */
+
+static void
+gss_release(struct evpl *evpl)
+{
+    if (g_gss) {
+        evpl_rpc2_gss_client_destroy(evpl, g_gss);
+        g_gss = NULL;
+    }
+
+    if (g_acc_ctx) {
+        g_acc->destroy(krb5_local_arg(g_kl), g_acc_ctx);
+        g_acc_ctx = NULL;
+    }
+} /* gss_release */
+
+/*
+ * The sequence number the client put in the credential of the call it just
+ * sent.  The reply has to echo it (RFC 2203 sec 5.3.3.2), and it is chosen by
+ * the client, so it is read back off the wire rather than assumed.
+ *
+ *   rpc_gss_cred_vers_1: version, gss_proc, seq_num, service, handle<>
+ */
+static int
+gss_call_seq(
+    const uint8_t *call,
+    uint32_t       len,
+    uint32_t      *out_seq)
+{
+    uint32_t cred_len;
+
+    if (len < 24 + 8) {
+        return -1;
+    }
+
+    cred_len = get32(call + 28);
+
+    if (cred_len < 16 || (uint64_t) 32 + cred_len > len) {
+        return -1;
+    }
+
+    *out_seq = get32(call + 32 + 8);
+    return 0;
+} /* gss_call_seq */
+
+/*
+ * Build the reply body for a GSS case.
+ *
+ * Both services put a counted blob first: under integrity it is the plaintext
+ * rpc_gss_data_t (seq_num followed by the results) with a checksum after it,
+ * and under privacy it is that same plaintext sealed into a single token.
+ * Every defect here is a deliberate deviation from one of those two shapes.
+ */
+static int
+build_gss_reply(
+    struct wirebuf           *b,
+    const struct client_case *c,
+    uint32_t                  xid,
+    uint32_t                  seq)
+{
+    struct wirebuf plain;
+    uint8_t        sealed[2048];
+    void          *mic = NULL;
+    size_t         mic_len = 0, sealed_len = 0;
+    uint32_t       echoed = seq;
+    uint32_t       seq_be;
+
+    if (c->defect == CDEF_GSSINTEGREPLYSEQMISMATCH ||
+        c->defect == CDEF_GSSPRIVREPLYSEQMISMATCH) {
+        echoed = seq + 1;
+    }
+
+    /* rpc_gss_data_t, the plaintext both services are built around. */
+    plain.len = 0;
+    put32(&plain, echoed);
+    put_hello(&plain);
+
+    b->len = 0;
+    put32(b, xid);
+    put32(b, RPC_REPLY);
+    put32(b, RPC_MSG_ACCEPTED);
+
+    /* The reply verifier under an established context is a MIC over the
+     * sequence number of the call being answered. */
+    seq_be = htonl(seq);
+
+    if (g_acc->get_mic(krb5_local_arg(g_kl), g_acc_ctx, &seq_be, sizeof(seq_be),
+                       &mic, &mic_len) == 0) {
+        put32(b, RPC_RPCSEC_GSS);
+        put32(b, (uint32_t) mic_len);
+        put_bytes(b, mic, (uint32_t) mic_len);
+        free(mic);
+        mic = NULL;
+    } else {
+        put32(b, RPC_AUTH_NONE);
+        put32(b, 0);
+    }
+
+    put32(b, RPC_SUCCESS);
+
+    /* The peer that simply left the protection off: results in the clear
+     * where the service requires them wrapped. */
+    if (c->defect == CDEF_GSSINTEGREPLYUNPROTECTED ||
+        c->defect == CDEF_GSSPRIVREPLYUNPROTECTED) {
+        put_hello(b);
+        return 0;
+    }
+
+    if (gss_case_service(c->defect) == EVPL_RPC2_GSS_SVC_PRIVACY) {
+        if (g_acc->wrap(krb5_local_arg(g_kl), g_acc_ctx, plain.data, plain.len,
+                        sealed, sizeof(sealed), &sealed_len)) {
+            return -1;
+        }
+
+        put32(b, (uint32_t) sealed_len);
+
+        if (c->defect == CDEF_GSSPRIVREPLYSEALCORRUPT) {
+            /* The last byte of the token, so the damage is inside the sealed
+             * region for any wrap-token layout rather than in a header field
+             * that a length check might reject first. */
+            sealed[sealed_len - 1] ^= 0xff;
+        }
+
+        put_bytes(b, sealed, (uint32_t) sealed_len);
+        return 0;
+    }
+
+    /* Integrity: databody_integ, then its checksum. */
+    if (c->defect == CDEF_GSSINTEGREPLYLENGTHBEYONDMESSAGE) {
+        /* A length that runs past the end of the record.  Nothing after it is
+         * reachable, so no checksum is appended: the point is whether the
+         * client trusts the length before it checks it. */
+        put32(b, plain.len + 4096);
+        put_bytes(b, plain.data, plain.len);
+        return 0;
+    }
+
+    put32(b, plain.len);
+    put_bytes(b, plain.data, plain.len);
+
+    if (c->defect == CDEF_GSSINTEGREPLYCHECKSUMMISSING) {
+        return 0;
+    }
+
+    if (g_acc->get_mic(krb5_local_arg(g_kl), g_acc_ctx, plain.data, plain.len,
+                       &mic, &mic_len)) {
+        return -1;
+    }
+
+    put32(b, (uint32_t) mic_len);
+
+    if (c->defect == CDEF_GSSINTEGREPLYCHECKSUMBAD) {
+        ((uint8_t *) mic)[mic_len - 1] ^= 0xff;
+    }
+
+    put_bytes(b, mic, (uint32_t) mic_len);
+    free(mic);
+
+    return 0;
+} /* build_gss_reply */
+
+/*
+ * One GSS case: stand a context up on a fresh connection, make the call under
+ * it, and answer with the bytes the case calls for.
+ *
+ * The context is rebuilt per case rather than shared.  A case that leaves the
+ * client's replay window or its sequence counter in an unexpected state would
+ * otherwise change the meaning of every case after it, and the failure would
+ * be attributed to the wrong one.
+ */
+static int
+run_gss_case(
+    struct evpl              *evpl,
+    const struct client_case *c,
+    struct call_state        *cs)
+{
+    struct evpl_rpc2_cred cred;
+    struct wirebuf        msg;
+    uint8_t               buf[4096];
+    uint32_t              len, xid, seq;
+    int                   rc;
+
+    if (gss_establish(evpl, (uint32_t) gss_case_service(c->defect))) {
+        gss_release(evpl);
+        return -1;
+    }
+
+    memset(&cred, 0, sizeof(cred));
+    cred.flavor     = EVPL_RPC2_AUTH_RPCSEC_GSS;
+    cred.gss.client = g_gss;
+
+    issue_call_cred(evpl, cs, &cred);
+
+    rc = read_call(evpl, buf, sizeof(buf), &len, &xid);
+    evpl_test_abort_if(rc != READ_OK,
+                       "case %s: never saw the client's protected CALL (rc %d)",
+                       defect_name(c->defect), rc);
+
+    evpl_test_abort_if(gss_call_seq(buf, len, &seq),
+                       "case %s: could not read the sequence number out of the "
+                       "client's credential", defect_name(c->defect));
+
+    if (build_gss_reply(&msg, c, xid, seq)) {
+        gss_release(evpl);
+        return -1;
+    }
+
+    rc = deliver(evpl, c, &msg);
+    evpl_test_abort_if(rc, "case %s/%s: failed to write the reply",
+                       defect_name(c->defect), delivery_name(c->delivery));
+
+    pump_until_fired(evpl, cs);
+
+    gss_release(evpl);
+    return 0;
+} /* run_gss_case */
 
 /* ------------------------------------------------------------------ *
 * Outbound AUTH_SYS credentials (RFC 5531 Appendix A)
@@ -1274,6 +1778,28 @@ run_case(
         evpl_test_abort("failed to (re)connect the client under test");
     }
 
+    /* A protected case needs a context first, and a context needs a
+     * mechanism; where there is none the case is skipped rather than failed,
+     * the same way the krb5 instances of the server-side suite are. */
+    if (is_gss_case(c->defect)) {
+        if (!g_kl) {
+            g_gss_skipped++;
+            return;
+        }
+
+        g_results.run++;
+
+        if (run_gss_case(evpl, c, cs)) {
+            evpl_test_error("case %s/%s: the harness could not hold up its end "
+                            "of the context", defect_name(c->defect),
+                            delivery_name(c->delivery));
+            g_results.unknown++;
+            return;
+        }
+
+        goto classify;
+    }
+
     g_results.run++;
 
     issue_call(evpl, cs);
@@ -1313,6 +1839,8 @@ run_case(
     /* Classify what the client did.  Note the ordering: a second completion
      * outranks whatever the first one said, because no status can make
      * double-completing a call correct. */
+ classify:
+
     if (cs->fired > 1) {
         actual = ACT_DOUBLE_CALLBACK;
     } else if (cs->fired == 1) {
@@ -1391,7 +1919,8 @@ main(
     struct evpl               *evpl;
     struct evpl_rpc2_program  *programs[1];
     struct evpl_thread_config *tcfg;
-    enum evpl_protocol_id      proto = EVPL_STREAM_SOCKET_TCP;
+    enum evpl_protocol_id      proto    = EVPL_STREAM_SOCKET_TCP;
+    const char                *krb5_why = NULL;
     unsigned int               i;
     int                        opt, rc, failed;
 
@@ -1399,18 +1928,18 @@ main(
 
     while ((opt = getopt(argc, argv, "r:p:")) != -1) {
         switch (opt) {
-            case 'r':
-                rc = evpl_protocol_lookup(&proto, optarg);
-                if (rc) {
-                    fprintf(stderr, "Invalid protocol '%s'\n", optarg);
-                    return 1;
-                }
-                break;
-            case 'p':
-                port = atoi(optarg);
-                break;
-            default:
-                usage(argv[0]);
+                case 'r':
+                    rc = evpl_protocol_lookup(&proto, optarg);
+                    if (rc) {
+                        fprintf(stderr, "Invalid protocol '%s'\n", optarg);
+                        return 1;
+                    }
+                    break;
+                case 'p':
+                    port = atoi(optarg);
+                    break;
+                default:
+                    usage(argv[0]);
         } /* switch */
     }
 
@@ -1447,6 +1976,17 @@ main(
                                      NULL);
     g_endpoint = evpl_endpoint_create("127.0.0.1", port);
 
+    /* The mechanism for the protected cases.  Its absence is not a failure --
+     * the rest of the matrix does not need it -- so the GSS cases report as
+     * skipped and everything else runs unchanged. */
+    g_acc = krb5_local_provider();
+    g_kl  = krb5_local_create(&krb5_why);
+
+    if (!g_kl) {
+        evpl_test_info("no kerberos: the protected reply cases will be skipped "
+                       "(%s)", krb5_why ? krb5_why : "unavailable");
+    }
+
     /* Before the reply matrix, and on a connection nothing has abused yet:
      * these check what the client puts on the wire, so they need a case-free
      * connection more than they need a particular one. */
@@ -1466,6 +2006,11 @@ main(
 
     if (g_conn_alive) {
         evpl_rpc2_client_disconnect(g_thread, g_conn);
+    }
+
+    if (g_kl) {
+        krb5_local_destroy(g_kl);
+        g_kl = NULL;
     }
 
     if (g_peer_fd >= 0) {
@@ -1492,9 +2037,9 @@ main(
     printf("outbound credential cases: %d run, %d failed\n",
            g_cred_run, g_cred_failed);
     printf("client reply cases: %d run, %d matched spec, %d known divergences, "
-           "%d unexpected\n",
+           "%d unexpected, %d skipped (no kerberos)\n",
            g_results.run, g_results.matched, g_results.known,
-           g_results.unknown);
+           g_results.unknown, g_gss_skipped);
     printf("  matched by required outcome: %d callback-ok, %d decode-error, "
            "%d failed, %d dropped\n",
            g_results.matched_by_expect[CEXP_CBSUCCESS],

--- a/src/rpc2/tests/krb5_local.c
+++ b/src/rpc2/tests/krb5_local.c
@@ -883,12 +883,13 @@ krb5_local_p_init(
     size_t     *out_len,
     int        *complete)
 {
-    struct krb5_local *kl = arg;
-    OM_uint32          maj, min, flags;
-    gss_buffer_desc    in = GSS_C_EMPTY_BUFFER, tok = GSS_C_EMPTY_BUFFER;
-    gss_name_t         name = GSS_C_NO_NAME;
-    gss_buffer_desc    nb;
-    char               principal[256];
+    struct krb5_local     *kl = arg;
+    struct krb5_local_ctx *lc = *gss_ctx;
+    OM_uint32              maj, min, flags;
+    gss_buffer_desc        in = GSS_C_EMPTY_BUFFER, tok = GSS_C_EMPTY_BUFFER;
+    gss_name_t             name = GSS_C_NO_NAME;
+    gss_buffer_desc        nb;
+    char                   principal[256];
 
     (void) target;
 
@@ -908,19 +909,28 @@ krb5_local_p_init(
         return -1;
     }
 
-    if (!in_token) {
-        /* First leg: start clean, so a context left over from an earlier case
-         * cannot sign with a session key this handshake never agreed. */
-        if (kl->init_ctx != GSS_C_NO_CONTEXT) {
-            gss_delete_sec_context(&min, &kl->init_ctx, GSS_C_NO_BUFFER);
-            kl->init_ctx = GSS_C_NO_CONTEXT;
+    /* One context per handshake, not one per realm: a caller may hold several
+     * at once -- an NFS connection and a MOUNT connection, say -- and a shared
+     * context would leave the older of them signing with a session key its
+     * acceptor half never agreed to. */
+    if (!lc) {
+        lc = calloc(1, sizeof(*lc));
+
+        if (!lc) {
+            gss_release_name(&min, &name);
+            return -1;
         }
-    } else {
+
+        lc->ctx  = GSS_C_NO_CONTEXT;
+        *gss_ctx = lc;
+    }
+
+    if (in_token) {
         in.value  = (void *) in_token;
         in.length = in_len;
     }
 
-    maj = gss_init_sec_context(&min, kl->init_cred, &kl->init_ctx, name,
+    maj = gss_init_sec_context(&min, kl->init_cred, &lc->ctx, name,
                                GSS_C_NO_OID,
                                GSS_C_INTEG_FLAG | GSS_C_CONF_FLAG |
                                GSS_C_SEQUENCE_FLAG,
@@ -947,7 +957,6 @@ krb5_local_p_init(
     gss_release_buffer(&min, &tok);
 
     *complete = (maj == GSS_S_COMPLETE);
-    *gss_ctx  = kl;
 
     return 0;
 } /* krb5_local_p_init */
@@ -976,8 +985,25 @@ krb5_local_i_get_mic(
     void      **mic,
     size_t     *mic_len)
 {
+    struct krb5_local_ctx *lc = gss_ctx;
+    OM_uint32              maj, min;
+    gss_buffer_desc        in, out = GSS_C_EMPTY_BUFFER;
+    int                    rc;
+
     (void) arg;
-    return krb5_local_get_mic(gss_ctx, msg, msg_len, mic, mic_len);
+
+    in.value  = (void *) msg;
+    in.length = msg_len;
+
+    maj = gss_get_mic(&min, lc->ctx, GSS_C_QOP_DEFAULT, &in, &out);
+
+    if (GSS_ERROR(maj)) {
+        return -1;
+    }
+
+    rc = krb5_local_buf_out(&out, mic, mic_len);
+    gss_release_buffer(&min, &out);
+    return rc;
 } /* krb5_local_i_get_mic */
 
 static int
@@ -989,8 +1015,20 @@ krb5_local_i_verify_mic(
     const void *mic,
     size_t      mic_len)
 {
+    struct krb5_local_ctx *lc = gss_ctx;
+    OM_uint32              maj, min;
+    gss_buffer_desc        in, tok;
+
     (void) arg;
-    return krb5_local_verify_mic(gss_ctx, msg, msg_len, mic, mic_len);
+
+    in.value   = (void *) msg;
+    in.length  = msg_len;
+    tok.value  = (void *) mic;
+    tok.length = mic_len;
+
+    maj = gss_verify_mic(&min, lc->ctx, &in, &tok, NULL);
+
+    return GSS_ERROR(maj) ? -1 : 0;
 } /* krb5_local_i_verify_mic */
 
 static int
@@ -1003,23 +1041,30 @@ krb5_local_i_wrap(
     size_t      out_cap,
     size_t     *r_out_len)
 {
-    void  *tok;
-    size_t tl;
+    struct krb5_local_ctx *lc = gss_ctx;
+    OM_uint32              maj, min;
+    gss_buffer_desc        ib, ob = GSS_C_EMPTY_BUFFER;
+    int                    conf;
 
     (void) arg;
 
-    if (krb5_local_wrap(gss_ctx, in, in_len, &tok, &tl)) {
+    ib.value  = (void *) in;
+    ib.length = in_len;
+
+    maj = gss_wrap(&min, lc->ctx, 1, GSS_C_QOP_DEFAULT, &ib, &conf, &ob);
+
+    if (GSS_ERROR(maj)) {
         return -1;
     }
 
-    if (tl > out_cap) {
-        free(tok);
+    if (ob.length > out_cap) {
+        gss_release_buffer(&min, &ob);
         return -1;
     }
 
-    memcpy(out, tok, tl);
-    *r_out_len = tl;
-    free(tok);
+    memcpy(out, ob.value, ob.length);
+    *r_out_len = ob.length;
+    gss_release_buffer(&min, &ob);
     return 0;
 } /* krb5_local_i_wrap */
 
@@ -1033,23 +1078,31 @@ krb5_local_i_unwrap(
     size_t      out_cap,
     size_t     *r_out_len)
 {
-    void  *plain;
-    size_t pl;
+    struct krb5_local_ctx *lc = gss_ctx;
+    OM_uint32              maj, min;
+    gss_buffer_desc        ib, ob = GSS_C_EMPTY_BUFFER;
+    int                    conf;
+    gss_qop_t              qop;
 
     (void) arg;
 
-    if (krb5_local_unwrap(gss_ctx, in, in_len, &plain, &pl)) {
+    ib.value  = (void *) in;
+    ib.length = in_len;
+
+    maj = gss_unwrap(&min, lc->ctx, &ib, &ob, &conf, &qop);
+
+    if (GSS_ERROR(maj)) {
         return -1;
     }
 
-    if (pl > out_cap) {
-        free(plain);
+    if (ob.length > out_cap) {
+        gss_release_buffer(&min, &ob);
         return -1;
     }
 
-    memcpy(out, plain, pl);
-    *r_out_len = pl;
-    free(plain);
+    memcpy(out, ob.value, ob.length);
+    *r_out_len = ob.length;
+    gss_release_buffer(&min, &ob);
     return 0;
 } /* krb5_local_i_unwrap */
 
@@ -1060,8 +1113,20 @@ krb5_local_i_destroy(
     void *arg,
     void *gss_ctx)
 {
+    struct krb5_local_ctx *lc = gss_ctx;
+    OM_uint32              min;
+
     (void) arg;
-    (void) gss_ctx;
+
+    if (!lc) {
+        return;
+    }
+
+    if (lc->ctx != GSS_C_NO_CONTEXT) {
+        gss_delete_sec_context(&min, &lc->ctx, GSS_C_NO_BUFFER);
+    }
+
+    free(lc);
 } /* krb5_local_i_destroy */
 
 static const struct evpl_rpc2_gss_provider krb5_local_initiator_vtable = {

--- a/src/rpc2/tests/krb5_local.c
+++ b/src/rpc2/tests/krb5_local.c
@@ -146,7 +146,9 @@ krb5_local_mint(
 } /* krb5_local_mint */
 
 struct krb5_local *
-krb5_local_create(const char **reason)
+krb5_local_create_as(
+    const char  *client_principal,
+    const char **reason)
 {
     struct krb5_local *kl;
     krb5_keyblock      svckey;
@@ -179,13 +181,43 @@ krb5_local_create(const char **reason)
         goto fail;
     }
 
-    if (krb5_build_principal(kl->ctx, &kl->client, strlen(KRB5_LOCAL_REALM),
-                             KRB5_LOCAL_REALM, KRB5_LOCAL_USER, NULL) ||
-        krb5_build_principal(kl->ctx, &kl->server, strlen(KRB5_LOCAL_REALM),
-                             KRB5_LOCAL_REALM, KRB5_LOCAL_SERVICE,
-                             KRB5_LOCAL_HOST, NULL)) {
-        why = "krb5_build_principal failed";
-        goto fail;
+    {
+        char        namebuf[256];
+        char       *slash;
+        const char *name = client_principal ? client_principal : KRB5_LOCAL_USER;
+        int         built;
+
+        if (strlen(name) >= sizeof(namebuf)) {
+            why = "client principal too long";
+            goto fail;
+        }
+
+        strcpy(namebuf, name);
+        slash = strchr(namebuf, '/');
+
+        /* A two-component name ("nfs/host") is a service principal, which is
+         * a different thing to the acceptor than a one-component user name --
+         * and what a consumer maps to a local identity turns on exactly that
+         * distinction. */
+        if (slash) {
+            *slash = '\0';
+            built = krb5_build_principal(kl->ctx, &kl->client,
+                                         strlen(KRB5_LOCAL_REALM),
+                                         KRB5_LOCAL_REALM, namebuf, slash + 1,
+                                         NULL);
+        } else {
+            built = krb5_build_principal(kl->ctx, &kl->client,
+                                         strlen(KRB5_LOCAL_REALM),
+                                         KRB5_LOCAL_REALM, namebuf, NULL);
+        }
+
+        if (built ||
+            krb5_build_principal(kl->ctx, &kl->server, strlen(KRB5_LOCAL_REALM),
+                                 KRB5_LOCAL_REALM, KRB5_LOCAL_SERVICE,
+                                 KRB5_LOCAL_HOST, NULL)) {
+            why = "krb5_build_principal failed";
+            goto fail;
+        }
     }
 
     /* AES-256 rather than whatever the host's default happens to be, so the
@@ -243,6 +275,12 @@ krb5_local_create(const char **reason)
         krb5_local_destroy(kl);
     }
     return NULL;
+} /* krb5_local_create_as */
+
+struct krb5_local *
+krb5_local_create(const char **reason)
+{
+    return krb5_local_create_as(NULL, reason);
 } /* krb5_local_create */
 
 void

--- a/src/rpc2/tests/krb5_local.c
+++ b/src/rpc2/tests/krb5_local.c
@@ -825,6 +825,222 @@ krb5_local_p_destroy(
     free(lc);
 } /* krb5_local_p_destroy */
 
+/*
+ * Initiator half of the provider vtable.
+ *
+ * The acceptor entries above each carry a per-context krb5_local_ctx; the
+ * initiator does not, because a client establishes one context at a time
+ * against one peer and the whole point of this harness is that both ends live
+ * in the same process.  So *gss_ctx is the krb5_local itself, and the mechanism
+ * state it hands back is the init_ctx already inside it.
+ */
+static int
+krb5_local_p_init(
+    void       *arg,
+    void      **gss_ctx,
+    const char *target,
+    const void *in_token,
+    size_t      in_len,
+    void      **out_token,
+    size_t     *out_len,
+    int        *complete)
+{
+    struct krb5_local *kl = arg;
+    OM_uint32          maj, min, flags;
+    gss_buffer_desc    in = GSS_C_EMPTY_BUFFER, tok = GSS_C_EMPTY_BUFFER;
+    gss_name_t         name = GSS_C_NO_NAME;
+    gss_buffer_desc    nb;
+    char               principal[256];
+
+    (void) target;
+
+    *out_token = NULL;
+    *out_len   = 0;
+    *complete  = 0;
+
+    snprintf(principal, sizeof(principal), "%s/%s@%s", KRB5_LOCAL_SERVICE,
+             KRB5_LOCAL_HOST, KRB5_LOCAL_REALM);
+
+    nb.value  = principal;
+    nb.length = strlen(principal);
+
+    if (GSS_ERROR(gss_import_name(&min, &nb,
+                                  (gss_OID) GSS_KRB5_NT_PRINCIPAL_NAME,
+                                  &name))) {
+        return -1;
+    }
+
+    if (!in_token) {
+        /* First leg: start clean, so a context left over from an earlier case
+         * cannot sign with a session key this handshake never agreed. */
+        if (kl->init_ctx != GSS_C_NO_CONTEXT) {
+            gss_delete_sec_context(&min, &kl->init_ctx, GSS_C_NO_BUFFER);
+            kl->init_ctx = GSS_C_NO_CONTEXT;
+        }
+    } else {
+        in.value  = (void *) in_token;
+        in.length = in_len;
+    }
+
+    maj = gss_init_sec_context(&min, kl->init_cred, &kl->init_ctx, name,
+                               GSS_C_NO_OID,
+                               GSS_C_INTEG_FLAG | GSS_C_CONF_FLAG |
+                               GSS_C_SEQUENCE_FLAG,
+                               0, GSS_C_NO_CHANNEL_BINDINGS,
+                               in_token ? &in : GSS_C_NO_BUFFER,
+                               NULL, &tok, &flags, NULL);
+
+    gss_release_name(&min, &name);
+
+    if (GSS_ERROR(maj)) {
+        return -1;
+    }
+
+    if (tok.length) {
+        *out_token = malloc(tok.length);
+        if (!*out_token) {
+            gss_release_buffer(&min, &tok);
+            return -1;
+        }
+        memcpy(*out_token, tok.value, tok.length);
+        *out_len = tok.length;
+    }
+
+    gss_release_buffer(&min, &tok);
+
+    *complete = (maj == GSS_S_COMPLETE);
+    *gss_ctx  = kl;
+
+    return 0;
+} /* krb5_local_p_init */
+
+/*
+ * The initiator's own vtable entries.
+ *
+ * These cannot be the acceptor's.  Every acceptor entry above is handed the
+ * per-context krb5_local_ctx that accept() minted, and signs with that
+ * context's session key; an initiator signs with kl->init_ctx, which is a
+ * different context entirely -- the one this side of the handshake built.
+ * Passing a krb5_local where a krb5_local_ctx is expected does not fail
+ * cleanly, it walks into the mechanism with the wrong pointer, which is
+ * exactly what a segfault inside kg_seal looks like.
+ *
+ * So the two roles get two vtables, and gss_ctx means something different in
+ * each: a minted context for the acceptor, the krb5_local itself for the
+ * initiator, which is where init_ctx lives.
+ */
+static int
+krb5_local_i_get_mic(
+    void       *arg,
+    void       *gss_ctx,
+    const void *msg,
+    size_t      msg_len,
+    void      **mic,
+    size_t     *mic_len)
+{
+    (void) arg;
+    return krb5_local_get_mic(gss_ctx, msg, msg_len, mic, mic_len);
+} /* krb5_local_i_get_mic */
+
+static int
+krb5_local_i_verify_mic(
+    void       *arg,
+    void       *gss_ctx,
+    const void *msg,
+    size_t      msg_len,
+    const void *mic,
+    size_t      mic_len)
+{
+    (void) arg;
+    return krb5_local_verify_mic(gss_ctx, msg, msg_len, mic, mic_len);
+} /* krb5_local_i_verify_mic */
+
+static int
+krb5_local_i_wrap(
+    void       *arg,
+    void       *gss_ctx,
+    const void *in,
+    size_t      in_len,
+    void       *out,
+    size_t      out_cap,
+    size_t     *r_out_len)
+{
+    void  *tok;
+    size_t tl;
+
+    (void) arg;
+
+    if (krb5_local_wrap(gss_ctx, in, in_len, &tok, &tl)) {
+        return -1;
+    }
+
+    if (tl > out_cap) {
+        free(tok);
+        return -1;
+    }
+
+    memcpy(out, tok, tl);
+    *r_out_len = tl;
+    free(tok);
+    return 0;
+} /* krb5_local_i_wrap */
+
+static int
+krb5_local_i_unwrap(
+    void       *arg,
+    void       *gss_ctx,
+    const void *in,
+    size_t      in_len,
+    void       *out,
+    size_t      out_cap,
+    size_t     *r_out_len)
+{
+    void  *plain;
+    size_t pl;
+
+    (void) arg;
+
+    if (krb5_local_unwrap(gss_ctx, in, in_len, &plain, &pl)) {
+        return -1;
+    }
+
+    if (pl > out_cap) {
+        free(plain);
+        return -1;
+    }
+
+    memcpy(out, plain, pl);
+    *r_out_len = pl;
+    free(plain);
+    return 0;
+} /* krb5_local_i_unwrap */
+
+/* The initiator's context belongs to the krb5_local, which krb5_local_destroy
+ * already tears down; nothing extra to release per context. */
+static void
+krb5_local_i_destroy(
+    void *arg,
+    void *gss_ctx)
+{
+    (void) arg;
+    (void) gss_ctx;
+} /* krb5_local_i_destroy */
+
+static const struct evpl_rpc2_gss_provider krb5_local_initiator_vtable = {
+    .init       = krb5_local_p_init,
+    .get_mic    = krb5_local_i_get_mic,
+    .verify_mic = krb5_local_i_verify_mic,
+    .wrap       = krb5_local_i_wrap,
+    .unwrap     = krb5_local_i_unwrap,
+    .destroy    = krb5_local_i_destroy,
+};
+
+const struct evpl_rpc2_gss_provider *
+krb5_local_initiator_provider(void)
+{
+    return &krb5_local_initiator_vtable;
+} /* krb5_local_initiator_provider */
+
 static const struct evpl_rpc2_gss_provider krb5_local_vtable = {
     .accept     = krb5_local_accept,
     .get_mic    = krb5_local_p_get_mic,

--- a/src/rpc2/tests/krb5_local.h
+++ b/src/rpc2/tests/krb5_local.h
@@ -44,6 +44,12 @@ krb5_local_destroy(
     struct krb5_local *kl);
 
 /* The acceptor, for evpl_rpc2_set_gss_provider(). */
+/* The initiator's vtable.  Distinct from the acceptor's because the two sign
+ * with different contexts; see the comment on krb5_local_i_get_mic. */
+const struct evpl_rpc2_gss_provider *
+krb5_local_initiator_provider(
+    void);
+
 const struct evpl_rpc2_gss_provider *
 krb5_local_provider(
     void);

--- a/src/rpc2/tests/krb5_local.h
+++ b/src/rpc2/tests/krb5_local.h
@@ -39,6 +39,20 @@ struct krb5_local *
 krb5_local_create(
     const char **reason);
 
+/*
+ * As krb5_local_create(), but naming the principal the initiator presents.
+ *
+ * "user" builds a one-component name and "svc/host" a two-component service
+ * principal; the realm is the harness's own either way.  A consumer that maps
+ * an authenticated principal to a local identity -- chimera's NFS server maps
+ * a service principal to root and an unknown user to anonymous -- has to be
+ * able to choose which of those it is presenting.  NULL takes the default.
+ */
+struct krb5_local *
+krb5_local_create_as(
+    const char  *client_principal,
+    const char **reason);
+
 void
 krb5_local_destroy(
     struct krb5_local *kl);

--- a/src/rpc2/tests/krb5_local_none.c
+++ b/src/rpc2/tests/krb5_local_none.c
@@ -25,6 +25,15 @@ krb5_local_create(const char **reason)
     return NULL;
 } /* krb5_local_create */
 
+struct krb5_local *
+krb5_local_create_as(
+    const char  *client_principal,
+    const char **reason)
+{
+    (void) client_principal;
+    return krb5_local_create(reason);
+} /* krb5_local_create_as */
+
 void
 krb5_local_destroy(struct krb5_local *kl)
 {

--- a/src/rpc2/tests/krb5_local_none.c
+++ b/src/rpc2/tests/krb5_local_none.c
@@ -38,6 +38,12 @@ krb5_local_provider(void)
 } /* krb5_local_provider */
 
 const struct evpl_rpc2_gss_provider *
+krb5_local_initiator_provider(void)
+{
+    return NULL;
+} /* krb5_local_initiator_provider */
+
+const struct evpl_rpc2_gss_provider *
 krb5_local_provider_noiov(void)
 {
     return NULL;

--- a/src/rpc2/tests/quint/client.qnt
+++ b/src/rpc2/tests/quint/client.qnt
@@ -81,6 +81,41 @@ module rpc2_client {
         | ReplyStringLenOverflow
         | ReplyStringLenBeyondMessage
 
+        /* --- replies to a call made under RPCSEC_GSS (RFC 2203) ----------
+         *
+         * These are the only cases where the call itself is protected: the
+         * client has established a context with the hostile server and is
+         * sending under integrity or privacy, so the reply must be wrapped
+         * the same way (RFC 2203 sec 5.3.3.2 / 5.3.3.3) and the client has to
+         * open it before its decoder ever sees results.
+         *
+         * They are separate variants rather than a service dimension over the
+         * existing ones because what can go wrong is different in kind: a
+         * checksum that does not verify has no analogue in an unprotected
+         * reply, and an unprotected reply has no checksum to get wrong. */
+        | GssIntegReplyValid
+        | GssPrivReplyValid
+        /* The protection is present but does not hold up. */
+        | GssIntegReplyChecksumBad
+        | GssPrivReplySealCorrupt
+        /* RFC 2203 sec 5.3.3.2: the sequence number the reply echoes is the
+         * one the call carried.  A reply echoing a different one is either a
+         * reply to some other call or an attacker's splice, and either way it
+         * is not this call's result. */
+        | GssIntegReplySeqMismatch
+        | GssPrivReplySeqMismatch
+        /* Framing of the wrapping itself, which is parsed before any of the
+         * cryptography runs -- the arithmetic here is where a length is most
+         * likely to be trusted before it is checked. */
+        | GssIntegReplyLengthBeyondMessage
+        | GssIntegReplyChecksumMissing
+        /* The reply the peer would have sent had there been no context at
+         * all: results in the clear where the service requires them wrapped.
+         * A client that decodes them has silently dropped to no protection,
+         * which is the whole point of asking for integrity or privacy. */
+        | GssIntegReplyUnprotected
+        | GssPrivReplyUnprotected
+
     /// What the client must do with the reply.
     type Outcome =
         /* The callback fires with status 0 and the value the peer encoded. */
@@ -183,6 +218,24 @@ module rpc2_client {
         | ReplyGarbageBody => CbDecodeError
         | ReplyStringLenOverflow => CbDecodeError
         | ReplyStringLenBeyondMessage => CbDecodeError
+
+        /* A correctly wrapped reply carries the results the caller asked
+         * for -- the wrapping is transport, not a different answer. */
+        | GssIntegReplyValid => CbSuccess
+        | GssPrivReplyValid => CbSuccess
+
+        /* Everything else here is a reply whose protection the client could
+         * not verify, so there are no results it is entitled to believe.  The
+         * call completes as a failure; which failure is left open for the
+         * same reason as the other refusals. */
+        | GssIntegReplyChecksumBad => CbFailed
+        | GssPrivReplySealCorrupt => CbFailed
+        | GssIntegReplySeqMismatch => CbFailed
+        | GssPrivReplySeqMismatch => CbFailed
+        | GssIntegReplyLengthBeyondMessage => CbFailed
+        | GssIntegReplyChecksumMissing => CbFailed
+        | GssIntegReplyUnprotected => CbFailed
+        | GssPrivReplyUnprotected => CbFailed
     }
 
     /// A defect that leaves the record framing intact gives the client no
@@ -233,7 +286,17 @@ module rpc2_client {
         ReplyTrailingGarbage(4), ReplyTrailingGarbage(64),
         ReplyGarbageBody,
         ReplyStringLenOverflow,
-        ReplyStringLenBeyondMessage
+        ReplyStringLenBeyondMessage,
+        GssIntegReplyValid,
+        GssPrivReplyValid,
+        GssIntegReplyChecksumBad,
+        GssPrivReplySealCorrupt,
+        GssIntegReplySeqMismatch,
+        GssPrivReplySeqMismatch,
+        GssIntegReplyLengthBeyondMessage,
+        GssIntegReplyChecksumMissing,
+        GssIntegReplyUnprotected,
+        GssPrivReplyUnprotected
     )
 
     /// Apply one specific case, recording the required behaviour alongside it.
@@ -296,9 +359,28 @@ module rpc2_client {
     val droppedRepliesKeepTheConnection =
         (expected != CbDropped) or (survives == ConnUp)
 
+    /// Requirement 3, and the reason the GSS cases exist: under a protected
+    /// service, results the client could not verify are not results.  This is
+    /// the property an implementation silently loses by falling back -- the
+    /// call still succeeds, so nothing looks wrong, and the protection the
+    /// caller asked for is simply gone.
+    val unverifiedResultsAreNeverDelivered =
+        match current.defect {
+            | GssIntegReplyChecksumBad => expected == CbFailed
+            | GssPrivReplySealCorrupt => expected == CbFailed
+            | GssIntegReplySeqMismatch => expected == CbFailed
+            | GssPrivReplySeqMismatch => expected == CbFailed
+            | GssIntegReplyLengthBeyondMessage => expected == CbFailed
+            | GssIntegReplyChecksumMissing => expected == CbFailed
+            | GssIntegReplyUnprotected => expected == CbFailed
+            | GssPrivReplyUnprotected => expected == CbFailed
+            | _ => true
+        }
+
     val safety =
         outcomeIsSpecified and noCallIsLostInSilence and
-        refusalIsNeverSuccess and droppedRepliesKeepTheConnection
+        refusalIsNeverSuccess and droppedRepliesKeepTheConnection and
+        unverifiedResultsAreNeverDelivered
 
     // ------------------------------------------------------------------
     // Scenario tests: the outcomes most likely to be got wrong
@@ -325,6 +407,34 @@ module rpc2_client {
             .then(use(ReplyAcceptStatWithBody(4), OneWrite))
             .expect(expected == CbFailed)
             .then(use(ReplyStatUndefined(2), OneWrite))
+            .expect(expected == CbFailed)
+
+    /// The two halves of a protected reply: one that verifies is the result,
+    /// and one that does not is not -- including the case where the peer
+    /// simply left the protection off, which is the fallback an attacker
+    /// would ask for.
+    run protectedReplyMustVerifyTest =
+        init
+            .then(use(GssIntegReplyValid, OneWrite))
+            .expect(expected == CbSuccess and survives == ConnUp)
+            .then(use(GssPrivReplyValid, OneWrite))
+            .expect(expected == CbSuccess)
+            .then(use(GssIntegReplyChecksumBad, OneWrite))
+            .expect(expected == CbFailed)
+            .then(use(GssPrivReplySealCorrupt, OneWrite))
+            .expect(expected == CbFailed)
+            .then(use(GssIntegReplyUnprotected, OneWrite))
+            .expect(expected == CbFailed)
+            .then(use(GssPrivReplyUnprotected, OneWrite))
+            .expect(expected == CbFailed)
+
+    /// A reply that verifies but answers a different call is still not this
+    /// call's result (RFC 2203 sec 5.3.3.2).
+    run protectedReplyMustEchoTheSequenceTest =
+        init
+            .then(use(GssIntegReplySeqMismatch, OneWrite))
+            .expect(expected == CbFailed)
+            .then(use(GssPrivReplySeqMismatch, OneWrite))
             .expect(expected == CbFailed)
 
     /// Losing the transport is still a completion.

--- a/src/rpc2/tests/quint/itf_to_client_cases.py
+++ b/src/rpc2/tests/quint/itf_to_client_cases.py
@@ -46,6 +46,16 @@ DEFECTS = [
     "ReplyGarbageBody",
     "ReplyStringLenOverflow",
     "ReplyStringLenBeyondMessage",
+    "GssIntegReplyValid",
+    "GssPrivReplyValid",
+    "GssIntegReplyChecksumBad",
+    "GssPrivReplySealCorrupt",
+    "GssIntegReplySeqMismatch",
+    "GssPrivReplySeqMismatch",
+    "GssIntegReplyLengthBeyondMessage",
+    "GssIntegReplyChecksumMissing",
+    "GssIntegReplyUnprotected",
+    "GssPrivReplyUnprotected",
 ]
 
 DELIVERIES = ["OneWrite", "TwoWrites", "Dribble"]


### PR DESCRIPTION
rpc2 has implemented only the acceptor half of RPCSEC_GSS: it can answer a call made under a context, but it cannot make one. Anything libevpl talks to as a client — an NFS proxy backend, one server calling another — has had exactly one credential available to it, AUTH_SYS, whatever the peer required. This adds the initiator, and then tests it the way the acceptor is tested.

**The initiator** mirrors the acceptor in shape. A provider gains an `init()` entry beside its `accept()`, and `evpl_rpc2_gss_client_create()` runs the token exchange over the program's NULL procedure (RFC 2203 sec 5.2) before handing back a context; a caller names that context in the credential and rpc2 does the rest. All three services are carried: `none` authenticates each call, `integrity` signs the arguments and verifies the reply's checksum, `privacy` seals and unseals them.

Two details are worth calling out because neither is visible from the RFC's prose:

- The call verifier is a MIC over the header through the credential, which does not depend on the verifier itself. So the header is marshalled once to learn the bytes, signed, then marshalled again with the verifier in place — two passes over a few dozen bytes.
- A context may be retired with calls still outstanding under it, and `evpl_rpc2_gss_client_destroy`'s own DESTROY is one such call. Destroy therefore clears the back-references those requests hold rather than leaving them pointing at freed memory. Their replies are still dispatched; they simply arrive unverified, which is what a reply to a context that no longer exists is. Without this the reply path reads freed memory — reproduced under ASan and covered by a test.

**The coverage** is the second commit. `conformance_client.c` drives libevpl's client from a raw socket, but every reply it could build was unprotected, so the code that opens a wrapped one was unreachable from the test suite. Reaching it means the hostile server has to hold up its end of a real context: answer the INIT with an `rpc_gss_init_res`, then wrap what it sends back. `krb5_local`'s acceptor half does that unmodified, so the checksums the client verifies come from a real mechanism — which is what makes a deliberately corrupted one meaningful.

Ten new defects, three deliveries each. The two that matter most have no analogue in an unprotected reply: results whose checksum does not verify, and results the peer simply sent in the clear. A client that accepts either has silently dropped to no protection while still reporting success, so the model states that as an invariant rather than leaving it implied by the case table.

All 203 tests pass, including the 127 client reply cases (30 of them protected) and the three new `client_gss` instances, one per service. Where krb5 is absent the protected cases report as skipped and everything else runs unchanged.
