### PR TITLE
rpc2 tests: many initiator identities in one realm

### DIFF
--- a/src/rpc2/tests/client_gss.c
+++ b/src/rpc2/tests/client_gss.c
@@ -45,6 +45,9 @@ struct test_state {
     struct evpl_rpc2_gss_client *gss;
     uint32_t                     service;
     int                          server_saw_gss;
+    /* The principal the acceptor saw on the last call, so a driver holding
+     * several identities can check that each call arrived as its own. */
+    char                         last_principal[256];
     int                          complete;
     int                          passed;
     int                          after_destroy_fired;
@@ -70,6 +73,8 @@ server_recv_greet(
      */
     if (cred && cred->flavor == EVPL_RPC2_AUTH_RPCSEC_GSS) {
         state->server_saw_gss = 1;
+        snprintf(state->last_principal, sizeof(state->last_principal), "%s",
+                 cred->gss.principal ? cred->gss.principal : "");
         evpl_test_info("server: call authenticated as '%s', service %u",
                        cred->gss.principal ? cred->gss.principal : "(none)",
                        cred->gss.service);
@@ -133,6 +138,24 @@ client_recv_after_destroy(
 
     state->after_destroy_fired = 1;
 } /* client_recv_after_destroy */
+
+/* Waits out one context establishment for the multi-identity phase. */
+struct multi_wait {
+    struct evpl_rpc2_gss_client *client;
+    int                          done;
+};
+
+static void
+multi_ready(
+    struct evpl_rpc2_gss_client *client,
+    int                          status,
+    void                        *private_data)
+{
+    struct multi_wait *w = private_data;
+
+    w->client = status ? NULL : client;
+    w->done   = 1;
+} /* multi_ready */
 
 /* The context is ready (or was refused); either way the test moves on. */
 static void
@@ -257,12 +280,100 @@ main(
     evpl_test_abort_if(!state.conn, "client connect failed");
 
     evpl_rpc2_gss_client_create(evpl, &prog.rpc2, state.conn,
-                                krb5_local_initiator_provider(), kl,
+                                krb5_local_initiator_provider(),
+                                krb5_local_initiator_arg(kl),
                                 state.service, "hello@localhost",
                                 gss_ready, &state);
 
     while (!state.complete) {
         evpl_continue(evpl);
+    }
+
+    /*
+     * Several users, one connection.
+     *
+     * RPCSEC_GSS carries no uid: a client calling as more than one user holds
+     * a context per user and names the right one in each call's credential,
+     * which is what rpc.gssd builds from each user's own ccache.  This is that
+     * arrangement in miniature -- two identities, two contexts, one connection
+     * -- and what it checks is that the acceptor attributes each call to the
+     * principal that made it rather than to whichever context came last.
+     */
+    if (state.passed) {
+        static const char *const     names[] = { "u1000", "u1001" };
+        struct krb5_local_identity  *ids[2]  = { NULL, NULL };
+        struct evpl_rpc2_gss_client *gss[2]  = { NULL, NULL };
+        int                          i, ok = 1;
+
+        for (i = 0; i < 2; i++) {
+            struct multi_wait w = { 0 };
+
+            ids[i] = krb5_local_identity_create(kl, names[i]);
+            evpl_test_abort_if(!ids[i], "could not build identity %s",
+                               names[i]);
+
+            evpl_rpc2_gss_client_create(evpl, &prog.rpc2, state.conn,
+                                        krb5_local_initiator_provider(),
+                                        krb5_local_identity_arg(ids[i]),
+                                        state.service, "hello@localhost",
+                                        multi_ready, &w);
+
+            while (!w.done) {
+                evpl_continue(evpl);
+            }
+
+            evpl_test_abort_if(!w.client, "context for %s never established",
+                               names[i]);
+            gss[i] = w.client;
+        }
+
+        /* Interleaved, and the older identity last: a server that keyed the
+         * identity off anything but the credential's handle would answer this
+         * as the most recently established one. */
+        for (i = 1; i >= 0; i--) {
+            struct evpl_rpc2_cred cred;
+            struct Hello          request;
+            char                  want[256];
+
+            memset(&cred, 0, sizeof(cred));
+            cred.flavor      = EVPL_RPC2_AUTH_RPCSEC_GSS;
+            cred.gss.service = state.service;
+            cred.gss.client  = gss[i];
+
+            request.id = 44 + i;
+            xdr_set_str_static(&request, greeting, "hi", strlen("hi"));
+
+            state.complete          = 0;
+            state.last_principal[0] = '\0';
+
+            prog.send_call_GREET(&prog.rpc2, evpl, state.conn, &cred,
+                                 &request, 0, 0, NULL, 0, 0,
+                                 client_recv_reply, &state);
+
+            while (!state.complete) {
+                evpl_continue(evpl);
+            }
+
+            snprintf(want, sizeof(want), "%s@TEST.LIBEVPL", names[i]);
+
+            if (strcmp(state.last_principal, want)) {
+                evpl_test_error("call under %s arrived as '%s'", names[i],
+                                state.last_principal);
+                ok = 0;
+            }
+        }
+
+        for (i = 0; i < 2; i++) {
+            evpl_rpc2_gss_client_destroy(evpl, gss[i]);
+            krb5_local_identity_destroy(ids[i]);
+        }
+
+        if (ok) {
+            evpl_test_info("two identities, one connection: each call "
+                           "attributed to its own principal");
+        } else {
+            state.passed = 0;
+        }
     }
 
     /*

--- a/src/rpc2/tests/conformance_client.c
+++ b/src/rpc2/tests/conformance_client.c
@@ -1309,7 +1309,7 @@ gss_establish(
 
     evpl_rpc2_gss_client_create(evpl, &g_prog.rpc2, g_conn,
                                 krb5_local_initiator_provider(),
-                                krb5_local_arg(g_kl), service,
+                                krb5_local_initiator_arg(g_kl), service,
                                 "conformance@localhost", gss_ready_cb, NULL);
 
     for (guard = 0; guard < 8 && !g_gss_ready && !g_gss_failed; guard++) {

--- a/src/rpc2/tests/krb5_local.c
+++ b/src/rpc2/tests/krb5_local.c
@@ -43,21 +43,45 @@ extern krb5_error_code encode_krb5_ticket(
 #define KRB5_LOCAL_USER    "conformance"
 
 struct krb5_local {
-    krb5_context   ctx;
-    krb5_principal client;
-    krb5_principal server;
-    krb5_keytab    keytab;
-    krb5_ccache    ccache;
+    krb5_context                ctx;
+    krb5_principal              client;
+    krb5_principal              server;
+    krb5_keytab                 keytab;
+    krb5_ccache                 ccache;
 
     /* The initiator's context, established lazily by the first init_token. */
-    gss_cred_id_t  init_cred;
-    gss_ctx_id_t   init_ctx;
+    gss_cred_id_t               init_cred;
+    gss_ctx_id_t                init_ctx;
 
     /* The acceptor's credential; contexts are per-exchange and owned by rpc2
      * through the provider's gss_ctx cookie. */
-    gss_cred_id_t  accept_cred;
+    gss_cred_id_t               accept_cred;
 
-    int            iov_enabled;
+    /* Lazily built by krb5_local_initiator_arg; freed with the realm. */
+    struct krb5_local_identity *default_identity;
+
+    /* The service key, kept rather than wiped after construction: minting a
+     * ticket for a principal named later is the whole of what an additional
+     * identity needs, and only the service key can do it. */
+    krb5_keyblock               svckey;
+
+    int                         iov_enabled;
+};
+
+/*
+ * One initiator identity: a principal with a service ticket of its own.
+ *
+ * The realm above is shared -- one service key, one acceptor credential --
+ * because a server holds one of each no matter how many users call it.  What
+ * is per-identity is what a real client's rpc.gssd keeps per user: a principal,
+ * the ticket issued to it, and the credential built from that ticket.
+ */
+struct krb5_local_identity {
+    struct krb5_local *kl;
+    krb5_principal     client;
+    krb5_ccache        ccache;
+    gss_cred_id_t      init_cred;
+    int                is_default; /* borrows the realm's ccache and cred */
 };
 
 /* ------------------------------------------------------------------ */
@@ -71,8 +95,10 @@ struct krb5_local {
  * of anybody.
  */
 static int
-krb5_local_mint(
+krb5_local_mint_for(
     struct krb5_local   *kl,
+    krb5_principal       client,
+    krb5_ccache          ccache,
     const krb5_keyblock *svckey)
 {
     krb5_enc_tkt_part enc;
@@ -98,7 +124,7 @@ krb5_local_mint(
 
     enc.flags                        = TKT_FLG_INITIAL;
     enc.session                      = &seskey;
-    enc.client                       = kl->client;
+    enc.client                       = client;
     enc.times.authtime               = now;
     enc.times.starttime              = now;
     enc.times.endtime                = now + 3600;
@@ -117,18 +143,18 @@ krb5_local_mint(
         goto out;
     }
 
-    creds.client       = kl->client;
+    creds.client       = client;
     creds.server       = kl->server;
     creds.keyblock     = seskey;
     creds.times        = enc.times;
     creds.ticket_flags = enc.flags;
     creds.ticket       = *tktdata;
 
-    if (krb5_cc_initialize(kl->ctx, kl->ccache, kl->client)) {
+    if (krb5_cc_initialize(kl->ctx, ccache, client)) {
         goto out;
     }
 
-    if (krb5_cc_store_cred(kl->ctx, kl->ccache, &creds)) {
+    if (krb5_cc_store_cred(kl->ctx, ccache, &creds)) {
         goto out;
     }
 
@@ -243,7 +269,7 @@ krb5_local_create_as(
         goto fail;
     }
 
-    if (krb5_local_mint(kl, &svckey)) {
+    if (krb5_local_mint_for(kl, kl->client, kl->ccache, &svckey)) {
         why = "could not mint a service ticket";
         goto fail;
     }
@@ -263,7 +289,8 @@ krb5_local_create_as(
         goto fail;
     }
 
-    krb5_free_keyblock_contents(kl->ctx, &svckey);
+    /* Retained on the realm; released in krb5_local_destroy. */
+    kl->svckey = svckey;
 
     return kl;
 
@@ -282,6 +309,152 @@ krb5_local_create(const char **reason)
 {
     return krb5_local_create_as(NULL, reason);
 } /* krb5_local_create */
+
+/*
+ * Build an initiator identity for `name` -- "u1000", or "nfs/host" for a
+ * service principal.  Each gets a memory ccache of its own, because a ccache
+ * holds one client's tickets and initializing it for a second principal would
+ * discard the first.
+ */
+struct krb5_local_identity *
+krb5_local_identity_create(
+    struct krb5_local *kl,
+    const char        *name)
+{
+    struct krb5_local_identity *id;
+    OM_uint32                   maj, min;
+    char                        ccname[160];
+    char                        namebuf[128];
+    char                       *slash, *p;
+    int                         built;
+
+    if (!kl || !name || !name[0] || strlen(name) >= sizeof(namebuf)) {
+        return NULL;
+    }
+
+    id = calloc(1, sizeof(*id));
+
+    if (!id) {
+        return NULL;
+    }
+
+    id->kl        = kl;
+    id->init_cred = GSS_C_NO_CREDENTIAL;
+
+    strcpy(namebuf, name);
+    slash = strchr(namebuf, '/');
+
+    if (slash) {
+        *slash = '\0';
+        built = krb5_build_principal(kl->ctx, &id->client,
+                                     strlen(KRB5_LOCAL_REALM),
+                                     KRB5_LOCAL_REALM, namebuf, slash + 1,
+                                     NULL);
+    } else {
+        built = krb5_build_principal(kl->ctx, &id->client,
+                                     strlen(KRB5_LOCAL_REALM),
+                                     KRB5_LOCAL_REALM, namebuf, NULL);
+    }
+
+    if (built) {
+        goto fail;
+    }
+
+    /* Named for the principal, so two identities never share a ccache. */
+    snprintf(ccname, sizeof(ccname), "MEMORY:evpl_krb5_id_%s", name);
+
+    for (p = ccname; *p; p++) {
+        if (*p == '/') {
+            *p = '_';
+        }
+    }
+
+    if (krb5_cc_resolve(kl->ctx, ccname, &id->ccache)) {
+        goto fail;
+    }
+
+    if (krb5_local_mint_for(kl, id->client, id->ccache, &kl->svckey)) {
+        goto fail;
+    }
+
+    maj = gss_krb5_import_cred(&min, id->ccache, NULL, NULL, &id->init_cred);
+
+    if (GSS_ERROR(maj)) {
+        goto fail;
+    }
+
+    return id;
+
+ fail:
+    krb5_local_identity_destroy(id);
+    return NULL;
+} /* krb5_local_identity_create */
+
+void
+krb5_local_identity_destroy(struct krb5_local_identity *id)
+{
+    OM_uint32 min;
+
+    if (!id) {
+        return;
+    }
+
+    if (!id->is_default) {
+        if (id->init_cred != GSS_C_NO_CREDENTIAL) {
+            gss_release_cred(&min, &id->init_cred);
+        }
+
+        if (id->ccache) {
+            krb5_cc_destroy(id->kl->ctx, id->ccache);
+        }
+
+        if (id->client) {
+            krb5_free_principal(id->kl->ctx, id->client);
+        }
+    } else {
+        (void) min;
+    }
+
+    free(id);
+} /* krb5_local_identity_destroy */
+
+/*
+ * The identity for the realm's own client principal.  A driver that only ever
+ * calls as one user -- which is most of them -- wants this and nothing else.
+ * It borrows the realm's ccache and credential rather than minting a second
+ * ticket for the same principal.
+ */
+void *
+krb5_local_initiator_arg(struct krb5_local *kl)
+{
+    if (!kl) {
+        return NULL;
+    }
+
+    if (!kl->default_identity) {
+        struct krb5_local_identity *id = calloc(1, sizeof(*id));
+
+        if (!id) {
+            return NULL;
+        }
+
+        id->kl         = kl;
+        id->client     = kl->client;
+        id->ccache     = kl->ccache;
+        id->init_cred  = kl->init_cred;
+        id->is_default = 1;
+
+        kl->default_identity = id;
+    }
+
+    return kl->default_identity;
+} /* krb5_local_initiator_arg */
+
+void *
+krb5_local_identity_arg(struct krb5_local_identity *id)
+{
+    return id;
+} /* krb5_local_identity_arg */
 
 void
 krb5_local_destroy(struct krb5_local *kl)
@@ -302,7 +475,13 @@ krb5_local_destroy(struct krb5_local *kl)
         gss_release_cred(&min, &kl->accept_cred);
     }
 
+    if (kl->default_identity) {
+        krb5_local_identity_destroy(kl->default_identity);
+        kl->default_identity = NULL;
+    }
+
     if (kl->ctx) {
+        krb5_free_keyblock_contents(kl->ctx, &kl->svckey);
         if (kl->keytab) {
             krb5_kt_close(kl->ctx, kl->keytab);
         }
@@ -883,13 +1062,13 @@ krb5_local_p_init(
     size_t     *out_len,
     int        *complete)
 {
-    struct krb5_local     *kl = arg;
-    struct krb5_local_ctx *lc = *gss_ctx;
-    OM_uint32              maj, min, flags;
-    gss_buffer_desc        in = GSS_C_EMPTY_BUFFER, tok = GSS_C_EMPTY_BUFFER;
-    gss_name_t             name = GSS_C_NO_NAME;
-    gss_buffer_desc        nb;
-    char                   principal[256];
+    struct krb5_local_identity *id = arg;
+    struct krb5_local_ctx      *lc = *gss_ctx;
+    OM_uint32                   maj, min, flags;
+    gss_buffer_desc             in = GSS_C_EMPTY_BUFFER, tok = GSS_C_EMPTY_BUFFER;
+    gss_name_t                  name = GSS_C_NO_NAME;
+    gss_buffer_desc             nb;
+    char                        principal[256];
 
     (void) target;
 
@@ -930,7 +1109,7 @@ krb5_local_p_init(
         in.length = in_len;
     }
 
-    maj = gss_init_sec_context(&min, kl->init_cred, &lc->ctx, name,
+    maj = gss_init_sec_context(&min, id->init_cred, &lc->ctx, name,
                                GSS_C_NO_OID,
                                GSS_C_INTEG_FLAG | GSS_C_CONF_FLAG |
                                GSS_C_SEQUENCE_FLAG,

--- a/src/rpc2/tests/krb5_local.h
+++ b/src/rpc2/tests/krb5_local.h
@@ -59,10 +59,49 @@ krb5_local_destroy(
 
 /* The acceptor, for evpl_rpc2_set_gss_provider(). */
 /* The initiator's vtable.  Distinct from the acceptor's because the two sign
- * with different contexts; see the comment on krb5_local_i_get_mic. */
+ * with different contexts; see the comment on krb5_local_i_get_mic.
+ *
+ * Its provider_arg is an identity, not the realm: krb5_local_initiator_arg()
+ * for the realm's own principal, or krb5_local_identity_arg() for one built
+ * with krb5_local_identity_create(). */
 const struct evpl_rpc2_gss_provider *
 krb5_local_initiator_provider(
     void);
+
+/*
+ * Initiator identities.
+ *
+ * A realm holds one service key and one acceptor credential, because a server
+ * does.  What it can hold many of is initiator identities -- a principal, the
+ * ticket issued to it, and the credential built from that ticket -- which is
+ * what a real client keeps per user.  RPCSEC_GSS has no uid on the wire: a
+ * client calling as several users establishes a context per user (rpc.gssd
+ * does exactly this, from each user's own credential cache), and a driver that
+ * wants to do the same needs an identity per user to do it with.
+ *
+ * `name` is "u1000" for a user principal or "nfs/host" for a service one; the
+ * realm is the harness's own.  What an acceptor does with an authenticated
+ * identity often turns on which of the two it is.
+ */
+struct krb5_local_identity;
+
+struct krb5_local_identity *
+krb5_local_identity_create(
+    struct krb5_local *kl,
+    const char        *name);
+
+void
+krb5_local_identity_destroy(
+    struct krb5_local_identity *id);
+
+/* The provider_arg for an identity, and for the realm's own principal. */
+void *
+krb5_local_identity_arg(
+    struct krb5_local_identity *id);
+
+void *
+krb5_local_initiator_arg(
+    struct krb5_local *kl);
 
 const struct evpl_rpc2_gss_provider *
 krb5_local_provider(

--- a/src/rpc2/tests/krb5_local_none.c
+++ b/src/rpc2/tests/krb5_local_none.c
@@ -52,6 +52,36 @@ krb5_local_initiator_provider(void)
     return NULL;
 } /* krb5_local_initiator_provider */
 
+struct krb5_local_identity *
+krb5_local_identity_create(
+    struct krb5_local *kl,
+    const char        *name)
+{
+    (void) kl;
+    (void) name;
+    return NULL;
+} /* krb5_local_identity_create */
+
+void
+krb5_local_identity_destroy(struct krb5_local_identity *id)
+{
+    (void) id;
+} /* krb5_local_identity_destroy */
+
+void *
+krb5_local_identity_arg(struct krb5_local_identity *id)
+{
+    (void) id;
+    return NULL;
+} /* krb5_local_identity_arg */
+
+void *
+krb5_local_initiator_arg(struct krb5_local *kl)
+{
+    (void) kl;
+    return NULL;
+} /* krb5_local_initiator_arg */
+
 const struct evpl_rpc2_gss_provider *
 krb5_local_provider_noiov(void)
 {


### PR DESCRIPTION
`krb5_local` held one client principal, so a driver could call as exactly one user.

RPCSEC_GSS carries no uid — the caller is whoever the context authenticated — so a client calling as several users holds a **context per user** and names the right one in each call's credential. That is what a real client's `rpc.gssd` builds, from each user's own credential cache, and a harness that cannot hold a second identity cannot express the arrangement at all.

**The shape.** The realm keeps what a *server* keeps: one service key, one acceptor credential. It gains identities alongside — a principal, the ticket minted for it, and the credential built from that ticket — each with a memory ccache of its own, because a ccache holds one client's tickets and initializing it for a second principal would discard the first. The service key is retained rather than wiped at construction, since minting a ticket for a principal named later is all an identity needs.

The initiator provider's `provider_arg` is now an identity rather than the realm: `krb5_local_initiator_arg()` for the realm's own principal, which is what every existing caller wants, or `krb5_local_identity_arg()` for one built with `krb5_local_identity_create()`. Only `p_init` needed changing — the per-context vtable entries already work off the context object.

**The test.** `client_gss` stands two identities up on one connection and calls under each, the older one last, checking that the acceptor attributes each call to the principal that made it rather than to whichever context was established most recently. I confirmed the check bites: deliberately sending both calls under the first context reports

```
call under u1001 arrived as 'u1000@TEST.LIBEVPL'
```

All 203 tests pass, under all three services, no leaked buffers. The no-krb5 build is stubbed and builds clean.

**What it is for.** Chimera's NFS model-based tests could only replay traces whose operations all ran as root — 24 of 28 traces in the NFS3 corpus were being set aside. With an identity per user they run whole, and the duplicate-request suites can finally exercise the RPCSEC_GSS arm of the server's requester-identity hash, which no test had ever executed.
