### PR TITLE
io_uring: fall back to a smaller ring instead of aborting on ENOMEM

### DIFF
--- a/src/core/io_uring/io_uring.c
+++ b/src/core/io_uring/io_uring.c
@@ -201,7 +201,8 @@ evpl_io_uring_create(
     //struct evpl_io_uring_shared  *shared = private_data;
     struct evpl_io_uring_context *ctx;
     int                           ret;
-    struct io_uring_params        params;
+    struct io_uring_params        params, saved_params;
+    unsigned int                  entries;
     int                           sqpoll = 1;
 
     memset(&params, 0, sizeof(params));
@@ -226,9 +227,47 @@ evpl_io_uring_create(
 
     ctx->next_send_group_id = EVPL_IO_URING_BUFGROUP_ID + 1;
 
-    ret = io_uring_queue_init_params(evpl_shared->config->io_uring_entries, &ctx->ring, &params);
+    /*
+     * A ring is not a small allocation: SQE128 and CQE32 double both entry
+     * sizes, so the default 8192 entries ask the kernel for roughly 1.5 MB of
+     * accounted memory, and SQPOLL adds a kernel thread per ring.  A process
+     * with several event-loop threads, or several such processes at once,
+     * can therefore be refused with ENOMEM on a machine that is otherwise
+     * healthy -- which is how a busy CI runner turns an unrelated test into a
+     * fatal abort.
+     *
+     * A smaller ring is a far better outcome than no process.  Halve down to
+     * EVPL_IO_URING_MIN_ENTRIES before giving up, and only on ENOMEM: every
+     * other failure (EPERM from SQPOLL without privilege, EINVAL from an
+     * unsupported flag) says the ring is unavailable for a reason a smaller
+     * one would not fix.
+     */
+    saved_params = params;
+
+    for (entries = evpl_shared->config->io_uring_entries;; entries >>= 1) {
+
+        ret = io_uring_queue_init_params(entries, &ctx->ring, &params);
+
+        if (ret >= 0 || ret != -ENOMEM || entries <= EVPL_IO_URING_MIN_ENTRIES) {
+            break;
+        }
+
+        /* io_uring_setup() copies its parameters back only on success, and
+         * liburing zeroes the ring itself, but do not rely on either across a
+         * retry: reset both so each attempt starts from the same state. */
+        params = saved_params;
+        memset(&ctx->ring, 0, sizeof(ctx->ring));
+    }
 
     evpl_io_uring_abort_if(ret < 0, "io_uring_queue_init_params() failed: %s (%d)", strerror(-ret), ret);
+
+    if (entries != evpl_shared->config->io_uring_entries) {
+        evpl_io_uring_info(
+            "io_uring ring reduced from %u to %u entries after ENOMEM; "
+            "the ring is smaller than configured, which costs throughput only "
+            "under queueing deep enough to fill it",
+            evpl_shared->config->io_uring_entries, entries);
+    }
 
     ctx->eventfd = eventfd(0, EFD_NONBLOCK);
 

--- a/src/core/io_uring/io_uring_internal.h
+++ b/src/core/io_uring/io_uring_internal.h
@@ -16,6 +16,11 @@
 #define EVPL_IO_URING_REQ_TCP     1
 #define EVPL_IO_URING_REQ_BLOCK   2
 
+/* Smallest ring the fallback in evpl_io_uring_create() will settle for before
+ * it gives up and aborts.  Small enough that a machine refusing this has a real
+ * memory problem, large enough to keep a batch of submissions in flight. */
+#define EVPL_IO_URING_MIN_ENTRIES 256
+
 #define evpl_io_uring_debug(...) evpl_debug("io_uring", __FILE__, __LINE__, __VA_ARGS__)
 #define evpl_io_uring_info(...)  evpl_info("io_uring", __FILE__, __LINE__, __VA_ARGS__)
 #define evpl_io_uring_error(...) evpl_error("io_uring", __FILE__, __LINE__, __VA_ARGS__)


### PR DESCRIPTION
A ring is not a small allocation. `IORING_SETUP_SQE128` and `IORING_SETUP_CQE32` double both entry sizes, so the default **8192 entries** ask the kernel for roughly **1.5 MB** of accounted memory, and SQPOLL adds a kernel thread per ring. A process with several event-loop threads — or several such processes at once — can be refused with `ENOMEM` on a machine that is otherwise perfectly healthy.

`evpl_io_uring_create()` treated that as fatal, killing the whole process.

In chimera's CI this is how an unrelated test becomes an abort. From the most recent extended run, `posix/fsstress_diskfs_io_uring`:

```
io_uring_queue_init_params() failed: Cannot allocate memory (-12)
level=fatal module=io_uring src/core/io_uring/io_uring.c:231
```

Several smbtorture cases have been lost the same way. Nothing is wrong except that too many rings were wanted at once — and note this is the **event core**, so it takes down any process on Linux regardless of which VFS backend the test is exercising.

## The change

A smaller ring is a far better outcome than no process. Halve down to `EVPL_IO_URING_MIN_ENTRIES` (256) before giving up, and report the reduction at info level so it is visible rather than a silent performance change. A smaller ring costs throughput only under queueing deep enough to fill it.

Retry **only** on `ENOMEM`. Every other failure — `EPERM` from SQPOLL without privilege, `EINVAL` from an unsupported flag — says the ring is unavailable for a reason a smaller ring would not fix, and those still abort exactly as before.

Parameters and the ring are reset between attempts rather than relying on `io_uring_setup()` copying back only on success.

## Why this rather than raising the limit

The obvious alternative is to raise `RLIMIT_MEMLOCK` for chimera's CI containers. I did not, because on kernels ≥ 5.12 io_uring memory is charged to the cgroup rather than to `RLIMIT_MEMLOCK`, so that may well be a no-op — and it would fix only CI, not a real deployment on a constrained machine. Degrading gracefully is robust regardless of which limit is actually binding.

## Verification — stated honestly

This file is Linux-only and **is not built on macOS**, where I am working, so I could not compile it locally; CI provides the real compile check.

What I could verify, I did: the retry loop was extracted into a standalone harness with a simulated kernel that refuses rings above a cap, and exercised across the cases that matter.

| case | result |
|---|---|
| memory plentiful | 1 call, keeps 8192 |
| kernel caps at 1024 | 4 calls, settles at 1024 |
| every size refused | stops at the 256 floor, returns ENOMEM, aborts as before |
| non-power-of-two config | terminates, no underflow |
| zero entries configured | single call, no loop |

The property that mattered most was termination in every case, including the pathological ones. Both files are uncrustify-clean against `etc/uncrustify.cfg`.
