### PR TITLE
io_uring: stop waking the sqpoll thread before the SQE is visible

### DIFF
--- a/src/core/io_uring/io_uring.c
+++ b/src/core/io_uring/io_uring.c
@@ -23,21 +23,26 @@ evpl_io_uring_flush_sqe(
 {
     struct evpl_io_uring_context *ctx = private_data;
 
-    /* IORING_SQ_NEED_WAKEUP lives in the SQ ring's kernel-visible flags word,
-     * not in io_uring::flags -- that one holds the IORING_SETUP_* flags this
-     * ring was created with.  Reading it there tests IORING_SETUP_IOPOLL
-     * (same bit 0), which is never set here, so this branch was dead and the
-     * log below has never once fired.  liburing's own io_uring_submit() checks
-     * the right word, so submission still worked; what was lost was any
-     * visibility into whether the sqpoll thread needed waking. */
-    unsigned int flags = atomic_load_explicit((_Atomic unsigned int *) ctx->ring.sq.kflags,
-                                              memory_order_relaxed);
-
-    if (flags & IORING_SQ_NEED_WAKEUP) {
-        io_uring_enter(ctx->ring.ring_fd, 0, 0, IORING_ENTER_SQ_WAKEUP, NULL);
-        evpl_io_uring_debug("woke the kernel sqpoll thread");
-    }
-
+    /*
+     * Just submit.  There was a hand-rolled IORING_SQ_NEED_WAKEUP check here
+     * that ran *before* this call, and waking the sqpoll thread at that point
+     * is worse than not waking it at all: io_uring_get_sqe() advances only
+     * liburing's private sqe_tail, so the poller wakes, finds the ring's
+     * kernel-visible tail unchanged, has nothing to do, and goes back to
+     * sleep -- clearing the very NEED_WAKEUP flag that io_uring_submit() is
+     * about to consult.  liburing then concludes no enter is needed and
+     * returns without a syscall, leaving the SQE sitting unconsumed until
+     * something else happens to wake the poller.
+     *
+     * io_uring_submit() does the same check in the only order that is correct:
+     * publish the tail first, then test NEED_WAKEUP and enter with
+     * IORING_ENTER_SQ_WAKEUP if it is set.
+     *
+     * (For most of this file's life the hand-rolled check read io_uring::flags
+     * rather than the SQ ring's, which tests IORING_SETUP_IOPOLL -- never set
+     * here -- so the branch was dead and liburing quietly did the right thing.
+     * Correcting the word woke the branch up, and with it this race.)
+     */
     io_uring_submit(&ctx->ring);
 } /* evpl_io_uring_flush */
 


### PR DESCRIPTION
The flush deferral checked `IORING_SQ_NEED_WAKEUP` and entered the ring with `IORING_ENTER_SQ_WAKEUP` **before** calling `io_uring_submit()`. That is worse than not waking the poller at all.

`io_uring_get_sqe()` advances only liburing's private `sqe_tail`; the ring's kernel-visible tail does not move until `io_uring_submit()` flushes it. So:

1. we wake the poller,
2. it looks at the ring, finds the tail unchanged, has nothing to do,
3. it goes back to sleep — **clearing the very `NEED_WAKEUP` flag** `io_uring_submit()` is about to consult,
4. liburing concludes no enter is needed and returns without a syscall,
5. the SQE sits unconsumed until something else happens to wake the poller.

That is precisely the shape of the diskfs intent-log stall behind chimera's `smb2.maxfid`: one journal write submitted and never completed, the pipeline stalled at depth one, and nothing left to wake it because the caller is blocked on that very write.

## This is my own regression

For most of this file's life the check read `io_uring::flags` rather than the SQ ring's `kflags`. Bit 0 there is `IORING_SETUP_IOPOLL`, never set here, so **the branch was dead** and liburing quietly did the right thing.

#162 corrected the word — which woke the branch up, and with it this race. The CI log from the first run carrying that fix shows `"woke the kernel sqpoll thread"` firing **183 times**, and the stall still present:

```
IL stall: blocked on retire slot 26057 -- record seq=26057 end_txn_id=26058
log_offset=17436672 len=16384 chunks=1/1 outstanding entries=1
```

So #162 was right about the *word* and wrong to keep the check at all.

## The fix

Delete it rather than move it. `io_uring_submit()` already performs the identical check in the only order that is correct: publish the tail, then test `NEED_WAKEUP`, then enter with `IORING_ENTER_SQ_WAKEUP` if it is set. A hand-rolled copy can only be redundant or wrong, and this one was wrong.

## Verification, stated honestly

This file is Linux-only and is not built on macOS, so CI provides the compile check. `io_uring_enter` is no longer referenced in this file; uncrustify clean.

I cannot yet show the stall is gone — that needs an extended run with this pin. What I can show is that the code path being deleted is unsound by construction, that it was firing constantly in the run that still stalled, and that removing it restores the behaviour that held for the whole period before #162, when this particular race could not occur.
