### PR TITLE
Fix UDP reply address lifetimes and export iovec build settings

### DIFF
--- a/include/evpl/evpl_bind.h
+++ b/include/evpl/evpl_bind.h
@@ -22,6 +22,8 @@ struct evpl_notify {
             struct evpl_iovec   *iovec;
             unsigned int         niov;
             unsigned int         length;
+            /* Borrowed until this callback returns; sendto/sendtov retain
+             * it when queuing a reply. */
             struct evpl_address *addr;
         } recv_msg;
         struct {
@@ -43,6 +45,7 @@ typedef void (*evpl_notify_callback_t)(
     struct evpl_notify *notify,
     void               *private_data);
 
+/* Transfers iovec ownership only; destination addresses remain borrowed. */
 #define EVPL_SEND_FLAG_TAKE_REF  0x01
 
 /*

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -103,6 +103,15 @@ add_subdirectory(thread)
 
 add_library(evpl SHARED ${CORE_SRC})
 
+# Both options change the public iovec layout or inline reference handling.
+# Consumers outside this directory must use the same representation as evpl.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(evpl PUBLIC EVPL_IOVEC_TRACE=1)
+endif()
+if(EVPL_IOVEC_PROFILE)
+    target_compile_definitions(evpl PUBLIC EVPL_IOVEC_PROFILE=1)
+endif()
+
 # Base dependencies present on every platform.
 set(EVPL_LIBDEPS ${BACKEND_LIBDEPS} prometheus-c)
 

--- a/src/core/send.c
+++ b/src/core/send.c
@@ -45,7 +45,10 @@ evpl_sendtoep(
     const void           *buffer,
     unsigned int          length)
 {
-    evpl_sendto(evpl, bind, evpl_endpoint_resolve(endpoint), buffer, length);
+    struct evpl_address *address = evpl_endpoint_resolve(endpoint);
+
+    evpl_sendto(evpl, bind, address, buffer, length);
+    evpl_address_release(address);
 } /* evpl_sendto */
 
 SYMBOL_EXPORT void
@@ -100,11 +103,17 @@ evpl_sendtov(
 
     dgram = evpl_dgram_ring_add(&bind->dgram_send);
 
-    dgram->dgram_type   = EVPL_DGRAM_TYPE_SEND;
-    dgram->bind         = bind;
-    dgram->niov         = i;
-    dgram->length       = length;
-    dgram->addr         = address;
+    dgram->dgram_type = EVPL_DGRAM_TYPE_SEND;
+    dgram->bind       = bind;
+    dgram->niov       = i;
+    dgram->length     = length;
+    dgram->addr       = address;
+    /* Datagram backends release the destination after sending (or closing).
+     * A received peer address is borrowed only for the notify callback, so
+     * the queued send needs its own reference. Connected binds own theirs. */
+    if (!bind->protocol->connected) {
+        evpl_address_incref(address);
+    }
     dgram->callback     = NULL;
     dgram->private_data = NULL;
 
@@ -126,5 +135,8 @@ evpl_sendtoepv(
     int                   length,
     unsigned int          flags)
 {
-    evpl_sendtov(evpl, bind, evpl_endpoint_resolve(endpoint), iovecs, nbufvecs, length, flags);
+    struct evpl_address *address = evpl_endpoint_resolve(endpoint);
+
+    evpl_sendtov(evpl, bind, address, iovecs, nbufvecs, length, flags);
+    evpl_address_release(address);
 } /* evpl_sendtoepv */

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -140,3 +140,9 @@ else()
     message(STATUS
         "Core conformance test disabled (needs quint and python3 on PATH)")
 endif()
+
+# Reply using the borrowed source address after the receive callback returns.
+unit_test_all_mechs(core udp_reply_address udp_reply_address.c)
+foreach(mech ${EVPL_MECHANISMS})
+    set_tests_properties(libevpl/core/udp_reply_address_${mech} PROPERTIES TIMEOUT 10)
+endforeach()

--- a/src/core/tests/udp_reply_address.c
+++ b/src/core/tests/udp_reply_address.c
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 Ben Jarvis
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "evpl/evpl.h"
+#include "tests/test_common.h"
+
+static unsigned int received;
+static const char   payload[] = "borrowed peer address";
+
+static void
+client_notify(
+    struct evpl        *evpl,
+    struct evpl_bind   *bind,
+    struct evpl_notify *notify,
+    void               *private_data)
+{
+    if (notify->notify_type != EVPL_NOTIFY_RECV_MSG) {
+        return;
+    }
+    if (notify->recv_msg.length != sizeof(payload) ||
+        memcmp(notify->recv_msg.iovec[0].data, payload, sizeof(payload))) {
+        fprintf(stderr, "incorrect UDP reply\n");
+        exit(1);
+    }
+    received++;
+    evpl_iovecs_release(evpl, notify->recv_msg.iovec, notify->recv_msg.niov);
+} /* client_notify */
+
+static void
+server_notify(
+    struct evpl        *evpl,
+    struct evpl_bind   *bind,
+    struct evpl_notify *notify,
+    void               *private_data)
+{
+    if (notify->notify_type != EVPL_NOTIFY_RECV_MSG) {
+        return;
+    }
+    /* Queue several replies sharing an address which UDP releases as soon
+     * as this callback returns. Cover copying, cloning and taking iovecs. */
+    evpl_sendto(evpl, bind, notify->recv_msg.addr, payload, sizeof(payload));
+    evpl_sendtov(evpl, bind, notify->recv_msg.addr, notify->recv_msg.iovec,
+                 notify->recv_msg.niov, notify->recv_msg.length, 0);
+    evpl_sendtov(evpl, bind, notify->recv_msg.addr, notify->recv_msg.iovec,
+                 notify->recv_msg.niov, notify->recv_msg.length, EVPL_SEND_FLAG_TAKE_REF);
+} /* server_notify */
+
+int
+main(void)
+{
+    struct evpl          *evpl;
+    struct evpl_endpoint *server, *client;
+    struct evpl_bind     *server_bind, *client_bind;
+    struct evpl_iovec     iovec;
+
+    test_evpl_config();
+    evpl        = evpl_create(NULL);
+    server      = evpl_endpoint_create("127.0.0.1", 8000);
+    client      = evpl_endpoint_create("127.0.0.1", 8001);
+    server_bind = evpl_bind(evpl, EVPL_DATAGRAM_SOCKET_UDP, server, server_notify, NULL);
+    client_bind = evpl_bind(evpl, EVPL_DATAGRAM_SOCKET_UDP, client, client_notify, NULL);
+
+    evpl_sendtoep(evpl, client_bind, server, payload, sizeof(payload));
+    if (evpl_iovec_alloc(evpl, sizeof(payload), 0, 1, 0, &iovec) != 1) {
+        return 1;
+    }
+    memcpy(iovec.data, payload, sizeof(payload));
+    evpl_sendtoepv(evpl, client_bind, server, &iovec, 1, sizeof(payload), 0);
+    evpl_iovec_release(evpl, &iovec);
+
+    /* Endpoint references must be independent of the pending sends. */
+    evpl_endpoint_close(server);
+    evpl_endpoint_close(client);
+    while (received < 6) {
+        evpl_continue(evpl);
+    }
+    evpl_close(evpl, client_bind);
+    evpl_close(evpl, server_bind);
+    evpl_destroy(evpl);
+    return received == 6 ? 0 : 1;
+} /* main */


### PR DESCRIPTION
Flowbench exposed two downstream integration bugs: UDP replies queued from a receive callback used a peer address freed before the send ran, and Debug consumers could compile inline iovec operations without libevpl's tracing representation.

Retain destinations for queued unconnected sends, balance endpoint-resolution references, and export the tracing/profiling definitions from the evpl CMake target. The new regression queues multiple replies sharing a borrowed peer address and covers copying, cloning, and transferred iovecs.

Validation: the UDP regression passes on macOS kqueue/select and Linux epoll/select in Debug (AddressSanitizer) and Release. Flowbench TCP/UDP integration tests also pass with these fixes. RDMA hardware was not available for runtime testing.
