### PR TITLE
docs: route site-absolute links through relative_url

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -12,24 +12,24 @@ Complete API documentation for libevpl organized by functional area.
 
 ## Core APIs
 
-- **[Core API](/api/core)** - Event loop management, initialization, and protocol queries
-- **[Configuration API](/api/config)** - Global and thread-local configuration
-- **[Binds & Connections](/api/binds)** - Creating connections, sending/receiving data
-- **[Endpoints API](/api/endpoints)** - Network address and port management
-- **[Memory API](/api/memory)** - Buffer allocation and management
-- **[Timer API](/api/timers)** - Scheduled callbacks and timeouts
-- **[Deferral API](/api/deferrals)** - Deferred task execution
-- **[Doorbell API](/api/doorbells)** - Inter-thread notifications
-- **[Poll API](/api/polls)** - Busy-poll callbacks for spin-mode work
-- **[Threading API](/api/threading)** - Thread creation and thread pools
-- **[Block I/O API](/api/block)** - High-performance storage operations (io_uring, VFIO-NVMe)
-- **[RDMA API](/api/rdma)** - RDMA-specific functionality
-- **[Logging API](/api/logging)** - Logging and diagnostics
+- **[Core API]({{ '/api/core' | relative_url }})** - Event loop management, initialization, and protocol queries
+- **[Configuration API]({{ '/api/config' | relative_url }})** - Global and thread-local configuration
+- **[Binds & Connections]({{ '/api/binds' | relative_url }})** - Creating connections, sending/receiving data
+- **[Endpoints API]({{ '/api/endpoints' | relative_url }})** - Network address and port management
+- **[Memory API]({{ '/api/memory' | relative_url }})** - Buffer allocation and management
+- **[Timer API]({{ '/api/timers' | relative_url }})** - Scheduled callbacks and timeouts
+- **[Deferral API]({{ '/api/deferrals' | relative_url }})** - Deferred task execution
+- **[Doorbell API]({{ '/api/doorbells' | relative_url }})** - Inter-thread notifications
+- **[Poll API]({{ '/api/polls' | relative_url }})** - Busy-poll callbacks for spin-mode work
+- **[Threading API]({{ '/api/threading' | relative_url }})** - Thread creation and thread pools
+- **[Block I/O API]({{ '/api/block' | relative_url }})** - High-performance storage operations (io_uring, VFIO-NVMe)
+- **[RDMA API]({{ '/api/rdma' | relative_url }})** - RDMA-specific functionality
+- **[Logging API]({{ '/api/logging' | relative_url }})** - Logging and diagnostics
 
 ## Protocol Modules
 
-- **[HTTP API](/api/http)** - HTTP client and server
-- **[RPC2 API](/api/rpc2)** - ONC RPC2 for NFS
+- **[HTTP API]({{ '/api/protocols/http' | relative_url }})** - HTTP client and server
+- **[RPC2 API]({{ '/api/protocols/rpc2' | relative_url }})** - ONC RPC2 for NFS
 
 ## Quick Reference
 
@@ -66,7 +66,7 @@ Always check return values and handle errors appropriately.
 
 ## See Also
 
-- [Getting Started](/getting-started) - Quick tutorial
-- [Architecture](/architecture) - Understanding core concepts
-- [Programming Guide](/programming_guide) - Best practices
-- [Examples](/examples) - Complete working code samples
+- [Getting Started]({{ '/getting-started' | relative_url }}) - Quick tutorial
+- [Architecture]({{ '/architecture' | relative_url }}) - Understanding core concepts
+- [Programming Guide]({{ '/programming_guide' | relative_url }}) - Best practices
+- [Examples]({{ '/examples' | relative_url }}) - Complete working code samples

--- a/docs/api/binds.md
+++ b/docs/api/binds.md
@@ -642,7 +642,7 @@ Request `EVPL_NOTIFY_SENT` notifications for send completions. By default, send 
 
 ## See Also
 
-- [Endpoints API](/api/endpoints) - Address and port management
-- [Memory API](/api/memory) - Buffer and iovec management
-- [Core API](/api/core) - Event loop management
-- [Getting Started](/getting-started) - Echo server example
+- [Endpoints API]({{ '/api/endpoints' | relative_url }}) - Address and port management
+- [Memory API]({{ '/api/memory' | relative_url }}) - Buffer and iovec management
+- [Core API]({{ '/api/core' | relative_url }}) - Event loop management
+- [Getting Started]({{ '/getting-started' | relative_url }}) - Echo server example

--- a/docs/api/block.md
+++ b/docs/api/block.md
@@ -372,7 +372,7 @@ Multiple outstanding requests improve IOPS to a point. Issue multiple requests i
 
 ## See Also
 
-- [Memory API](/api/memory) - Buffer management for block I/O
-- [Configuration API](/api/config) - Performance tuning
-- [Core API](/api/core) - Event loop integration
-- [Architecture](/architecture) - Understanding async I/O
+- [Memory API]({{ '/api/memory' | relative_url }}) - Buffer management for block I/O
+- [Configuration API]({{ '/api/config' | relative_url }}) - Performance tuning
+- [Core API]({{ '/api/core' | relative_url }}) - Event loop integration
+- [Architecture]({{ '/architecture' | relative_url }}) - Understanding async I/O

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -867,7 +867,7 @@ Set the wait timeout in milliseconds when no events are available. A value of -1
 
 ## See Also
 
-- [Core API](/api/core) - Initialization and event loops
-- [Architecture](/architecture) - Understanding hybrid event/polling
-- [Performance](/performance) - Benchmark results
-- [Programming Guide](/programming_guide) - Performance tuning
+- [Core API]({{ '/api/core' | relative_url }}) - Initialization and event loops
+- [Architecture]({{ '/architecture' | relative_url }}) - Understanding hybrid event/polling
+- [Performance]({{ '/performance' | relative_url }}) - Benchmark results
+- [Programming Guide]({{ '/programming_guide' | relative_url }}) - Performance tuning

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -165,7 +165,7 @@ concatenation remains a valid single page).
 
 ## See Also
 
-- [Configuration API](/api/config) - Global and thread-local configuration
-- [Binds & Connections API](/api/binds) - Creating and managing connections
-- [Threading API](/api/threading) - Thread pools and thread management
-- [Architecture Guide](/architecture) - Understanding event loops and protocols
+- [Configuration API]({{ '/api/config' | relative_url }}) - Global and thread-local configuration
+- [Binds & Connections API]({{ '/api/binds' | relative_url }}) - Creating and managing connections
+- [Threading API]({{ '/api/threading' | relative_url }}) - Thread pools and thread management
+- [Architecture Guide]({{ '/architecture' | relative_url }}) - Understanding event loops and protocols

--- a/docs/api/deferrals.md
+++ b/docs/api/deferrals.md
@@ -10,7 +10,7 @@ permalink: /api/deferrals
 
 Provides a mechanism to schedule callbacks for execution at the end of the current event loop iteration, before it might block waiting for more activity.
 
-All operations on a deferral must be performed by the thread that owns the associated evpl context. A deferral is a mechanism for a thread to schedule work for itself to do later. For cross-thread communication, use [doorbells](/api/doorbells) instead.
+All operations on a deferral must be performed by the thread that owns the associated evpl context. A deferral is a mechanism for a thread to schedule work for itself to do later. For cross-thread communication, use [doorbells]({{ '/api/doorbells' | relative_url }}) instead.
 
 ## Overview
 
@@ -85,7 +85,7 @@ Schedule a deferral to fire at the end of the current event loop iteration.
 
 ## See Also
 
-- [Timers API](/api/timers) - Scheduled callbacks
-- [Doorbells API](/api/doorbells) - Cross-thread communication
-- [Core API](/api/core) - Event loop management
-- [Architecture](/architecture) - Understanding event loops
+- [Timers API]({{ '/api/timers' | relative_url }}) - Scheduled callbacks
+- [Doorbells API]({{ '/api/doorbells' | relative_url }}) - Cross-thread communication
+- [Core API]({{ '/api/core' | relative_url }}) - Event loop management
+- [Architecture]({{ '/architecture' | relative_url }}) - Understanding event loops

--- a/docs/api/doorbells.md
+++ b/docs/api/doorbells.md
@@ -107,8 +107,8 @@ Get the file descriptor associated with a doorbell (for advanced use cases).
 
 ## See Also
 
-- [Threading API](/api/threading) - Thread pools and worker threads
-- [Deferrals API](/api/deferrals) - Same-thread deferred execution
-- [Core API](/api/core) - Event loop management
-- [Architecture](/architecture) - Threading model
-- [Programming Guide](/programming_guide) - Multi-threading patterns
+- [Threading API]({{ '/api/threading' | relative_url }}) - Thread pools and worker threads
+- [Deferrals API]({{ '/api/deferrals' | relative_url }}) - Same-thread deferred execution
+- [Core API]({{ '/api/core' | relative_url }}) - Event loop management
+- [Architecture]({{ '/architecture' | relative_url }}) - Threading model
+- [Programming Guide]({{ '/programming_guide' | relative_url }}) - Multi-threading patterns

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -90,6 +90,6 @@ Get the port number from an endpoint.
 
 ## See Also
 
-- [Binds & Connections API](/api/binds) - Using endpoints with connections
-- [Core API](/api/core) - Protocol selection for endpoints
-- [Getting Started](/getting-started) - Basic endpoint usage examples
+- [Binds & Connections API]({{ '/api/binds' | relative_url }}) - Using endpoints with connections
+- [Core API]({{ '/api/core' | relative_url }}) - Protocol selection for endpoints
+- [Getting Started]({{ '/getting-started' | relative_url }}) - Basic endpoint usage examples

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -508,7 +508,7 @@ The handle must not be used afterwards.
 
 ## See Also
 
-- [Binds & Connections API](/api/binds) - Underlying network I/O
-- [Memory API](/api/memory) - Buffer management
-- [Threading API](/api/threading) - Multi-threaded servers
-- [Examples](/examples) - Complete HTTP server examples (coming soon)
+- [Binds & Connections API]({{ '/api/binds' | relative_url }}) - Underlying network I/O
+- [Memory API]({{ '/api/memory' | relative_url }}) - Buffer management
+- [Threading API]({{ '/api/threading' | relative_url }}) - Multi-threaded servers
+- [Examples]({{ '/examples' | relative_url }}) - Complete HTTP server examples (coming soon)

--- a/docs/api/memory.md
+++ b/docs/api/memory.md
@@ -260,5 +260,5 @@ When enabled, iovec operations are validated and will abort with a descriptive e
 
 ## See Also
 
-- [Binds & Connections API](/api/binds) - Using iovecs with send/receive
-- [Architecture](/architecture) - Memory management overview
+- [Binds & Connections API]({{ '/api/binds' | relative_url }}) - Using iovecs with send/receive
+- [Architecture]({{ '/architecture' | relative_url }}) - Memory management overview

--- a/docs/api/polls.md
+++ b/docs/api/polls.md
@@ -13,7 +13,7 @@ Provides per-thread poll callbacks that run while the event loop is in poll
 state when the thread transitions between polling and event-driven waiting.
 
 For background on libevpl's hybrid event/poll model, see the
-[Architecture](/architecture) page.
+[Architecture]({{ '/architecture' | relative_url }}) page.
 
 ## Overview
 
@@ -198,6 +198,6 @@ thread that owns `evpl`.
 
 ## See Also
 
-- [Configuration API](/api/config) - `poll_mode`, `spin_ns`, `poll_iterations`
-- [Doorbell API](/api/doorbells) - Inter-thread wakeups (often paired with polls)
-- [Architecture](/architecture) - Hybrid event/poll model
+- [Configuration API]({{ '/api/config' | relative_url }}) - `poll_mode`, `spin_ns`, `poll_iterations`
+- [Doorbell API]({{ '/api/doorbells' | relative_url }}) - Inter-thread wakeups (often paired with polls)
+- [Architecture]({{ '/architecture' | relative_url }}) - Hybrid event/poll model

--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -45,7 +45,7 @@ Despite being implemented over TCP (a stream protocol), TCP-RDMA presents a data
 - Debugging RDMA protocols with standard network tools
 - Cross-platform RDMA application support
 
-See the [RDMA API documentation](/api/rdma) for details on using TCP-RDMA.
+See the [RDMA API documentation]({{ '/api/rdma' | relative_url }}) for details on using TCP-RDMA.
 
 ## Frameworks
 
@@ -81,7 +81,7 @@ Common protocol name strings:
 
 ## See Also
 
-- [Core API](/api/core) - Event loop and initialization
-- [Binds & Connections API](/api/binds) - Using protocols with connections
-- [RDMA API](/api/rdma) - RDMA and TCP-RDMA operations
-- [Configuration API](/api/config) - Protocol-specific settings
+- [Core API]({{ '/api/core' | relative_url }}) - Event loop and initialization
+- [Binds & Connections API]({{ '/api/binds' | relative_url }}) - Using protocols with connections
+- [RDMA API]({{ '/api/rdma' | relative_url }}) - RDMA and TCP-RDMA operations
+- [Configuration API]({{ '/api/config' | relative_url }}) - Protocol-specific settings

--- a/docs/api/rdma.md
+++ b/docs/api/rdma.md
@@ -97,6 +97,6 @@ Check if a bind supports RDMA operations.
 
 ## See Also
 
-- [Binds & Connections API](/api/binds) - RDMA connection setup
-- [Memory API](/api/memory) - Buffer management
-- [Protocols](/api/protocols) - Available protocols including TCP-RDMA
+- [Binds & Connections API]({{ '/api/binds' | relative_url }}) - RDMA connection setup
+- [Memory API]({{ '/api/memory' | relative_url }}) - Buffer management
+- [Protocols]({{ '/api/protocols' | relative_url }}) - Available protocols including TCP-RDMA

--- a/docs/api/rpc2.md
+++ b/docs/api/rpc2.md
@@ -230,10 +230,10 @@ Destroy an RPC2 server and free resources.
 
 ## See Also
 
-- [Threading API](/api/threading) - Multi-threaded RPC servers
-- [RDMA API](/api/rdma) - RPC-over-RDMA optimization
-- [Memory API](/api/memory) - Zero-copy buffer management
-- [Architecture](/architecture) - Understanding RPC protocol module
+- [Threading API]({{ '/api/threading' | relative_url }}) - Multi-threaded RPC servers
+- [RDMA API]({{ '/api/rdma' | relative_url }}) - RPC-over-RDMA optimization
+- [Memory API]({{ '/api/memory' | relative_url }}) - Zero-copy buffer management
+- [Architecture]({{ '/architecture' | relative_url }}) - Understanding RPC protocol module
 - **RFC 5531** - RPC: Remote Procedure Call Protocol Specification Version 2
 - **RFC 5666** - Remote Direct Memory Access Transport for RPC
 - **RFC 1813** - NFS Version 3 Protocol Specification

--- a/docs/api/timers.md
+++ b/docs/api/timers.md
@@ -118,7 +118,7 @@ Remove a timer from the event loop.
 
 ## See Also
 
-- [Deferrals API](/api/deferrals) - Same-iteration task scheduling
-- [Doorbells API](/api/doorbells) - Cross-thread notifications
-- [Core API](/api/core) - Event loop management
-- [Architecture](/architecture) - Understanding event loops
+- [Deferrals API]({{ '/api/deferrals' | relative_url }}) - Same-iteration task scheduling
+- [Doorbells API]({{ '/api/doorbells' | relative_url }}) - Cross-thread notifications
+- [Core API]({{ '/api/core' | relative_url }}) - Event loop management
+- [Architecture]({{ '/architecture' | relative_url }}) - Understanding event loops

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ The core of libevpl is the event loop (`struct evpl`), which manages all asynchr
 
 This model eliminates the need for locking when accessing per-connection state, since all operations on a given connection happen sequentially within a single thread's event loop. Applications can maintain complex state machines without worrying about concurrent access from multiple threads.
 
-For API details on event loop creation and management, see the [Core API](/api/core) documentation.
+For API details on event loop creation and management, see the [Core API]({{ '/api/core' | relative_url }}) documentation.
 
 ## Hybrid Event and Poll Modes
 
@@ -87,7 +87,7 @@ When the system becomes heavily loaded:
 - Latency drops to near-hardware levels
 - CPU usage increases but is justified by the workload
 
-The transition is automatic and transparent to the application. Configuration options control the threshold for switching modes (see [Configuration API](/api/config)).
+The transition is automatic and transparent to the application. Configuration options control the threshold for switching modes (see [Configuration API]({{ '/api/config' | relative_url }})).
 
 This hybrid approach provides the best of both worlds: energy-efficient operation under light load and maximum performance under heavy load.
 
@@ -130,7 +130,7 @@ libevpl addresses this by maintaining pools of pre-registered memory. Instead of
 
 This amortizes the registration cost across many I/O operations. The expensive registration happens once during initialization; individual I/O operations simply use already-registered memory.
 
-See the [Memory Management API](/api/memory) for details on buffer allocation and management.
+See the [Memory Management API]({{ '/api/memory' | relative_url }}) for details on buffer allocation and management.
 
 ### Zero-Copy I/O
 
@@ -177,7 +177,7 @@ Currently supported backends include:
 
 Other acceleration frameworks will be added over time.
 
-See [Bind API](/api/binds) for protocol querying and selection mechanisms.
+See [Bind API]({{ '/api/binds' | relative_url }}) for protocol querying and selection mechanisms.
 
 ## Connection Management and Steering
 
@@ -205,7 +205,7 @@ This model provides several advantages:
 
 This is particularly important for RDMA connections, where the hardware resources (queue pairs) are naturally in proximity with specific CPU cores and memory domains.
 
-See [Bind API](/api/binds) for listener management details.
+See [Bind API]({{ '/api/binds' | relative_url }}) for listener management details.
 
 ## Embedding Application Logic in the Event Loop
 
@@ -222,7 +222,7 @@ Timers allow application code to execute at periodic intervals. Common uses incl
 
 All timers in libevpl are periodic—they automatically reschedule after firing. For one-shot behavior, the timer callback removes itself. Timers are managed by the event loop and fire with microsecond precision (actual precision depends on the system timer resolution and event loop load).
 
-See [Timers API](/api/timers) for timer management functions.
+See [Timers API]({{ '/api/timers' | relative_url }}) for timer management functions.
 
 ### Deferrals
 
@@ -235,7 +235,7 @@ Deferrals schedule work to run at the end of the current event loop iteration. T
 
 Deferrals execute in the same thread that schedules them, so they don't require synchronization for accessing thread-local state.
 
-See [Deferrals API](/api/deferrals) for deferral scheduling functions.
+See [Deferrals API]({{ '/api/deferrals' | relative_url }}) for deferral scheduling functions.
 
 ### Doorbells
 
@@ -258,7 +258,7 @@ Common uses include:
 
 Unlike deferrals, doorbells are thread-safe and can signal across threads. However, they have higher overhead due to the synchronization requirements.
 
-See [Doorbells API](/api/doorbells) for doorbell management functions.
+See [Doorbells API]({{ '/api/doorbells' | relative_url }}) for doorbell management functions.
 
 ## Block I/O Integration
 
@@ -275,7 +275,7 @@ Backends include io_uring (for kernel-mediated async I/O) and VFIO-NVMe (for dir
 
 Like network I/O, block I/O uses pre-registered memory buffers from the same pools, enabling zero-copy operation where supported.
 
-See [Block I/O API](/api/block) for block device operations.
+See [Block I/O API]({{ '/api/block' | relative_url }}) for block device operations.
 
 ## Threading Model
 
@@ -288,7 +288,7 @@ libevpl follows a strict single-threaded event loop model:
 
 This model eliminates the need for fine-grained locking within the event loop. Each event loop has exclusive access to its own state, allowing for lock-free operation within a single thread. Applications scale by running multiple threads, each with its own event loop, rather than by sharing a single event loop across threads.
 
-For multi-threaded applications, libevpl provides thread pools where each thread runs an independent event loop. See [Threading API](/api/threading) for thread pool management.
+For multi-threaded applications, libevpl provides thread pools where each thread runs an independent event loop. See [Threading API]({{ '/api/threading' | relative_url }}) for thread pool management.
 
 ## Configuration
 
@@ -304,7 +304,7 @@ libevpl's behavior is controlled through configuration settings at two levels:
 - Priority settings
 - Event loop-specific parameters
 
-See [Configuration API](/api/config) for all available settings.
+See [Configuration API]({{ '/api/config' | relative_url }}) for all available settings.
 
 ## Design Principles Summary
 
@@ -323,6 +323,6 @@ These principles combine to enable portable, high-performance applications that 
 
 Now that you understand libevpl's architecture:
 
-- Explore the [API Reference](/api) for detailed function documentation
-- Review [Getting Started](/getting_started) for a practical introduction
-- Study the [Examples](/examples) to see these concepts in action
+- Explore the [API Reference]({{ '/api' | relative_url }}) for detailed function documentation
+- Review [Getting Started]({{ '/getting_started' | relative_url }}) for a practical introduction
+- Study the [Examples]({{ '/examples' | relative_url }}) to see these concepts in action

--- a/docs/examples/echo_connected_msg.md
+++ b/docs/examples/echo_connected_msg.md
@@ -18,6 +18,6 @@ This example demonstrates an echo server using message semantics with a segmenta
 
 ## See Also
 
-- [Event Loop API](/api/core) - Event loop management
-- [Binds API](/api/bind) - Network connections and I/O
-- [Echo Server (Stream)](/examples/echo-stream) - Stream-based alternative
+- [Event Loop API]({{ '/api/core' | relative_url }}) - Event loop management
+- [Binds API]({{ '/api/binds' | relative_url }}) - Network connections and I/O
+- [Echo Server (Stream)]({{ '/examples/echo-stream' | relative_url }}) - Stream-based alternative

--- a/docs/examples/echo_stream.md
+++ b/docs/examples/echo_stream.md
@@ -18,6 +18,6 @@ This example demonstrates a simple echo server and client using stream semantics
 
 ## See Also
 
-- [Event Loop API](/api/core) - Event loop management
-- [Binds API](/api/bind) - Network connections and I/O
-- [Echo Server (Message)](/examples/echo-message) - Message-based alternative
+- [Event Loop API]({{ '/api/core' | relative_url }}) - Event loop management
+- [Binds API]({{ '/api/binds' | relative_url }}) - Network connections and I/O
+- [Echo Server (Message)]({{ '/examples/echo-message' | relative_url }}) - Message-based alternative

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -12,8 +12,8 @@ Complete, working examples that demonstrate various features of libevpl. All exa
 
 ## Available Examples
 
-- **[Echo Server (Stream)](/examples/echo-stream)** - Simple echo server using stream semantics
-- **[Echo Server (Message)](/examples/echo-message)** - Echo server with message framing and segmentation
+- **[Echo Server (Stream)]({{ '/examples/echo-stream' | relative_url }})** - Simple echo server using stream semantics
+- **[Echo Server (Message)]({{ '/examples/echo-message' | relative_url }})** - Echo server with message framing and segmentation
 
 ## Building and Running
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,10 +79,10 @@ Contributions, feedback, and real-world usage reports are welcome and help guide
 
 Ready to explore libevpl? Here's your path forward:
 
-1. **[Building & Installation](/build)** - Get libevpl compiled and installed on your system
-2. **[Architecture & Concepts](/architecture)** - Understand libevpl's design and core abstractions
-3. **[API Documentation](/api)** - Dive into the detailed API reference
-4. **[Examples](/examples)** - Study working code samples
+1. **[Building & Installation]({{ '/build' | relative_url }})** - Get libevpl compiled and installed on your system
+2. **[Architecture & Concepts]({{ '/architecture' | relative_url }})** - Understand libevpl's design and core abstractions
+3. **[API Documentation]({{ '/api' | relative_url }})** - Dive into the detailed API reference
+4. **[Examples]({{ '/examples' | relative_url }})** - Study working code samples
 
 ## License
 


### PR DESCRIPTION
Every cross-page link in the docs 404s. Reported against `/libevpl/api`, whose "Binds" link goes to `https://chimeraproject.io/api/binds` instead of `https://chimeraproject.io/libevpl/api/binds`.

## Cause

The site is served under a baseurl. `_config.yml` sets `baseurl: "/libevpl"`, and the Pages workflow passes the same value on the command line. But all 100 cross-page links were written as site-absolute paths:

```markdown
See [Bind API](/api/binds) for protocol querying and selection mechanisms.
```

Jekyll emits those verbatim, so they resolve against the domain root and miss the `/libevpl` prefix entirely. Page permalinks were always correct, and the theme's navigation already filters its own links, which is why the sidebar works and the body links do not.

## Fix

Put all 100 through the `relative_url` filter, which prepends `site.baseurl`, so they follow wherever the site is mounted:

```markdown
See [Bind API]({{ '/api/binds' | relative_url }}) for protocol querying and selection mechanisms.
```

Four links also named a path that no page is published at, and are repointed at the real permalink:

| Was | Now |
|---|---|
| `/api/bind` | `/api/binds` |
| `/api/http` | `/api/protocols/http` |
| `/api/rpc2` | `/api/protocols/rpc2` |

No page content changed, only link targets.

## Verification

Built the site the way the Pages workflow does, `jekyll build --baseurl /libevpl`:

- Rendered body links still missing the prefix: **0** (was 100)
- `/libevpl/api` now emits `href="/libevpl/api/binds"`
- All three repointed targets resolve to generated pages

Worth noting the Pages workflow only runs on push to `main`, so this PR gets no build check of its own.

## Left alone deliberately

Seven links point at pages that do not exist at all: `/getting-started` (3 links), `/getting_started` (1) and `/programming_guide` (3). Those are missing pages rather than mis-written links. They now carry the correct prefix but will still 404 until someone writes the pages or decides where they should point instead, and picking a substitute is a content decision rather than a link fix.
