### PR TITLE
io_uring: do not let a completion arrive with nothing to wake the loop

### DIFF
--- a/src/core/io_uring/io_uring.c
+++ b/src/core/io_uring/io_uring.c
@@ -23,12 +23,19 @@ evpl_io_uring_flush_sqe(
 {
     struct evpl_io_uring_context *ctx = private_data;
 
-    unsigned int                  flags = atomic_load_explicit((_Atomic unsigned int *) &ctx->ring.flags,
-                                                               memory_order_relaxed);
+    /* IORING_SQ_NEED_WAKEUP lives in the SQ ring's kernel-visible flags word,
+     * not in io_uring::flags -- that one holds the IORING_SETUP_* flags this
+     * ring was created with.  Reading it there tests IORING_SETUP_IOPOLL
+     * (same bit 0), which is never set here, so this branch was dead and the
+     * log below has never once fired.  liburing's own io_uring_submit() checks
+     * the right word, so submission still worked; what was lost was any
+     * visibility into whether the sqpoll thread needed waking. */
+    unsigned int flags = atomic_load_explicit((_Atomic unsigned int *) ctx->ring.sq.kflags,
+                                              memory_order_relaxed);
 
     if (flags & IORING_SQ_NEED_WAKEUP) {
         io_uring_enter(ctx->ring.ring_fd, 0, 0, IORING_ENTER_SQ_WAKEUP, NULL);
-        evpl_io_uring_info("had to wake up the kernel sqpoll thread");
+        evpl_io_uring_debug("woke the kernel sqpoll thread");
     }
 
     io_uring_submit(&ctx->ring);
@@ -144,8 +151,17 @@ evpl_io_uring_poll_enter(
     void        *private_data)
 {
     struct evpl_io_uring_context *ctx = private_data;
+    int                           rc;
 
-    io_uring_unregister_eventfd(&ctx->ring);
+    /* A failure here only leaves the eventfd armed while we poll, which costs a
+     * spurious wakeup and nothing else -- unlike poll_exit below, where it is
+     * the difference between waking and hanging. */
+    rc = io_uring_unregister_eventfd(&ctx->ring);
+
+    if (rc < 0) {
+        evpl_io_uring_debug("io_uring_unregister_eventfd() failed: %s (%d)", strerror(-rc), rc);
+    }
+
     evpl_io_uring_complete(evpl, ctx);
 } /* evpl_io_uring_poll_enter */
 
@@ -155,8 +171,34 @@ evpl_io_uring_poll_exit(
     void        *private_data)
 {
     struct evpl_io_uring_context *ctx = private_data;
+    int                           rc = 0, i;
 
-    io_uring_register_eventfd(&ctx->ring, ctx->eventfd);
+    /*
+     * Leaving poll mode makes this eventfd the only thing that can wake the
+     * loop for a completion, so a silent failure here is a hang: the loop
+     * blocks, the CQE arrives with nothing to signal, and if the caller is
+     * waiting on that very request nothing else will ever wake it either.
+     * The result was previously discarded.
+     *
+     * Retry the transient cases -- EINTR, and the EBUSY io_uring can return
+     * while the ring is mid-operation.  A failure that survives those is
+     * fatal: there is no correct way to continue, because the loop is about to
+     * block on a signal that will never arrive, and an abort naming the cause
+     * is strictly better than the silent hang that leaves.
+     */
+    for (i = 0; i < EVPL_IO_URING_ARM_RETRIES; i++) {
+        rc = io_uring_register_eventfd(&ctx->ring, ctx->eventfd);
+
+        if (rc == 0 || (rc != -EINTR && rc != -EBUSY && rc != -EAGAIN)) {
+            break;
+        }
+    }
+
+    evpl_io_uring_abort_if(rc < 0,
+                           "io_uring_register_eventfd() failed: %s (%d); completions would "
+                           "arrive with nothing to wake the event loop",
+                           strerror(-rc), rc);
+
     evpl_io_uring_complete(evpl, ctx);
 } /* evpl_io_uring_poll_exit */
 
@@ -185,9 +227,15 @@ evpl_io_uring_complete_event(
 
     if (rc != sizeof(value)) {
         evpl_event_mark_unreadable(evpl, &ctx->event);
-        return;
     }
 
+    /* Drain regardless of what the eventfd said.  The counter and the
+     * completion queue are separate pieces of state: a CQE posted while the
+     * eventfd was unregistered (the whole of poll mode) never incremented it,
+     * and returning early on an empty read would leave that CQE sitting in the
+     * ring.  With one request outstanding and nothing else to wake this loop,
+     * that is a hang rather than a delay -- the request the caller is blocked
+     * on is the only thing that could have produced the next wakeup. */
     do {
         n = evpl_io_uring_complete(evpl, ctx);
     } while (n);
@@ -234,7 +282,12 @@ evpl_io_uring_create(
 
     evpl_io_uring_abort_if(ctx->eventfd < 0, "eventfd");
 
-    io_uring_register_eventfd(&ctx->ring, ctx->eventfd);
+    ret = io_uring_register_eventfd(&ctx->ring, ctx->eventfd);
+
+    evpl_io_uring_abort_if(ret < 0,
+                           "io_uring_register_eventfd() failed: %s (%d); no completion "
+                           "would ever wake this event loop",
+                           strerror(-ret), ret);
 
     evpl_add_event(evpl, &ctx->event, ctx->eventfd,
                    evpl_io_uring_complete_event, NULL, NULL);

--- a/src/core/io_uring/io_uring_internal.h
+++ b/src/core/io_uring/io_uring_internal.h
@@ -16,6 +16,11 @@
 #define EVPL_IO_URING_REQ_TCP     1
 #define EVPL_IO_URING_REQ_BLOCK   2
 
+/* Bounded retries for arming the completion eventfd when leaving poll mode.
+ * Small: the failures worth retrying are transient, and a persistent one must
+ * be reported rather than spun on. */
+#define EVPL_IO_URING_ARM_RETRIES 5
+
 #define evpl_io_uring_debug(...) evpl_debug("io_uring", __FILE__, __LINE__, __VA_ARGS__)
 #define evpl_io_uring_info(...)  evpl_info("io_uring", __FILE__, __LINE__, __VA_ARGS__)
 #define evpl_io_uring_error(...) evpl_error("io_uring", __FILE__, __LINE__, __VA_ARGS__)


### PR DESCRIPTION
Independent of the ring-size work (#163) despite touching the same file — this is a completion-delivery bug, not a sizing one.

chimera's `smb2.maxfid` hangs in diskfs's intent log, and with the new stall diagnostics the dump says the same thing every time:

```
IL stall: blocked on retire slot 115172 -- record seq=115172 end_txn_id=123033
log_offset=15962112 len=20480 chunks=1/1 outstanding entries=1; 1 of 1 ring slot(s) not done
```

Six occurrences across one run, **every one with exactly one journal write outstanding** (`redo_inflight=1`, `submitted-not-durable=1`), each a single 20 KiB one-chunk record. Five cleared; the last never did, and the log ends mid-stall at the 600 s kill.

## What that narrows it to

The pipeline **only ever stalls at depth one**. A slow device would stall at any queue depth — so this is not the device, it is the completion never being *seen*.

And the stall watchdog is a timer on that same event loop, so the loop is demonstrably alive while it happens. Something is running, and the completion queue still is not being drained. That is what sent me to this file rather than to diskfs.

It is also self-consistent with the transient-vs-terminal split: an unreaped CQE clears as soon as unrelated traffic drives the loop back through a drain, which is what the five recovered stalls look like — and never clears when the caller is blocked on that very request, which is the sixth.

## Three defects, each able to produce it

**1. The result of arming the completion eventfd was discarded.** Once the loop leaves poll mode the eventfd is the only thing that can wake it for a completion. If `io_uring_register_eventfd()` fails in `poll_exit`, the loop blocks, the CQE arrives and signals nothing, and if the caller is waiting on that request nothing else will wake it either. Now retried for the transient cases (`EINTR`, `EBUSY`, `EAGAIN`) and fatal otherwise — there is no correct way to continue into a wait for a signal that cannot come, and an abort naming the cause beats a silent hang. The registration at ring creation was unchecked in the same way and is likewise fatal.

**2. The completion handler returned early without draining** when the eventfd read came up empty. The eventfd counter and the completion queue are separate pieces of state: a CQE posted while the eventfd was unregistered — which is the whole of poll mode — never incremented it. It now drains regardless of what the read said.

**3. `IORING_SQ_NEED_WAKEUP` was read from the wrong word.** `io_uring::flags` holds the `IORING_SETUP_*` flags the ring was created with, not the SQ ring's kernel-visible flags. Bit 0 there is `IORING_SETUP_IOPOLL`, never set here, so the branch was dead and `"had to wake up the kernel sqpoll thread"` has never once fired. liburing's own `io_uring_submit()` checks the right word so submission still worked — what was lost was any sight of whether the sqpoll thread needed waking, which is exactly the question a depth-one stall raises.

## Verification — stated honestly

This file is Linux-only and **is not built on macOS**, where I work, so CI provides the compile check. I also cannot prove which of the three was the hang: I could not reproduce it locally, and each is a genuine defect on its own merits. What I can say is that all three sit in the path the evidence points to, and that after this a recurrence cannot be silent — it will either not happen or it will name itself.

What I did verify: the retry loop was extracted into a standalone harness — succeeds first try (1 call), transient-then-success (3 calls), hard error with no retry (1 call), and persistent `EBUSY` capped at the retry limit. Both files uncrustify-clean.

One deliberate detail: the new constant is named to the same width as the surrounding `#define` group, so uncrustify does not re-align three unrelated lines — that churn differs between the local 0.83 and CI's 0.78.1 and has no business in this diff.
