### PR TITLE
core: stop poll_remove racing the poll-mode spin grace period

### DIFF
--- a/src/core/tests/poll_remove.c
+++ b/src/core/tests/poll_remove.c
@@ -54,9 +54,23 @@ poll_callback(
 } /* poll_callback */
 
 /* Clear the counters and run the loop long enough that every registered poller
- * has certainly been dispatched.  The loop only visits pollers while it is in
- * poll mode, which it enters on its own as soon as one is registered and holds
- * while a caller keeps pumping. */
+ * has certainly been dispatched.
+ *
+ * The loop only visits pollers while it is in poll mode, and pumping alone does
+ * not keep it there: poll mode is held against *activity*, not against calls.
+ * A loop that has gone spin_ns (1 ms by default) without an evpl_activity()
+ * leaves poll mode -- and on the very first evpl_continue(), where poll_mode is
+ * still 0, that grace period is measured from evpl_create(), so a thread merely
+ * scheduled away for a moment between the two never enters poll mode at all.
+ * With no fd, timer or event registered here, the loop then waits on the one
+ * thing that can still wake it, which is nothing: wait_ms defaults to -1 and it
+ * blocks in epoll forever.  That is a hang, not a slow test, and it is why this
+ * used to fail only under CPU contention.
+ *
+ * evpl_poll_pin() is the primitive for "work that can only be observed by
+ * polling, so never sleep".  It holds poll mode by refcount rather than against
+ * the clock, which is what makes the dispatch counts below depend on the poller
+ * bookkeeping under test and not on how this process was scheduled. */
 static void
 pump(struct evpl *evpl)
 {
@@ -81,6 +95,11 @@ main(
     evpl_init(NULL);
 
     evpl = evpl_create(NULL);
+
+    /* Before the first evpl_continue(): the grace period this defeats is
+     * already running by then.  Held for the whole body -- every pump below
+     * relies on poll dispatch happening. */
+    evpl_poll_pin(evpl);
 
     for (i = 0; i < 4; ++i) {
         handle[i] = evpl_add_poll(evpl, NULL, NULL, poll_callback,
@@ -123,6 +142,8 @@ main(
 
     evpl_remove_poll(evpl, handle[4]);
     evpl_remove_poll(evpl, handle[2]);
+
+    evpl_poll_unpin(evpl);
 
     evpl_destroy(evpl);
 


### PR DESCRIPTION
`libevpl/core/poll_remove_epoll` and `poll_remove_select` intermittently **time out** in chimera's Extended runs. They are not slow — they hang, blocked forever in `epoll_pwait()`.

## Root cause

`poll_remove.c` registers pollers with no enter/exit callback, no fd, no timer and no event, then pumps `evpl_continue()` and asserts on which callbacks fired. Its comment stated the false premise:

> The loop only visits pollers while it is in poll mode, which it enters on its own as soon as one is registered and **holds while a caller keeps pumping**.

Poll mode is held against `evpl_activity()`, not against calls into the loop. Pumping alone marks no activity.

`evpl->poll_mode` starts at 0, so the *first* `evpl_continue()` takes the event-mode branch, where the spin grace period is measured from `evpl_create()`. If more than `spin_ns` (1 ms default) of wall clock passed in between, `elapsed > spin_ticks` fires, poll mode is never entered at all, `msecs` stays at the `wait_ms` default of **-1**, and the loop blocks on the only thing that can still wake it — nothing.

The test does 5 pumps × 64 iterations = 320, well under the `poll_iterations` threshold of 1000, so that first call decides the entire run.

Confirmed on a caught instance: `wchan: ep_poll`, syscall 22 (`epoll_pwait`) with `timeout = 0xffffffffffffffff` (-1).

## Why only under load

The failure needs >1 ms between `evpl_create()` and the first `evpl_continue()`. Serially that gap is microseconds; under CPU oversubscription a single preemption clears it.

| | result |
|---|---|
| serial, unmodified | 0 / 80 hang |
| 24 concurrent on 6 CPUs | ~1 / 24 hang |

## This test was the only unmitigated poll registration

| poll source | enter/exit | mitigation |
|---|---|---|
| io_uring, libaio | non-NULL | `exit_callback` arms an eventfd |
| xlio | NULL | `force_poll_mode = 1`, `evpl_activity()` in callback |
| vfio | NULL | `evpl_poll_pin()` + `evpl_activity()` |
| `tests/poll_remove.c` | NULL | **none** |

`evpl_io_uring_poll_exit()` already documents the contract: *"Leaving poll mode makes this eventfd the only thing that can wake the loop... a silent failure here is a hang."* So the library behaviour is correct and deliberate; the test simply never held up its end.

## Fix

Use `evpl_poll_pin()` — the documented primitive for work observable only by polling. It holds poll mode by refcount rather than against the clock, so the dispatch counts depend on the poller bookkeeping actually under test rather than on scheduling. The misleading comment is replaced with the real rule.

No library change: `evpl_poll_pin()` already covers this, and making the loop refuse to sleep whenever `num_poll > 0` would force vfio to spin permanently.

## Verification

Rather than rely on a stochastic 1-in-24, the window was forced directly with a 2 ms stall between `evpl_create()` and the first pump:

| build | result |
|---|---|
| baseline + 2 ms stall, serial | **10 / 10 hang** |
| fixed + 2 ms stall, serial | **0 / 10 hang**, all assertions pass |
| fixed, clean, 24-way × 6 rounds | **144 / 144 pass, 0 hangs** |
| `ctest -R poll_remove` | `poll_remove_epoll` + `poll_remove_select` pass |

The stall probe was removed before commit.
