### PR TITLE
config: let the environment state the io_uring ring size

### DIFF
--- a/src/core/config.c
+++ b/src/core/config.c
@@ -4,6 +4,8 @@
 
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
 #include <string.h>
 #include <pthread.h>
 
@@ -18,6 +20,7 @@ SYMBOL_EXPORT struct evpl_global_config *
 evpl_global_config_init(void)
 {
     struct evpl_global_config *config = evpl_zalloc(sizeof(*config));
+    const char                *env;
 
     config->core_mech = EVPL_CORE_MECH_DEFAULT;
 
@@ -59,6 +62,37 @@ evpl_global_config_init(void)
 
     config->io_uring_enabled = 1;
     config->io_uring_entries = 8192;
+
+    /*
+     * A ring is not a small allocation: IORING_SETUP_SQE128 and
+     * IORING_SETUP_CQE32 double both entry sizes, so 8192 entries ask the
+     * kernel for roughly 1.5 MB of accounted memory, and SQPOLL adds a kernel
+     * thread per ring.  A host running many event-loop threads, or many such
+     * processes at once, can be refused with ENOMEM while otherwise healthy --
+     * which is how chimera's CI loses unrelated tests to a ring allocation.
+     *
+     * The size stays the caller's to choose and is honoured or fails; there is
+     * deliberately no silent reduction, because a ring that quietly shrank
+     * would make throughput depend on how loaded the machine was when the
+     * process started.  This override exists so a constrained environment can
+     * state a smaller size up front, the same way evpl_global_config_set_
+     * io_uring_entries() does for a caller that parses its own configuration.
+     */
+    env = getenv("EVPL_IO_URING_ENTRIES");
+
+    if (env) {
+        char *end;
+        long  entries = strtol(env, &end, 10);
+
+        if (*end == '\0' && entries > 0 && entries <= UINT_MAX) {
+            config->io_uring_entries = (unsigned int) entries;
+        } else {
+            evpl_error("config", __FILE__, __LINE__,
+                       "EVPL_IO_URING_ENTRIES=\"%s\" is not a positive integer; "
+                       "keeping the default of %u",
+                       env, config->io_uring_entries);
+        }
+    }
 
     config->rdmacm_enabled                = 1;
     config->rdmacm_tos                    = 0;


### PR DESCRIPTION
Replaces #160, which reduced the ring automatically on ENOMEM. That was the wrong shape: a ring that quietly shrank would make throughput depend on how loaded the machine happened to be when the process started, and would hide the resource problem instead of reporting it. The size should be stated, and honoured or failed.

## The problem it addresses

A ring is not a small allocation. `IORING_SETUP_SQE128` and `IORING_SETUP_CQE32` double both entry sizes, so the default **8192 entries ask the kernel for roughly 1.5 MB** of accounted memory, and SQPOLL adds a kernel thread per ring. A host running many event-loop threads — or many such processes at once — gets refused with `ENOMEM` while otherwise perfectly healthy:

```
io_uring_queue_init_params() failed: Cannot allocate memory (-12)
level=fatal module=io_uring
```

In chimera's CI that takes out unrelated tests (`posix/fsstress_diskfs_io_uring`, several smbtorture cases) which never asked for a ring that large.

## Why an environment variable

The size was already the caller's to choose through `evpl_global_config_set_io_uring_entries()` — but only for a caller that parses its own configuration. chimera's daemon does; its **test harnesses build their server state programmatically and never see a config file**, so a constrained environment had no lever at all for exactly the processes that hit this.

`EVPL_IO_URING_ENTRIES` gives it one, following the existing `EVPL_IOVEC_PROFILE` precedent in core. The ring still fails rather than shrinks; this only lets a constrained environment state a smaller size up front.

A value that is not a positive integer is reported and the default kept, rather than silently becoming zero.

## Verification

`config.c` is core, not io_uring, so it **does** build on macOS — compiled clean under `-Wall -Werror`. The parsing was additionally exercised in a harness across the cases that matter:

| input | result |
|---|---|
| unset | default 8192 |
| `"1024"` | 1024 |
| `"0"`, `"-4"` | default kept, reported |
| `"abc"`, `"512x"`, `""` | default kept, reported |
| `"99999999999"` | default kept, reported |

uncrustify clean.

chimera will set this for its constrained CI shards, and grows a matching `common.io_uring_entries` config key for deployments, in a companion PR.
