### PR TITLE
rpc2: hand the reply-capture hook the results, not the wire message

### DIFF
--- a/include/evpl/evpl_rpc2_program.h
+++ b/include/evpl/evpl_rpc2_program.h
@@ -90,23 +90,33 @@ struct evpl_rpc2_rdma_segment_list {
  * Optional pre-dispatch reply-capture callback.
  *
  * If set on an evpl_rpc2_encoding before a send_reply call, libevpl invokes
- * this callback inside send_reply -- after the reply has been marshalled
- * into iovecs but before they are queued onto the wire and the request is
- * freed.  This gives applications a chance to copy out the encoded reply
- * bytes for later replay (NFS4.1 session replay cache).
+ * this callback inside send_reply, once the procedure's results have been
+ * marshalled and before anything else is done to them.  This is what lets an
+ * application keep a reply for later replay: an NFSv4.1 session cache, an
+ * NFSv3 duplicate-request cache.
  *
- * The iov array spans the whole outgoing message and total_length is its
- * length.  rpc_offset is how many leading bytes of that are TRANSPORT framing
- * rather than RPC: 4 for the record marker over a stream transport, and the
- * length of the RPC-over-RDMA header over an RDMA one.  A caller that wants
- * the RPC reply itself -- which is what a replay cache stores, since the
- * framing has to be rebuilt for the retransmit anyway -- skips rpc_offset
- * bytes.  Ignoring it yields a buffer whose framing only happens to be
- * parseable on the transport it was captured from.
+ * What the callback is shown is the RESULTS -- not the outgoing message.  The
+ * iov array spans a buffer whose first `body_offset` bytes are reserved
+ * headroom; the results run from there to total_length, and that span is the
+ * whole of what to store.
  *
- * The callback runs before any Reply-chunk reduction, so the RPC reply is
- * always present in full here even when the wire form sends its body by RDMA
- * write and leaves only the header inline.
+ * That is deliberately narrower than the wire form, because everything the
+ * wire form adds is a property of the send rather than of the answer.  The
+ * transport framing has to be rebuilt for a retransmit anyway.  The RPC header
+ * carries the retransmit's own xid and verifier.  And under RPCSEC_GSS
+ * integrity or privacy the security layer reframes the results around the
+ * sequence number of the call being answered (RFC 2203 sec 5.3.3.2/5.3.3.3),
+ * so a cached wire reply replayed for a later call is wrapped around the wrong
+ * one -- and, sent back through the same path, is wrapped a second time.
+ * Storing the results and letting the reply be built afresh is what keeps a
+ * cached reply correct under every service.
+ *
+ * The callback runs before any Reply-chunk reduction, so the results are
+ * always present in full here even when the wire form sends the body by RDMA
+ * write and leaves only the header inline.  It runs only for a MSG_ACCEPTED /
+ * SUCCESS reply: anything else carries no results, so there is nothing to
+ * replay -- which is also what keeps a call the dispatcher refused out of an
+ * application's cache.
  *
  * Pointers are valid only for the duration of the callback; the callback must
  * copy any bytes it wishes to retain.
@@ -115,7 +125,7 @@ typedef void (*evpl_rpc2_reply_capture_cb_t)(
     const struct evpl_iovec *iov,
     int                      niov,
     int                      total_length,
-    uint32_t                 rpc_offset,
+    uint32_t                 body_offset,
     void                    *private_data);
 
 /*

--- a/src/rpc2/rpc2.c
+++ b/src/rpc2/rpc2.c
@@ -855,6 +855,27 @@ evpl_rpc2_send_reply(
             rpc_reply.body.rbody.areply.reply_data.info.high = request->mismatch_high;
         }
 
+        /*
+         * Capture the results here, before the security layer reframes them
+         * and before the RPC header is prepended: what a replay cache owes a
+         * retransmit is the procedure's answer, not the bytes some earlier
+         * send happened to make of it.  Wrapping is applied afresh on the
+         * replay, which is what keeps a cached reply correct under a service
+         * that reframes -- and correct with the retransmit's own sequence
+         * number rather than the original's.
+         *
+         * Only for a SUCCESS reply: anything else carries no results, so there
+         * is nothing to replay.  That is also what keeps a call the dispatcher
+         * refused -- GARBAGE_ARGS, say -- out of an application's cache, where
+         * an unauthenticated peer could otherwise evict real entries with a
+         * stream of malformed requests.
+         */
+        if (error_stat == SUCCESS && request->encoding.reply_capture_cb) {
+            request->encoding.reply_capture_cb(
+                msg_iov, msg_niov, length, (uint32_t) reserve,
+                request->encoding.reply_capture_private);
+        }
+
         /* Integrity service (krb5i): reframe the proc results as
          * rpc_gss_integ_data before the RPC header is prepended.  Non-RDMA
          * only (GSS over RDMA is not a supported transport).  On failure we
@@ -1069,25 +1090,6 @@ evpl_rpc2_send_reply(
 
     if (request->metric) {
         prometheus_time_histogram_sample(request->metric, &request->timestamp);
-    }
-
-    /* If the application requested reply capture (e.g. for an NFS4.1 SEQUENCE
-     * replay cache or an NFSv3 duplicate-request cache), invoke the callback
-     * now.
-     *
-     * Before the Reply-chunk reduction below, not after: that path clones only
-     * the first `offset` header bytes into final_reply_iov and RDMA-writes the
-     * body straight to the requester, so a callback run afterwards would see a
-     * header with no reply behind it.  Here msg_iov still spans the whole
-     * message, and `offset` is the transport framing ahead of the RPC reply --
-     * 4 for a stream record marker, marshall_length_rdma_msg() for RDMA. */
-    if (request->encoding.reply_capture_cb) {
-        request->encoding.reply_capture_cb(
-            msg_iov,
-            msg_niov,
-            length,
-            (uint32_t) offset,
-            request->encoding.reply_capture_private);
     }
 
     if (reduce) {


### PR DESCRIPTION
Found by running chimera's NFSv4 model-based corpus under `sec=krb5i` and `sec=krb5p`, where it failed partway through with a decode error that neither `krb5` nor AUTH_SYS produced.

**The bug.** `evpl_rpc2_send_reply_dispatch` does three things in order: RPCSEC_GSS integrity/privacy reframes the results into `rpc_gss_integ_data` / `rpc_gss_priv_data`; the RPC header is marshalled onto that; then `reply_capture_cb` fires with "the whole outgoing message".

So a replay cache built on this hook stores the *wrapped* body. Feeding it back through the reply path on a retransmit wraps it a second time — the client unwraps one layer and hands `rpc_gss_integ_data` to a decoder expecting procedure results. With no wrapping in force the stored body happens to be the results already, which is why only the two wrapped services broke, and why they broke identically.

Byte-level evidence from the failing retransmit, dumping what the cache handed back:

```
body_len=244 first16=000000d0 00000022 00000000 00000003
```

`0xd0` = 208 (databody length), `0x22` = 34 (the *original* call's GSS sequence number), then the COMPOUND status. 244 = 4 + 208 + 4 + a 28-byte krb5 MIC. That is `rpc_gss_integ_data`, not results.

**The fix.** The capture now runs before any of that, where the results are all there is: `msg_iov`'s first `body_offset` bytes are reserved headroom and everything after them is the answer. A cache keeps the answer; the RPC header, the security layer and the transport framing are rebuilt by the ordinary reply path for whichever call is being answered now. That also makes a replayed reply carry the retransmit's own sequence number rather than the original's — a second, latent defect the same change removes.

It fires only for a MSG_ACCEPTED/SUCCESS reply. That is the same filter consumers were applying by parsing the stored header, so nothing loses a guard: in particular a call the dispatcher refused (GARBAGE_ARGS) still never reaches a cache an unauthenticated peer could otherwise churn.

**Contract change.** `evpl_rpc2_reply_capture_cb_t`'s fourth argument changes meaning from `rpc_offset` (transport framing to skip) to `body_offset` (reserved headroom to skip). libevpl has no in-tree consumer; chimera is the one I know of, and its side is a companion change that gets simpler — it drops the RPC-header parser it needed to find the body.

All 203 libevpl tests pass. On the chimera side the previously-failing NFSv4 corpus now runs clean under all four flavors (142 traces, 601 contexts, zero leaked buffers), and its `sec=krb5p` cell is registered rather than left out.
