### PR TITLE
docs: drop the links to pages that were never written

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -66,7 +66,5 @@ Always check return values and handle errors appropriately.
 
 ## See Also
 
-- [Getting Started]({{ '/getting-started' | relative_url }}) - Quick tutorial
 - [Architecture]({{ '/architecture' | relative_url }}) - Understanding core concepts
-- [Programming Guide]({{ '/programming_guide' | relative_url }}) - Best practices
 - [Examples]({{ '/examples' | relative_url }}) - Complete working code samples

--- a/docs/api/binds.md
+++ b/docs/api/binds.md
@@ -645,4 +645,4 @@ Request `EVPL_NOTIFY_SENT` notifications for send completions. By default, send 
 - [Endpoints API]({{ '/api/endpoints' | relative_url }}) - Address and port management
 - [Memory API]({{ '/api/memory' | relative_url }}) - Buffer and iovec management
 - [Core API]({{ '/api/core' | relative_url }}) - Event loop management
-- [Getting Started]({{ '/getting-started' | relative_url }}) - Echo server example
+- [Examples]({{ '/examples' | relative_url }}) - Echo server example

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -870,4 +870,3 @@ Set the wait timeout in milliseconds when no events are available. A value of -1
 - [Core API]({{ '/api/core' | relative_url }}) - Initialization and event loops
 - [Architecture]({{ '/architecture' | relative_url }}) - Understanding hybrid event/polling
 - [Performance]({{ '/performance' | relative_url }}) - Benchmark results
-- [Programming Guide]({{ '/programming_guide' | relative_url }}) - Performance tuning

--- a/docs/api/doorbells.md
+++ b/docs/api/doorbells.md
@@ -111,4 +111,3 @@ Get the file descriptor associated with a doorbell (for advanced use cases).
 - [Deferrals API]({{ '/api/deferrals' | relative_url }}) - Same-thread deferred execution
 - [Core API]({{ '/api/core' | relative_url }}) - Event loop management
 - [Architecture]({{ '/architecture' | relative_url }}) - Threading model
-- [Programming Guide]({{ '/programming_guide' | relative_url }}) - Multi-threading patterns

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -92,4 +92,4 @@ Get the port number from an endpoint.
 
 - [Binds & Connections API]({{ '/api/binds' | relative_url }}) - Using endpoints with connections
 - [Core API]({{ '/api/core' | relative_url }}) - Protocol selection for endpoints
-- [Getting Started]({{ '/getting-started' | relative_url }}) - Basic endpoint usage examples
+- [Examples]({{ '/examples' | relative_url }}) - Basic endpoint usage examples

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -324,5 +324,4 @@ These principles combine to enable portable, high-performance applications that 
 Now that you understand libevpl's architecture:
 
 - Explore the [API Reference]({{ '/api' | relative_url }}) for detailed function documentation
-- Review [Getting Started]({{ '/getting_started' | relative_url }}) for a practical introduction
 - Study the [Examples]({{ '/examples' | relative_url }}) to see these concepts in action


### PR DESCRIPTION
Stacked on #167. That PR fixed the missing baseurl on every cross-page link; this one clears the seven links it deliberately left alone, which point at pages that do not exist.

`/getting-started`, `/getting_started` and `/programming_guide` have no page behind them. The site has Introduction, Architecture, Performance, Building, Community, Download, API and Examples, and nothing else. So those seven 404 whatever prefix they carry.

## Five are duplicates once the dead target goes

They sit in "See Also" or "Next Steps" lists that already link the page a reader would actually be sent to, so the bullet adds nothing:

| File | Dead link | Already in the same list |
|---|---|---|
| `architecture.md` | Getting Started | Examples |
| `api/api.md` | Getting Started | Examples |
| `api/api.md` | Programming Guide | Architecture |
| `api/doorbells.md` | Programming Guide | Architecture, as "Threading model" |
| `api/config.md` | Programming Guide | Architecture and Performance |

Removed.

## Two describe content that does exist

Both describe the Examples page, and neither list already links it. Repointed and renamed so the text matches where it goes:

| File | Was | Now |
|---|---|---|
| `api/binds.md` | Getting Started, "Echo server example" | Examples |
| `api/endpoints.md` | Getting Started, "Basic endpoint usage examples" | Examples |

## What this does not do

It does not invent anything. No link is repointed at a page that fails to cover what its text claims, and where there was no honest substitute the entry is dropped rather than redirected somewhere approximate. In particular nothing is aimed at `/performance`, which is a table of benchmark numbers rather than the tuning guidance the "Programming Guide" links promised.

If you would rather have real Getting Started and Programming Guide pages, that is the alternative to this PR and I am happy to write them instead.

## Verification

Built the site as the Pages workflow does, `jekyll build --baseurl /libevpl`, then resolved every rendered internal link against the generated tree.

- 27 distinct internal targets, **0 missing**
- No page content changed, only these list entries
