### PR TITLE
io_uring: make SQPOLL opt-in, default off

### DIFF
--- a/include/evpl/evpl_config.h
+++ b/include/evpl/evpl_config.h
@@ -181,6 +181,10 @@ void evpl_global_config_set_io_uring_entries(
     struct evpl_global_config *config,
     unsigned int               entries);
 
+void evpl_global_config_set_io_uring_sqpoll(
+    struct evpl_global_config *config,
+    int                        enabled);
+
 void evpl_global_config_set_rdmacm_enabled(
     struct evpl_global_config *config,
     int                        enabled);

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -94,6 +94,39 @@ evpl_global_config_init(void)
         }
     }
 
+    /*
+     * SQPOLL hands submission to a kernel thread that busy-polls the SQ and
+     * keeps spinning for sq_thread_idle after the last entry, then has to be
+     * woken by a syscall for the next one.  That is a win only while the ring
+     * stays busy.  Every evpl thread owns a ring, so for a process with many
+     * mostly idle loops it is a kernel thread per loop, each burning a CPU for
+     * a second after every submission -- and a depth-one workload, such as a
+     * journal write that must complete before the next is issued, pays a
+     * scheduler hop through that thread on every I/O.  Measured on chimera's
+     * diskfs metadata storm, the ring with SQPOLL was 4.6x slower than the
+     * same ring without it, and 2.3x slower than libaio on the same device.
+     *
+     * Default off: submission happens in the issuing thread's
+     * io_uring_enter() and completions wake the loop through the registered
+     * eventfd exactly as before.  A deployment whose rings stay busy can turn
+     * it on with evpl_global_config_set_io_uring_sqpoll() or
+     * EVPL_IO_URING_SQPOLL=1.
+     */
+    config->io_uring_sqpoll = 0;
+
+    env = getenv("EVPL_IO_URING_SQPOLL");
+
+    if (env) {
+        if (strcmp(env, "0") == 0 || strcmp(env, "1") == 0) {
+            config->io_uring_sqpoll = (unsigned int) (env[0] - '0');
+        } else {
+            evpl_error("config", __FILE__, __LINE__,
+                       "EVPL_IO_URING_SQPOLL=\"%s\" is not 0 or 1; "
+                       "keeping the default of %u",
+                       env, config->io_uring_sqpoll);
+        }
+    }
+
     config->rdmacm_enabled                = 1;
     config->rdmacm_tos                    = 0;
     config->rdmacm_max_sge                = 31;
@@ -481,6 +514,14 @@ evpl_global_config_set_io_uring_entries(
 {
     config->io_uring_entries = entries;
 } /* evpl_global_config_set_io_uring_entries */
+
+SYMBOL_EXPORT void
+evpl_global_config_set_io_uring_sqpoll(
+    struct evpl_global_config *config,
+    int                        enabled)
+{
+    config->io_uring_sqpoll = enabled ? 1 : 0;
+} /* evpl_global_config_set_io_uring_sqpoll */
 
 SYMBOL_EXPORT void
 evpl_global_config_set_rdmacm_enabled(

--- a/src/core/evpl.h
+++ b/src/core/evpl.h
@@ -74,6 +74,7 @@ struct evpl_global_config {
 
     unsigned int              io_uring_enabled;
     unsigned int              io_uring_entries;
+    unsigned int              io_uring_sqpoll;
 
     unsigned int              rdmacm_enabled;
     unsigned int              rdmacm_tos;

--- a/src/core/io_uring/io_uring.c
+++ b/src/core/io_uring/io_uring.c
@@ -42,39 +42,73 @@ evpl_io_uring_flush_sqe(
 } /* evpl_io_uring_flush */
 
 
+/*
+ * Ring setup shared by the availability probe and every per-thread ring, so
+ * the probe tests exactly the configuration the threads will run with.
+ *
+ * SQPOLL is off unless configured (see the io_uring_sqpoll note in config.c):
+ * a kernel thread per ring that spins for a second after each submission is
+ * paid for only by a ring that stays busy, and the depth-one I/O it slows
+ * down is the common case for an event loop that mostly waits.  Without it,
+ * COOP_TASKRUN keeps completion task-work from interrupting this thread while
+ * it runs, and TASKRUN_FLAG lets liburing skip the io_uring_enter() when
+ * nothing is pending.  DEFER_TASKRUN is deliberately not used: it runs
+ * completions only when the issuing thread enters the ring, and this loop
+ * sleeps in the core poller on the ring's eventfd, so completions would never
+ * be posted while it waits.
+ */
+static void
+evpl_io_uring_params(struct io_uring_params *params)
+{
+    memset(params, 0, sizeof(*params));
+
+    params->flags = IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_SQE128 | IORING_SETUP_CQE32;
+
+    if (evpl_shared->config->io_uring_sqpoll) {
+        params->flags         |= IORING_SETUP_SQPOLL;
+        params->sq_thread_idle = 1000;
+    } else {
+        params->flags |= IORING_SETUP_COOP_TASKRUN | IORING_SETUP_TASKRUN_FLAG;
+    }
+} /* evpl_io_uring_params */
+
+/*
+ * Availability probe: a NULL return tells the shared attach that io_uring is
+ * not usable here (old kernel, seccomp, SQPOLL refused without privilege) and
+ * no thread will create a ring.  The probe ring used to live for the whole
+ * process, an SQPOLL ring that nothing ever attached to and whose kernel
+ * thread served no one; build it with the real parameters and tear it down.
+ */
 static void *
 evpl_io_uring_init(void)
 {
-    struct evpl_io_uring_shared *shared;
-    struct io_uring_params       params;
-    int                          rc;
+    struct io_uring        ring;
+    struct io_uring_params params;
+    int                    rc;
 
-    memset(&params, 0, sizeof(params));
+    evpl_io_uring_params(&params);
 
-    params.flags         |= IORING_SETUP_SQPOLL;
-    params.sq_thread_idle = 1000;
-
-    shared = evpl_zalloc(sizeof(*shared));
-
-    rc = io_uring_queue_init_params(256, &shared->ring, &params);
+    /* Probe with a small ring: this asks whether the flags are accepted, not
+     * whether the configured size fits.  A size the host cannot afford is
+     * still reported where it happens, by the per-thread create below. */
+    rc = io_uring_queue_init_params(256, &ring, &params);
 
     if (rc < 0) {
-        evpl_free(shared);
+        evpl_io_uring_debug("io_uring unavailable: %s (%d)", strerror(-rc), rc);
         return NULL;
     }
 
-    return shared;
+    io_uring_queue_exit(&ring);
+
+    /* Nothing is shared between rings; the framework pattern needs a non-NULL
+     * token to record that the probe passed. */
+    return (void *) 1;
 } /* evpl_io_uring_init */
 
 static void
 evpl_io_uring_cleanup(void *private_data)
 {
-    struct evpl_io_uring_shared *shared = private_data;
-
-    io_uring_queue_exit(&shared->ring);
-
-    evpl_free(shared);
-
+    (void) private_data;
 } /* evpl_io_uring_cleanup */
 
 static inline int
@@ -246,29 +280,13 @@ evpl_io_uring_create(
     struct evpl *evpl,
     void        *private_data)
 {
-    //struct evpl_io_uring_shared  *shared = private_data;
     struct evpl_io_uring_context *ctx;
     int                           ret;
     struct io_uring_params        params;
-    int                           sqpoll = 1;
 
-    memset(&params, 0, sizeof(params));
+    (void) private_data;
 
-    params.flags = IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_SQE128 | IORING_SETUP_CQE32;
-
-    if (sqpoll) {
-        params.flags |= IORING_SETUP_SQPOLL;
-
-        params.sq_thread_idle = 1000;
-    } else {
-        //params.flags |= IORING_SETUP_COOP_TASKRUN | IORING_SETUP_TASKRUN_FLAG;
-        params.flags |= IORING_SETUP_DEFER_TASKRUN;
-    }
-
-#if 0
-    params.flags |= IORING_SETUP_ATTACH_WQ;
-    params.wq_fd  = shared->ring.ring_fd;
-    #endif /* if 0 */
+    evpl_io_uring_params(&params);
 
     ctx = evpl_zalloc(sizeof(*ctx));
 

--- a/src/core/io_uring/io_uring_internal.h
+++ b/src/core/io_uring/io_uring_internal.h
@@ -33,10 +33,6 @@
 #define evpl_io_uring_abort_if(cond, ...) \
         evpl_abort_if(cond, "io_uring", __FILE__, __LINE__, __VA_ARGS__)
 
-struct evpl_io_uring_shared {
-    struct io_uring ring;
-};
-
 struct evpl_io_uring_socket;
 
 struct evpl_io_uring_request {


### PR DESCRIPTION
Every ring was created with `IORING_SETUP_SQPOLL` and a 1 s spin-idle. Each evpl thread owns a ring, so each one also owned a kernel thread that busy-polled for a second after every submission and had to be woken by a syscall for the next. That is a win only while the ring stays busy. For a loop that mostly waits it is a CPU burned per thread, and a depth-one workload (a journal write that must complete before the next is issued) pays a scheduler hop through that thread on every I/O.

Measured on chimera's diskfs metadata storm (create 20000 files, ASAN build, 6 CPUs), same binary:

| configuration | create phase |
|---|---|
| libaio | 133 s |
| io_uring, SQPOLL on (old default) | 311 s |
| io_uring, SQPOLL off | 68 s |

With SQPOLL on, four `iou-sqp` threads sat at ~80% CPU each serving one serial client. In chimera's CI the io_uring cells of `smb2.maxfid`, `diskfs_evict` and `diskfs_reclaim` ran 1.5-3x slower than the aio cells of the same tests, and two of them hit their ctest caps every run.

**Change**

- New config field `io_uring_sqpoll`, default off. `evpl_global_config_set_io_uring_sqpoll()` and `EVPL_IO_URING_SQPOLL=0|1` set it (same shape as `io_uring_entries`).
- Without SQPOLL the ring uses `COOP_TASKRUN | TASKRUN_FLAG`. `DEFER_TASKRUN` is deliberately not used: it posts completions only when the issuing thread enters the ring, and this loop sleeps in the core poller on the ring's eventfd.
- `evpl_io_uring_init` built a second SQPOLL ring per process that nothing attached to (`ATTACH_WQ` was under `#if 0`). It is now only the availability probe: built with the real flags, torn down immediately.

All 211 tests pass in the devcontainer with the default and with `EVPL_IO_URING_SQPOLL=1`.
